### PR TITLE
Clock Usage: Round expectedTime to nearest second

### DIFF
--- a/frontend/src/board/pgn/boardTools/underboard/clock/rating/clockRating.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/rating/clockRating.ts
@@ -32,7 +32,7 @@ export function getPerfectLineSeconds(timeControls: TimeControl[], move: number)
         expectedTime += timeControls[1]?.seconds ?? 0;
     }
 
-    return expectedTime;
+    return Math.floor(expectedTime);
 }
 
 /**

--- a/frontend/src/board/pgn/boardTools/underboard/clock/rating/clockRating.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/rating/clockRating.ts
@@ -32,7 +32,7 @@ export function getPerfectLineSeconds(timeControls: TimeControl[], move: number)
         expectedTime += timeControls[1]?.seconds ?? 0;
     }
 
-    return Math.floor(expectedTime);
+    return Math.round(expectedTime);
 }
 
 /**


### PR DESCRIPTION
When dealing with the ideal time, fractions of a second shouldn't be treated as significant digits.

This change rounds down any decimals when calculating that ideal time.

Contributes to #1506 