### PR TITLE
feat(#993): add spacebar analysis

### DIFF
--- a/frontend/src/board/pgn/KeyboardHandler.tsx
+++ b/frontend/src/board/pgn/KeyboardHandler.tsx
@@ -24,7 +24,7 @@ interface KeyboardHandlerProps {
 }
 
 const KeyboardHandler: React.FC<KeyboardHandlerProps> = ({ underboardRef }) => {
-    const { chess, board, boardRef, keydownMap, toggleOrientation } = useChess();
+    const { chess, board, boardRef, keydownMap, toggleOrientation, addEngineMoveRef } = useChess();
     const reconcile = useReconcile();
     const [variationBehavior] = useLocalStorage(VariationBehaviorKey, VariationBehavior.Dialog);
     const [variationDialogMove, setVariationDialogMove] = useState<Move | null>(null);
@@ -95,6 +95,7 @@ const KeyboardHandler: React.FC<KeyboardHandlerProps> = ({ underboardRef }) => {
                         variationBehavior === VariationBehavior.Dialog
                             ? setVariationDialogMove
                             : undefined,
+                    addEngineMove: addEngineMoveRef?.current || undefined,
                 },
             });
         },
@@ -108,6 +109,7 @@ const KeyboardHandler: React.FC<KeyboardHandlerProps> = ({ underboardRef }) => {
             setVariationDialogMove,
             underboardRef,
             reconcile,
+            addEngineMoveRef,
         ],
     );
 

--- a/frontend/src/board/pgn/PgnBoard.tsx
+++ b/frontend/src/board/pgn/PgnBoard.tsx
@@ -52,7 +52,7 @@ interface ChessContextType {
     boardRef?: RefObject<HTMLDivElement | null>;
     config?: ChessConfig;
     toggleOrientation?: () => void;
-    keydownMap?: React.MutableRefObject<Record<string, boolean>>;
+    keydownMap?: React.RefObject<Record<string, boolean>>;
     slots?: PgnBoardSlots;
     slotProps?: PgnBoardSlotProps;
     orientation?: 'white' | 'black';
@@ -61,6 +61,7 @@ interface ChessContextType {
         isComplete: boolean;
         reset: () => void;
     };
+    addEngineMoveRef?: React.RefObject<(() => void) | null>;
 }
 
 export const ChessContext = createContext<ChessContextType>({});
@@ -140,6 +141,7 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
         const [orientation, setOrientation] = useState(game?.orientation || startOrientation);
         const keydownMap = useRef<Record<string, boolean>>({});
         const [showGlyphs] = useLocalStorage(ShowGlyphsKey, false);
+        const addEngineMoveRef = useRef<(() => void) | null>(null);
 
         // Solitaire chess
         const solitaireSolution = useRef<Chess>(new Chess({ pgn }));
@@ -249,6 +251,7 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
                         setSolitaireComplete(false);
                     },
                 },
+                addEngineMoveRef,
             }),
             [
                 chess,
@@ -269,6 +272,7 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
                 solitaireSolution,
                 solitaireComplete,
                 onSolitaireMove,
+                addEngineMoveRef,
             ],
         );
 

--- a/frontend/src/board/pgn/boardTools/underboard/settings/KeyboardShortcuts.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/KeyboardShortcuts.tsx
@@ -69,6 +69,8 @@ function displayShortcutAction(action: ShortcutAction): string {
             return 'Unfocus Text Fields';
         case ShortcutAction.InsertNullMove:
             return 'Insert Null Move';
+        case ShortcutAction.InsertEngineMove:
+            return 'Insert Top Engine Move';
     }
 }
 
@@ -119,6 +121,8 @@ function shortcutActionDescription(action: ShortcutAction): string {
             return 'Unfocuses all text fields, allowing the usage of keyboard shortcuts and board controls.';
         case ShortcutAction.InsertNullMove:
             return 'Inserts a null move into the PGN, passing the turn to the other side without changing the position. Null moves cannot be added when in check or immediately after another null move.';
+        case ShortcutAction.InsertEngineMove:
+            return 'Inserts the top engine move into the game or as a comment if a move already exists.';
     }
 }
 
@@ -160,6 +164,11 @@ interface ShortcutHandlerOptions {
      * A function which toggles the orientation of the board.
      */
     toggleOrientation?: () => void;
+
+    /**
+     * Whether to insert the next engine's move when hitting the keybind.
+     */
+    addEngineMove?: () => void;
 }
 
 interface ShortcutHandlerProps {
@@ -341,6 +350,12 @@ function handleInsertNullMove({ chess, reconcile }: ShortcutHandlerProps) {
     reconcile?.();
 }
 
+/** Handles inserting the top engine move.
+ */
+function handleInsertEngineMove({ opts }: ShortcutHandlerProps) {
+    opts?.addEngineMove?.();
+}
+
 /**
  * Maps ShortcutActions to their handler functions. Not all ShortcutActions are included.
  */
@@ -365,6 +380,7 @@ export const keyboardShortcutHandlers: Record<ShortcutAction, ShortcutHandler> =
     [ShortcutAction.FocusCommentTextField]: handleFocusCommentTextField,
     [ShortcutAction.UnfocusTextField]: handleUnfocusTextField,
     [ShortcutAction.InsertNullMove]: handleInsertNullMove,
+    [ShortcutAction.InsertEngineMove]: handleInsertEngineMove,
 };
 
 /**

--- a/frontend/src/board/pgn/boardTools/underboard/settings/ShortcutAction.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ShortcutAction.ts
@@ -61,6 +61,9 @@ export enum ShortcutAction {
 
     /** Inserts a null move. */
     InsertNullMove = 'INSERT_NULL_MOVE',
