### PR TITLE
feat: enhance player header with chess titles 

### DIFF
--- a/frontend/src/board/pgn/PlayerHeader.tsx
+++ b/frontend/src/board/pgn/PlayerHeader.tsx
@@ -1,5 +1,7 @@
 import { useLightMode } from '@/style/useLightMode';
 import { Chess, Event, EventType, Move, Pgn } from '@jackstenglein/chess';
+
+import { PlayerNameWithTitle } from '@/components/ui/PlayerNameWithTitle';
 import { Divider, Paper, Stack, Tooltip, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
@@ -89,7 +91,16 @@ function getCapturedPieceCounts(fen: string) {
     return capturedPieces;
 }
 
-const rerenderHeaders = ['White', 'WhiteElo', 'Black', 'BlackElo', 'Result', 'TimeControl'];
+const rerenderHeaders = [
+    'White',
+    'WhiteElo',
+    'Black',
+    'BlackElo',
+    'Result',
+    'TimeControl',
+    'WhiteTitle',
+    'BlackTitle',
+];
 
 const PlayerHeader: React.FC<PlayerHeaderProps> = ({ type }) => {
     const { chess, board } = useChess();
@@ -201,14 +212,20 @@ const PlayerHeader: React.FC<PlayerHeaderProps> = ({ type }) => {
                         </>
                     )}
 
-                    <Typography
-                        variant='subtitle2'
-                        color='text.secondary'
-                        fontWeight='bold'
-                        whiteSpace='nowrap'
-                    >
-                        {playerName}
-                    </Typography>
+                    <PlayerNameWithTitle
+                        name={playerName}
+                        title={
+                            type === 'header' && board.state.orientation === 'white'
+                                ? pgn.header.tags.BlackTitle
+                                : pgn.header.tags.WhiteTitle
+                        }
+                        variant='body2'
+                        sx={{
+                            color: 'text.secondary',
+                            fontWeight: 'bold',
+                            whiteSpace: 'nowrap',
+                        }}
+                    />
 
                     {playerElo && (
                         <Typography variant='subtitle2' color='text.secondary' whiteSpace='nowrap'>

--- a/frontend/src/board/pgn/boardTools/underboard/tags/Tags.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/tags/Tags.tsx
@@ -82,6 +82,8 @@ const columns: GridColDef<TagRow>[] = [
 
 const dateTags = ['Date', 'EventDate', 'UTCDate', 'EndDate'];
 
+const CHESS_TITLES = ['', 'GM', 'WGM', 'IM', 'WIM', 'FM', 'WFM', 'CM', 'WCM', 'NM', 'WNM'];
+
 function CustomEditComponent(props: GridRenderEditCellParams<TagRow>) {
     if (props.row.name === 'Result') {
         return (
@@ -106,6 +108,28 @@ function CustomEditComponent(props: GridRenderEditCellParams<TagRow>) {
             />
         );
     }
+    if (props.row.name === 'WhiteTitle' || props.row.name === 'BlackTitle') {
+        return (
+            <GridEditSingleSelectCell
+                {...props}
+                variant='outlined'
+                colDef={{
+                    ...props.colDef,
+                    type: 'singleSelect',
+                    valueOptions: CHESS_TITLES,
+                    getOptionValue(value) {
+                        return value;
+                    },
+                    getOptionLabel(value) {
+                        if (typeof value === 'string') {
+                            return value || 'None';
+                        }
+                        return '';
+                    },
+                }}
+            />
+        );
+    }
     if (props.row.name === 'TimeControl') {
         return <TimeControlGridEditor {...props} />;
     }
@@ -118,8 +142,10 @@ function CustomEditComponent(props: GridRenderEditCellParams<TagRow>) {
 const defaultTags = [
     'White',
     'WhiteElo',
+    'WhiteTitle',
     'Black',
     'BlackElo',
+    'BlackTitle',
     'Result',
     'Date',
     'Event',
@@ -243,7 +269,7 @@ const Tags: React.FC<TagsProps> = ({ game, allowEdits }) => {
                         return oldRow;
                     }
 
-                    if (!value) {
+                    if (!value && !['WhiteTitle', 'BlackTitle'].includes(name)) {
                         return oldRow;
                     }
 

--- a/frontend/src/components/ui/ChessTitleBadge.test.tsx
+++ b/frontend/src/components/ui/ChessTitleBadge.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ChessTitleBadge } from './ChessTitleBadge';
+
+describe('ChessTitleBadge', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders GM title correctly', () => {
+        render(<ChessTitleBadge title='GM' />);
+        expect(screen.getByText('GM')).toBeInTheDocument();
+        expect(screen.getByLabelText('Grandmaster')).toBeInTheDocument();
+    });
+
+    it('renders IM title correctly', () => {
+        render(<ChessTitleBadge title='IM' />);
+        expect(screen.getByText('IM')).toBeInTheDocument();
+        expect(screen.getByLabelText('International Master')).toBeInTheDocument();
+    });
+
+    it('renders FM title correctly', () => {
+        render(<ChessTitleBadge title='FM' />);
+        expect(screen.getByText('FM')).toBeInTheDocument();
+        expect(screen.getByLabelText('FIDE Master')).toBeInTheDocument();
+    });
+
+    it('renders WGM title correctly', () => {
+        render(<ChessTitleBadge title='WGM' />);
+        expect(screen.getByText('WGM')).toBeInTheDocument();
+        expect(screen.getByLabelText('Woman Grandmaster')).toBeInTheDocument();
+    });
+
+    it('does not render for unknown title', () => {
+        const { container } = render(<ChessTitleBadge title='UNKNOWN' />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('does not render for empty title', () => {
+        const { container } = render(<ChessTitleBadge title='' />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('applies custom styling', () => {
+        const customSx = { backgroundColor: 'red' };
+        render(<ChessTitleBadge title='CM' sx={customSx} />);
+        const chip = screen.getByText('CM');
+        expect(chip).toBeInTheDocument();
+    });
+
+    it('renders with medium size', () => {
+        render(<ChessTitleBadge title='NM' size='medium' />);
+        const chip = screen.getByText('NM');
+        expect(chip).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/ui/ChessTitleBadge.tsx
+++ b/frontend/src/components/ui/ChessTitleBadge.tsx
@@ -1,0 +1,59 @@
+import { Chip, Tooltip } from '@mui/material';
+import { SxProps, Theme } from '@mui/material/styles';
+
+// * Standard chess titles recognized by FIDE
+const CHESS_TITLES: Record<string, string> = {
+    GM: 'Grandmaster',
+    WGM: 'Woman Grandmaster',
+    IM: 'International Master',
+    WIM: 'Woman International Master',
+    FM: 'FIDE Master',
+    WFM: 'Woman FIDE Master',
+    CM: 'Candidate Master',
+    WCM: 'Woman Candidate Master',
+    NM: 'National Master',
+    WNM: 'Woman National Master',
+    LM: 'Lifetime Master',
+};
+
+interface ChessTitleBadgeProps {
+    /** The chess title abbreviation (e.g., 'GM', 'IM') */
+    title: string;
+    /** Optional custom styling */
+    sx?: SxProps<Theme>;
+    /** Size of the chip - defaults to 'small' for compact display */
+    size?: 'small' | 'medium';
+}
+
+/**
+ * Displays a chess title as a small badge with a tooltip showing the full title name.
+ * Only displays if the title is a recognized chess title.
+ */
+export function ChessTitleBadge({ title, sx, size = 'small' }: ChessTitleBadgeProps) {
+    // * Only render if this is a recognized chess title
+    if (!title || !CHESS_TITLES[title]) {
+        return null;
+    }
+
+    const fullTitle = CHESS_TITLES[title];
+
+    return (
+        <Tooltip title={fullTitle} arrow>
+            <Chip
+                label={title}
+                size={size}
+                variant='outlined'
+                color='primary'
+                sx={{
+                    fontSize: '0.75rem',
+                    height: size === 'small' ? '20px' : '24px',
+                    '& .MuiChip-label': {
+                        px: 0.5,
+                        fontWeight: 'bold',
+                    },
+                    ...sx,
+                }}
+            />
+        </Tooltip>
+    );
+}

--- a/frontend/src/components/ui/PlayerNameWithTitle.test.tsx
+++ b/frontend/src/components/ui/PlayerNameWithTitle.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PlayerNameWithTitle } from './PlayerNameWithTitle';
+
+describe('PlayerNameWithTitle', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders name without title when no title provided', () => {
+        render(<PlayerNameWithTitle name='Magnus Carlsen' />);
+        expect(screen.getByText('Magnus Carlsen')).toBeInTheDocument();
+        expect(screen.queryByText('GM')).not.toBeInTheDocument();
+    });
+
+    it('renders name with title when title provided', () => {
+        render(<PlayerNameWithTitle name='Garry Kasparov' title='GM' />);
+        expect(screen.getByText('Garry Kasparov')).toBeInTheDocument();
+        expect(screen.getByText('GM')).toBeInTheDocument();
+        expect(screen.getByLabelText('Grandmaster')).toBeInTheDocument();
+    });
+
+    it('renders title before name by default', () => {
+        render(<PlayerNameWithTitle name='Bobby Fischer' title='IM' />);
+        const container = screen.getByText('Bobby Fischer').parentElement;
+        const titleElement = screen.getByLabelText('International Master');
+        const nameElement = screen.getByText('Bobby Fischer');
+
+        expect(container?.children[0]).toBe(titleElement);
+        expect(container?.children[1]).toBe(nameElement);
+    });
+
+    it('renders title after name when titleBeforeName is false', () => {
+        render(<PlayerNameWithTitle name='Anatoly Karpov' title='FM' titleBeforeName={false} />);
+        const container = screen.getByText('Anatoly Karpov').parentElement;
+        const titleElement = screen.getByLabelText('FIDE Master');
+        const nameElement = screen.getByText('Anatoly Karpov');
+
+        expect(container?.children[0]).toBe(nameElement);
+        expect(container?.children[1]).toBe(titleElement);
+    });
+
+    it('applies custom typography variant', () => {
+        render(<PlayerNameWithTitle name='Vishy Anand' title='GM' variant='h6' />);
+        const nameElement = screen.getByText('Vishy Anand');
+        expect(nameElement).toHaveClass('MuiTypography-h6');
+    });
+
+    it('handles empty name gracefully', () => {
+        const { container } = render(<PlayerNameWithTitle name='' title='CM' />);
+        expect(screen.getByText('CM')).toBeInTheDocument();
+        // Just verify the component renders without crashing
+        expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('handles special characters in name', () => {
+        render(<PlayerNameWithTitle name='José R. Capablanca' title='WGM' />);
+        expect(screen.getByText('José R. Capablanca')).toBeInTheDocument();
+        expect(screen.getByText('WGM')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/ui/PlayerNameWithTitle.tsx
+++ b/frontend/src/components/ui/PlayerNameWithTitle.tsx
@@ -1,0 +1,59 @@
+import { Stack, Typography } from '@mui/material';
+import { SxProps, Theme } from '@mui/material/styles';
+import { ChessTitleBadge } from './ChessTitleBadge';
+
+interface PlayerNameWithTitleProps {
+    /** The player's name */
+    name: string;
+    /** The player's chess title (e.g., 'GM', 'IM') */
+    title?: string;
+    /** Typography variant for the name */
+    variant?: 'body1' | 'body2' | 'caption' | 'h6';
+    /** Optional custom styling */
+    sx?: SxProps<Theme>;
+    /** Whether to show the title before the name (default: true) */
+    titleBeforeName?: boolean;
+}
+
+/**
+ * Displays a player's name with their chess title badge.
+ * The title badge appears before the name by default, but can be configured.
+ */
+export function PlayerNameWithTitle({
+    name,
+    title,
+    variant = 'body2',
+    sx,
+    titleBeforeName = true,
+}: PlayerNameWithTitleProps) {
+    if (!title) {
+        return (
+            <Typography variant={variant} sx={sx}>
+                {name}
+            </Typography>
+        );
+    }
+
+    const titleElement = <ChessTitleBadge title={title} />;
+    const nameElement = (
+        <Typography variant={variant} sx={sx}>
+            {name}
+        </Typography>
+    );
+
+    return (
+        <Stack direction='row' alignItems='center' spacing={0.5} sx={{ minHeight: 0 }}>
+            {titleBeforeName ? (
+                <>
+                    {titleElement}
+                    {nameElement}
+                </>
+            ) : (
+                <>
+                    {nameElement}
+                    {titleElement}
+                </>
+            )}
+        </Stack>
+    );
+}


### PR DESCRIPTION
## Description 

Add a title badge in the game editor and in the tags tab based on the whiteTitle and blackTitle headers from pgn spec.

## Components

### ChessTitleBadge

A small badge component that displays chess titles (GM, IM, FM, etc.) with tooltips showing the full title name.

**Props:**

- `title: string` - The chess title abbreviation (e.g., 'GM', 'IM')
- `size?: 'small' | 'medium'` - Size of the chip (defaults to 'small')
- `sx?: SxProps<Theme>` - Optional custom styling

**Usage:**

```tsx
import { ChessTitleBadge } from '@/components/ui/ChessTitleBadge';

<ChessTitleBadge title="GM" />
<ChessTitleBadge title="IM" size="medium" />
```

**Supported Titles:**

- GM - Grandmaster
- WGM - Woman Grandmaster
- IM - International Master
- WIM - Woman International Master
- FM - FIDE Master
- WFM - Woman FIDE Master
- CM - Candidate Master
- WCM - Woman Candidate Master
- NM - National Master
- WNM - Woman National Master

### PlayerNameWithTitle

A component that displays a player's name with their chess title badge.

**Props:**

- `name: string` - The player's name
- `title?: string` - The player's chess title (e.g., 'GM', 'IM')
- `variant?: 'body1' | 'body2' | 'caption' | 'h6'` - Typography variant for the name
- `sx?: SxProps<Theme>` - Optional custom styling
- `titleBeforeName?: boolean` - Whether to show the title before the name (default: true)

**Usage:**

```tsx
import { PlayerNameWithTitle } from '@/components/ui/PlayerNameWithTitle';

// Title before name (default)
<PlayerNameWithTitle name="Magnus Carlsen" title="GM" />

// Title after name
<PlayerNameWithTitle name="Hikaru Nakamura" title="GM" titleBeforeName={false} />

// No title
<PlayerNameWithTitle name="John Doe" />

// Custom styling
<PlayerNameWithTitle
    name="Alice Smith"
    title="IM"
    variant="h6"
    sx={{ color: 'primary.main' }}
/>
```

## Integration with Game Editor

These components are designed to work with PGN headers that include `WhiteTitle` and `BlackTitle` fields. They are currently implemented in the following game editor contexts:

### 1. PGN Header Tab (Tags Component)

- Supports editing of title fields using a select component

### 2. Chessboard Player Headers

- Shows chess titles around the chessboard where player names are displayed
- Rerender when the title is updated

**Example PGN Header:**

```
[White "Magnus Carlsen"]
[WhiteTitle "GM"]
[Black "Hikaru Nakamura"]
[BlackTitle "GM"]
[Result "1-0"]
```


Related issue: #1415 
