### PR TITLE
Fix custom task editing in activity timeline.

### DIFF
--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
@@ -26,17 +26,15 @@ export function EditTimelinEntryDialog({
     const isCustom = entry.isCustomRequirement;
 
     const customTask = isCustom
-        ? user?.customTasks?.find(t => t.id === entry.requirementId)
+        ? user?.customTasks?.find((t) => t.id === entry.requirementId)
         : undefined;
 
     const { requirement: fetchedRequirement } = useRequirement(
-        isCustom ? undefined : entry.requirementId
+        isCustom ? undefined : entry.requirementId,
     );
 
-    const requirement = isCustom
-        ? customTask
-        : fetchedRequirement;
-    
+    const requirement = isCustom ? customTask : fetchedRequirement;
+
     const {
         errors,
         request,


### PR DESCRIPTION
Editing custom activity tasks failed because EditTimelineEntryDialog always attempted to fetch a requirement via useRequirement().  

Custom tasks are stored in user.customTasks and do not exist in the requirement service, causing a 404 and prevented dialog from loading.

This change:

- Skips useRequirement() for custom tasks
- Uses the matching task from user.customTasks instead
- Keeps existing behavior for normal requirements.

Tested locally:

- Normal activities edit correctly.
- Custom activities edit correctly.
- No requirement API calls for custom tasks.

Resolves #1902.  

