### PR TITLE
Added separate MUI solid "paper" background style for DataGrid headers

### DIFF
--- a/frontend/src/style/ThemeProvider.tsx
+++ b/frontend/src/style/ThemeProvider.tsx
@@ -91,6 +91,7 @@ declare module '@mui/material/styles' {
         trainingPlanTaskComplete?: Palette['primary'];
         DataGrid: {
             bg: string;
+            headerBg: string;
         };
 
         // Calendar colors
@@ -163,7 +164,7 @@ declare module '@mui/material' {
 const defaultTheme = createTheme({});
 
 const defaultPalette = {
-    DataGrid: { bg: 'transparent' },
+    DataGrid: { bg: 'transparent', headerBg: 'var(--mui-palette-background-paper)' },
     meet: defaultTheme.palette.augmentColor({
         color: {
             main: '#93a84f',


### PR DESCRIPTION
### Summary

This fixes #1969. For now this will only affect [chessdojo.club/scoreboard](https://chessdojo.club/scoreboard) URLs as those are the only pages with a sticky `DataGrid` header. 

### Testing

https://github.com/user-attachments/assets/48b7ddae-d8a4-46e3-8b5d-f60ec2a5f215

To test this scroll functionality, I also added this "dummy data" to `frontend/src/scoreboard/Scoreboard.tsx` (not included in PR). 
I did this because there are not enough fake paying test users in the test database to scroll down and verify the fix. This seemed easier than modifying anything backend, for now.

In case you want to recreate it I just changed [this line](https://github.com/jackstenglein/chess-dojo/blob/5e3eaa01bfbd94651026369b2bbe4dd70a3b573d/frontend/src/scoreboard/Scoreboard.tsx#L22C1-L22C57) to

```
import {
    RatingSystem,
    SubscriptionStatus,
    TimeFormat,
    User,
    compareCohorts,
} from '../database/user';
```

added this function

```
function generateDummyRows(count: number): ScoreboardRow[] {
    const rows: ScoreboardRow[] = [];
    for (let i = 0; i < count; i++) {
        const startRating = 600 + i * 37;
        rows.push({
            username: `dummy_${i}`,
            displayName: `Player ${i + 1}`,
            discordUsername: '',
            dojoCohort: '1200-1300',
            bio: '',
            ratingSystem: RatingSystem.Chesscom,
            ratings: {
                [RatingSystem.Chesscom]: {
                    hideUsername: false,
                    startRating,
                    currentRating: startRating + ((i * 13) % 300),
                },
            },
            progress: {},
            disableBookingNotifications: false,
            disableCancellationNotifications: false,
            isAdmin: false,
            isCalendarAdmin: false,
            isTournamentAdmin: false,
            isBetaTester: false,
            isCoach: false,
            createdAt: '2024-01-01T00:00:00Z',
            updatedAt: '2025-02-19T00:00:00Z',
            numberOfGraduations: 0,
            previousCohort: '',
            lastGraduatedAt: '',
            enableLightMode: false,
            enableZenMode: false,
            timezoneOverride: '',
            timeFormat: TimeFormat.Default,
            hasCreatedProfile: true,
            followerCount: 0,
            followingCount: 0,
            referralSource: '',
            totalDojoScore: (i * 7) % 100,
            subscriptionStatus: SubscriptionStatus.Subscribed,
            exams: {},
            weekStart: 0,
            minutesSpent: {
                ALL_TIME: i * 200,
                LAST_7_DAYS: i * 10,
                LAST_30_DAYS: i * 40,
                LAST_90_DAYS: i * 100,
                LAST_365_DAYS: i * 180,
                NON_DOJO: i * 30,
                ALL_COHORTS_ALL_TIME: i * 250,
                ALL_COHORTS_LAST_7_DAYS: i * 12,
                ALL_COHORTS_LAST_30_DAYS: i * 50,
                ALL_COHORTS_LAST_90_DAYS: i * 120,
                ALL_COHORTS_LAST_365_DAYS: i * 200,
                ALL_COHORTS_NON_DOJO: i * 40,
            },
        } as User);
    }
    return rows;
}

const DUMMY_ROWS = generateDummyRows(50);
```

and then I just modified [this line ](https://github.com/jackstenglein/chess-dojo/blob/5e3eaa01bfbd94651026369b2bbe4dd70a3b573d/frontend/src/scoreboard/Scoreboard.tsx#L539) to be 

```
const rows = (
            addUser && user && !isFreeTier ? initialRows.concat(user) : initialRows
        ).concat(DUMMY_ROWS);
```

I also tested the following pages that use `DataGrid` to make sure they didn't have any unexpected changes to their 
styling:

- [localhost:3000/games](http://localhost:3000/games)
- [localhost:3000/games/review-queue](http://localhost:3000/games/review-queue)
- [localhost:3000/recent](http://localhost:3000/recent)
- [localhost:3000/tests/checkmate](http://localhost:3000/tests/checkmate)
- [localhost:3000/tournaments/open-classical](http://localhost:3000/tournaments/open-classical)
- [localhost:3000/tournaments/liga](http://localhost:3000/tournaments/liga)
- [localhost:3000/profile/92f5759a-ae36-41f2-82b3-30cdc2d02909](http://localhost:3000/profile/92f5759a-ae36-41f2-82b3-30cdc2d02909)