### PR TITLE
Show recursive game count badge on folder icons

### DIFF
--- a/common/src/database/directory.ts
+++ b/common/src/database/directory.ts
@@ -104,6 +104,12 @@ export const DirectoryItemSchema = z.discriminatedUnion('type', [
 
             /** The description of the directory. */
             description: z.string().trim().max(100).optional(),
+
+            /**
+             * The recursive count of games in this directory and its subdirectories
+             * visible to the viewer. Computed server-side at fetch time; not stored in DynamoDB.
+             */
+            gameCount: z.number().optional(),
         }),
     }),
     z.object({

--- a/frontend/src/components/profile/directories/DirectoriesSection.tsx
+++ b/frontend/src/components/profile/directories/DirectoriesSection.tsx
@@ -19,7 +19,7 @@ import {
     SHARED_DIRECTORY_ID,
 } from '@jackstenglein/chess-dojo-common/src/database/directory';
 import { Folder, Visibility, VisibilityOff } from '@mui/icons-material';
-import { Grid, Stack, SxProps, Typography, useMediaQuery } from '@mui/material';
+import { Badge, Grid, Stack, SxProps, Typography, useMediaQuery } from '@mui/material';
 import {
     DataGridPro,
     GridColumnVisibilityModel,
@@ -341,7 +341,13 @@ function ListViewCell(params: GridRenderCellParams<DirectoryItem>) {
         <Stack height={1} justifyContent='center' py={1}>
             <Grid container>
                 <Grid size={1} display='flex' justifyContent='center'>
-                    <Folder />
+                    <Badge
+                        badgeContent={params.row.metadata.gameCount}
+                        color='secondary'
+                        sx={{ '& .MuiBadge-badge': { fontSize: '0.65rem', minWidth: 16, height: 16 } }}
+                    >
+                        <Folder />
+                    </Badge>
                 </Grid>
                 <Grid size={11}>
                     <Stack

--- a/frontend/src/components/profile/directories/DirectoryGridColumns.tsx
+++ b/frontend/src/components/profile/directories/DirectoryGridColumns.tsx
@@ -13,7 +13,7 @@ import {
     DirectoryVisibility,
 } from '@jackstenglein/chess-dojo-common/src/database/directory';
 import { Folder, Visibility, VisibilityOff } from '@mui/icons-material';
-import { Stack, Tooltip, Typography } from '@mui/material';
+import { Badge, Stack, Tooltip, Typography } from '@mui/material';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
 
 export const publicColumns: GridColDef<DirectoryItem>[] = [
@@ -33,7 +33,15 @@ export const publicColumns: GridColDef<DirectoryItem>[] = [
             const item = params.row;
 
             if (item.type === DirectoryItemTypes.DIRECTORY) {
-                return <Folder sx={{ height: 1 }} />;
+                return (
+                    <Badge
+                        badgeContent={item.metadata.gameCount}
+                        color='secondary'
+                        sx={{ '& .MuiBadge-badge': { fontSize: '0.65rem', minWidth: 16, height: 16 } }}
+                    >
+                        <Folder sx={{ height: 1 }} />
+                    </Badge>
+                );
             }
 
             let value = item.metadata.cohort;


### PR DESCRIPTION
Adds a recursive game count badge on folder icons in the games directory view, so users can see at a glance how many games are inside each folder (including subfolders).

**Approach:** Compute at fetch time. When a directory is fetched, the backend iterates its folder items, recursively counts visible games in each subfolder, and attaches the count as `gameCount` on the item metadata. Visibility rules are respected. PRIVATE folders return 0 for users without access, and unlisted games are excluded for non-viewers.

**Changes:**
- `common/src/database/directory.ts` — adds `gameCount?: number` to the directory item metadata schema (optional, not stored in DynamoDB)
- `backend/directoryService/get.ts` — adds `getRecursiveGameCount()` and calls it in `handlerV2` after `filterPrivateItems`
- `frontend/…/DirectoryGridColumns.tsx` — wraps folder icon with MUI `Badge` in the grid view
- `frontend/…/DirectoriesSection.tsx` — same Badge wrapping in the mobile list view