### PR TITLE
Allow disabling the graduation/demotion dialog #580

### DIFF
--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -415,6 +415,9 @@ type SiteNotificationSettings struct {
 
 	// Whether to disable notifications on newsfeed reactions
 	DisableNewsfeedReaction bool `dynamodbav:"disableNewsfeedReaction" json:"disableNewsfeedReaction"`
+
+	// Whether to hide prompt of changing cohort. If value set, the prompt will not be shown until saved date.
+	HideCohortPromptUntil string `dynamodbav:"hideCohortPromptUntil" json:"hideCohortPromptUntil"`
 }
 
 func (sns *SiteNotificationSettings) GetDisableGameComment() bool {

--- a/frontend/src/components/profile/SwitchCohortPrompt.tsx
+++ b/frontend/src/components/profile/SwitchCohortPrompt.tsx
@@ -1,52 +1,88 @@
+import { useApi } from '@/api/Api';
 import { useAuth } from '@/auth/Auth';
 import {
     getCurrentRating,
+    getPartialUserHideCohortPrompt,
+    getUserHasHiddenCohortPrompt,
     shouldPromptDemotion,
     shouldPromptGraduation,
 } from '@/database/user';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import { Alert, Button, Snackbar } from '@mui/material';
+import { Alert, Button, Snackbar, Stack } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 export function SwitchCohortPrompt() {
-    const { user } = useAuth();
+    const { user, updateUser } = useAuth();
+    const api = useApi();
 
     const [showGraduation, setShowGraduation] = useState(false);
-    const [showDemotion, setShowDemotion] = useState(false);
-
-    const [hideGraduation, setHideGraduation] = useState(false);
-    const [hideDemotion, setHideDemotion] = useState(false);
+    const [open, setOpen] = useState(false);
 
     useEffect(() => {
-        setShowGraduation(shouldPromptGraduation(user));
-        setShowDemotion(shouldPromptDemotion(user));
-    }, [user, setShowGraduation, setShowDemotion]);
+        const userHasHiddenCohortPrompt = getUserHasHiddenCohortPrompt(user);
+        if (userHasHiddenCohortPrompt){
+            setOpen(false);
+            return;
+        }
 
+        const promptGraudation = shouldPromptGraduation(user);
+        if (promptGraudation){
+            setShowGraduation(true);
+            setOpen(true);
+            return;
+        }
+
+        const promptDemotion = shouldPromptDemotion(user);
+        if (promptDemotion){
+            setShowGraduation(false);
+            setOpen(true);
+            return;
+        }
+        
+        setOpen(false);
+    }, [user]);
+
+    const handleHideCohortPrompt = () => {
+        const partialUser = getPartialUserHideCohortPrompt(user?.notificationSettings?.siteNotificationSettings);
+        api.updateUser(partialUser)
+            .then(_ => updateUser(partialUser));
+        handleClose();
+    }
+
+    const handleClose = () => {
+        setOpen(false);
+    }
     return (
         <Snackbar
             anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-            open={(showGraduation && !hideGraduation) || (showDemotion && !hideDemotion)}
-            onClose={
-                showGraduation
-                    ? () => setHideGraduation(true)
-                    : () => setHideDemotion(true)
-            }
+            open={open}
+            onClose={handleClose}
             autoHideDuration={showGraduation ? 6000 : 7000}
         >
             <Alert
                 variant='filled'
                 severity={showGraduation ? 'success' : 'error'}
                 action={
-                    showDemotion && (
-                        <Button
-                            color='inherit'
-                            size='small'
-                            href='/profile/edit'
-                            endIcon={<NavigateNextIcon />}
+                    <Stack direction="row">
+                        <Button 
+                            color="inherit" 
+                            size="small" 
+                            onClick={handleHideCohortPrompt}
                         >
-                            Settings
+                            Hide for 1 month
                         </Button>
-                    )
+                        {!showGraduation && (
+                            <Button
+                                color='inherit'
+                                size='small'
+                                href='/profile/edit'
+                                sx={{ml: 2, px: 3}}
+                                endIcon={<NavigateNextIcon />}
+                            >
+                                Settings
+                            </Button>
+                        )}
+                    </Stack>
                 }
                 sx={{ width: 1 }}
             >


### PR DESCRIPTION
Backend
- Added HideCohortPromptUntil in SiteNotificationSettings, which stores a datetime iso string

Frontend
- Updated SwitchCohortPrompt to not show the snackbar if current date is before HideCohortPromptUntil