### PR TITLE
Bugfix(Navbar Darkmode Issue #1253): add dark mode to small screen menu bar

### DIFF
--- a/frontend/cypress/e2e/navbar/navbar.cy.ts
+++ b/frontend/cypress/e2e/navbar/navbar.cy.ts
@@ -27,7 +27,7 @@ const viewPortWidths = [
     { width: 449, hidden: 10, endHidden: 3 },
 ];
 
-describe.only('Navbar', () => {
+describe('Navbar', () => {
     it('should have limited options when unauthenticated', () => {
         cy.visit('/');
 
@@ -80,7 +80,6 @@ describe.only('Navbar', () => {
                         cy.get('#menu-appbar').contains(item);
                     }
                 });
-                cy.get('#menu-appbar').contains('Dark Mode'); // Worth updating?
             }
         });
     });

--- a/frontend/cypress/e2e/navbar/navbar.cy.ts
+++ b/frontend/cypress/e2e/navbar/navbar.cy.ts
@@ -27,7 +27,7 @@ const viewPortWidths = [
     { width: 449, hidden: 10, endHidden: 3 },
 ];
 
-describe('Navbar', () => {
+describe.only('Navbar', () => {
     it('should have limited options when unauthenticated', () => {
         cy.visit('/');
 
@@ -80,6 +80,7 @@ describe('Navbar', () => {
                         cy.get('#menu-appbar').contains(item);
                     }
                 });
+                cy.get('#menu-appbar').contains('Dark Mode'); // Worth updating?
             }
         });
     });

--- a/frontend/src/navbar/DarkModeToggle.tsx
+++ b/frontend/src/navbar/DarkModeToggle.tsx
@@ -1,0 +1,53 @@
+import NightlightIcon from '@mui/icons-material/Nightlight';
+import {
+    FormControlLabel,
+    ListItemIcon,
+    MenuItem,
+    Switch,
+    useColorScheme,
+} from '@mui/material';
+import { useApi } from '../api/Api';
+import { useAuth } from '../auth/Auth';
+
+
+const DarkModeToggle = () => {
+    const auth = useAuth();
+    const user = auth.user;
+    const { mode, setMode } = useColorScheme();
+    const api = useApi();
+
+    if (!user) {
+        return null;
+    }
+
+    const toggleColorMode = () => {
+        setMode(mode === 'light' ? 'dark' : 'light');
+        void api.updateUser({ enableLightMode: mode === 'dark' });
+    };
+
+    return (
+        <>
+            <MenuItem>
+                <ListItemIcon>
+                    <NightlightIcon />
+                </ListItemIcon>
+
+                <FormControlLabel
+                    value='start'
+                    control={
+                        <Switch
+                            color='primary'
+                            checked={mode === 'dark'}
+                            onChange={toggleColorMode}
+                        />
+                    }
+                    label='Dark Mode'
+                    labelPlacement='start'
+                    sx={{ ml: 0 }}
+                />
+            </MenuItem>
+        </>
+    );
+};
+
+export default DarkModeToggle;

--- a/frontend/src/navbar/NavbarMenu.tsx
+++ b/frontend/src/navbar/NavbarMenu.tsx
@@ -64,6 +64,7 @@ import {
 import React, { useState } from 'react';
 import ProfileButton from './ProfileButton';
 import UnauthenticatedMenu, { ExtraSmallMenuUnauthenticated } from './UnauthenticatedMenu';
+import DarkModeToggle from './DarkModeToggle';
 
 const config = getConfig();
 
@@ -719,6 +720,8 @@ const ExtraSmallMenu = ({ meetingCount }: MenuProps) => {
                     </ListItemIcon>
                     <Typography textAlign='center'>Help</Typography>
                 </MenuItem>
+
+                <DarkModeToggle />
 
                 <MenuItem
                     onClick={() => {

--- a/frontend/src/navbar/ProfileButton.tsx
+++ b/frontend/src/navbar/ProfileButton.tsx
@@ -1,30 +1,24 @@
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import NightlightIcon from '@mui/icons-material/Nightlight';
 import Person2Icon from '@mui/icons-material/Person2';
 import SettingsIcon from '@mui/icons-material/Settings';
 import SportsIcon from '@mui/icons-material/Sports';
 import {
     Button,
-    FormControlLabel,
     ListItemIcon,
     Menu,
     MenuItem,
     Stack,
-    Switch,
     Typography,
-    useColorScheme,
 } from '@mui/material';
 import { useState } from 'react';
-import { useApi } from '../api/Api';
 import { useAuth } from '../auth/Auth';
 import Avatar from '../profile/Avatar';
+import DarkModeToggle from './DarkModeToggle';
 
 const ProfileButton = () => {
     const auth = useAuth();
     const user = auth.user;
-    const { mode, setMode } = useColorScheme();
-    const api = useApi();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
     if (!user) {
@@ -44,11 +38,6 @@ const ProfileButton = () => {
             func();
             handleClose();
         };
-    };
-
-    const toggleColorMode = () => {
-        setMode(mode === 'light' ? 'dark' : 'light');
-        void api.updateUser({ enableLightMode: mode === 'dark' });
     };
 
     return (
@@ -96,25 +85,7 @@ const ProfileButton = () => {
                     </MenuItem>
                 )}
 
-                <MenuItem>
-                    <ListItemIcon>
-                        <NightlightIcon />
-                    </ListItemIcon>
-
-                    <FormControlLabel
-                        value='start'
-                        control={
-                            <Switch
-                                color='primary'
-                                checked={mode === 'dark'}
-                                onChange={toggleColorMode}
-                            />
-                        }
-                        label='Dark Mode'
-                        labelPlacement='start'
-                        sx={{ ml: 0 }}
-                    />
-                </MenuItem>
+                <DarkModeToggle />
 
                 <MenuItem onClick={handleClick(auth.signout)}>
                     <ListItemIcon>


### PR DESCRIPTION
See: https://github.com/jackstenglein/chess-dojo-scheduler/issues/1253

The Dark mode toggle is currently visible only on a large screen. Added to the small screen section in the navbar. Screenshots of Before and After are below.

Before:
<img width="736" alt="Screenshot 2025-06-11 at 11 27 47 AM" src="https://github.com/user-attachments/assets/0808eeac-a7a5-4a01-80a5-8fe46b4a6e6f" />

After:
<img width="693" alt="Screenshot 2025-06-11 at 11 28 17 AM" src="https://github.com/user-attachments/assets/6779795e-49be-4aa2-aa10-5df33f41b043" />

