### PR TITLE
fix(#1329): loading indicator on calendar invite

### DIFF
--- a/frontend/src/components/calendar/eventEditor/form/InviteFormSection.tsx
+++ b/frontend/src/components/calendar/eventEditor/form/InviteFormSection.tsx
@@ -79,6 +79,7 @@ export function InviteFormSection({
                         );
                     })
                     .catch((err) => {
+                        setLoading(false);
                         console.error('searchUsers: ', err);
                     });
             }, 400),


### PR DESCRIPTION
Fixes #1329

Used in the Calendar > Edit Event modal.

Display a CircularProgress while fetching users to display in the "Invited Users" Autocomplete component.