### PR TITLE
Replace progress slider with number spinner

### DIFF
--- a/frontend/src/components/profile/trainingPlan/InputSlider.tsx
+++ b/frontend/src/components/profile/trainingPlan/InputSlider.tsx
@@ -16,7 +16,8 @@ const InputSlider: React.FC<InputSliderProps> = ({ value, setValue, max, min, su
         if (value < min) {
             setValue(min);
         }
-    }, []);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [min, setValue]);
 
     const handleSliderChange = (_: Event, newValue: number | number[]) => {
         setValue(newValue as number);


### PR DESCRIPTION
## Summary
Closes #1913

- Added a new `NumberSpinner` component with decrement/increment buttons and a centered numeric input
- Replaced the `InputSlider` (slider + text field) in `ProgressUpdater` with the new `NumberSpinner`
- Removed the max count constraint so users can increment past the target count

## Test plan
- [ ] Open a ProgressBar task (e.g. "Read Simple Chess" with Pages suffix) and verify the +/- spinner appears
- [ ] Verify decrement is disabled at the min value
- [ ] Verify the input accepts typed numbers and clamps to min on blur
- [ ] Verify Unspecified display type tasks also show the spinner
- [ ] Verify Checkbox, Minutes, and NonDojo tasks are unaffected

<img width="233" height="88" alt="image" src="https://github.com/user-attachments/assets/4d89b36c-9f6a-49f6-b76b-9f133e598136" />
