### PR TITLE
Allow temporary variations to be explored in game viewer

### DIFF
--- a/frontend/src/games/view/PgnViewer.tsx
+++ b/frontend/src/games/view/PgnViewer.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { pgnView } from '@mliebelt/pgn-viewer';
+import { pgnEdit } from '@mliebelt/pgn-viewer';
 import {
     Button,
     Grid,
@@ -151,12 +151,13 @@ const PgnViewer: React.FC<PgnViewerProps> = ({ game, onFeature }) => {
     const id = 'board';
 
     useLayoutEffect(() => {
-        pgnView(id, {
+        pgnEdit(id, {
             pgn: game.pgn,
             pieceStyle: 'wikipedia',
             theme: 'brown',
             showResult: true,
             notationLayout: 'list',
+            layout: 'left',
         });
     }, [id, game.pgn]);
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -50,8 +50,8 @@ div #board #boardMoves {
     color: inherit;
 }
 
-div #board #boardButton {
-    grid-area: button;
+div #board #editboardButton {
+    visibility:hidden;
 }
 
 div#board.dark move-number {


### PR DESCRIPTION
This allows someone viewing a game to move the pieces to create additional variations.  These will not be persisted.