+
+    /** Inserts the engine's top move. */
+    InsertEngineMove = 'INSERT_ENGINE_MOVE',
 }
 
 export interface KeyBinding {
@@ -95,5 +98,6 @@ export const ShortcutBindings = {
         [ShortcutAction.FocusCommentTextField]: { modifier: '', key: '' },
         [ShortcutAction.UnfocusTextField]: { modifier: '', key: '' },
         [ShortcutAction.InsertNullMove]: { modifier: '', key: '' },
+        [ShortcutAction.InsertEngineMove]: { modifier: '', key: 'Space' },
     },
 } as const;

--- a/frontend/src/board/pgn/pgnText/engine/EngineSection.tsx
+++ b/frontend/src/board/pgn/pgnText/engine/EngineSection.tsx
@@ -50,7 +50,10 @@ export default function EngineSection() {
                     <Tooltip title='Toggle Engine' disableInteractive>
                         <Switch
                             checked={enabled}
-                            onChange={() => setEnabled((prev) => !prev)}
+                            onChange={(e) => {
+                                setEnabled((prev) => !prev);
+                                e.currentTarget.blur();
+                            }}
                             sx={{ mr: 1 }}
                         />
                     </Tooltip>

--- a/frontend/src/board/pgn/pgnText/engine/EvaluationSection.tsx
+++ b/frontend/src/board/pgn/pgnText/engine/EvaluationSection.tsx
@@ -50,7 +50,12 @@ export const EvaluationSection = ({
                 onMouseLeave={onMouseLeave}
             >
                 {Array.from({ length: maxLines }).map((_, i) => (
-                    <LineEvaluation engineInfo={engineInfo} key={i} line={allLines[i]} />
+                    <LineEvaluation
+                        engineInfo={engineInfo}
+                        key={i}
+                        line={allLines[i]}
+                        isTop={i === 0}
+                    />
                 ))}
             </List>
             <Popper

--- a/frontend/src/board/pgn/pgnText/engine/Settings.tsx
+++ b/frontend/src/board/pgn/pgnText/engine/Settings.tsx
@@ -1,6 +1,7 @@
 import {
     ENGINE_ADD_INFO_ON_EVAL_CLICK,
     ENGINE_ADD_INFO_ON_MOVE_CLICK,
+    ENGINE_ADD_INFO_ON_SPACEBAR,
     ENGINE_DEPTH,
     ENGINE_HASH,
     ENGINE_LINE_COUNT,
@@ -64,6 +65,10 @@ export default function Settings() {
     const [addEngineInfoOnMove, setAddEngineInfoOnMove] = useLocalStorage<boolean>(
         ENGINE_ADD_INFO_ON_MOVE_CLICK.Key,
         ENGINE_ADD_INFO_ON_MOVE_CLICK.Default,
+    );
+    const [addEngineInfoOnSpacebar, setAddEngineInfoOnSpacebar] = useLocalStorage<boolean>(
+        ENGINE_ADD_INFO_ON_SPACEBAR.Key,
+        ENGINE_ADD_INFO_ON_SPACEBAR.Default,
     );
     const [highlightEngineLines, setHighlightEngineLines] = useLocalStorage<boolean>(
         HIGHLIGHT_ENGINE_LINES.Key,
@@ -196,6 +201,16 @@ export default function Settings() {
                                 />
                             }
                             label='Add engine info as a comment when clicking move'
+                        />
+
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={addEngineInfoOnSpacebar}
+                                    onChange={(e) => setAddEngineInfoOnSpacebar(e.target.checked)}
+                                />
+                            }
+                            label='Enable "spacebar analysis"'
                         />
 
                         <FormControlLabel

--- a/frontend/src/stockfish/engine/engine.ts
+++ b/frontend/src/stockfish/engine/engine.ts
@@ -169,6 +169,14 @@ export const ENGINE_ADD_INFO_ON_MOVE_CLICK = {
     Default: false,
 } as const;
 
+/** Settings for adding info by typing spacebar while the engine is running. */
+export const ENGINE_ADD_INFO_ON_SPACEBAR = {
+    /** Local storage key for the spacebar behavior. */
+    Key: 'engine-add-info-on-spacebar',
+    /** The default value. */
+    Default: true,
+};
+
 /** Settings for highlighting engine lines. */
 export const HIGHLIGHT_ENGINE_LINES = {
     /** Local storage key for highlighting engine lines. */


### PR DESCRIPTION
This feature adds two settings in the game analysis window:

1. The option to use the spacebar to add the engine's top move either to the game or to a line of analysis (marked with the engine flag). 
2. The option to retain the engine's info on each move, or only retain it on the final move of a line.

The second option should only appear when the first option is checked.

_I tested in all the ways I could think of, but please do give feedback! I'm certainly learning a lot in the process of working on these, and I'm always happy to receive suggestions on how to improve._

