### PR TITLE
fix(#1869): import PGNs with commands with no values

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,7 @@
                 "@aws-sdk/s3-request-presigner": "^3.901.0",
                 "@aws-sdk/util-dynamodb": "^3.899.0",
                 "@googleapis/drive": "^19.2.1",
-                "@jackstenglein/chess": "^2.2.17",
+                "@jackstenglein/chess": "^2.2.18",
                 "@jackstenglein/chess-dojo-common": "file:../common",
                 "@savi2w/chess-tcn": "^1.0.0",
                 "adm-zip": "^0.5.16",
@@ -63,7 +63,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@jackstenglein/chess": "^2.2.17",
+                "@jackstenglein/chess": "^2.2.18",
                 "ml-regression-simple-linear": "^3.0.1",
                 "stripe": "^17.5.0",
                 "uuid": "^13.0.0",
@@ -5531,12 +5531,12 @@
             }
         },
         "node_modules/@jackstenglein/chess": {
-            "version": "2.2.17",
-            "resolved": "https://registry.npmjs.org/@jackstenglein/chess/-/chess-2.2.17.tgz",
-            "integrity": "sha512-V8u6vjBkau5i23OigdFMyEXAOZmqFuDgiJcb56Qz1UzBPjTyIUX8YWbPqB2rThs6uEoIm5ux0QAnDILm3BK9Rw==",
+            "version": "2.2.18",
+            "resolved": "https://registry.npmjs.org/@jackstenglein/chess/-/chess-2.2.18.tgz",
+            "integrity": "sha512-qdDhEaJhiwRHzmmc8xnlLCHhe2ezFw4KRKjyWIH0FNWkXTd8oswSr662hXizUTU30Amfq4+/gWRiSXtlYDZJvA==",
             "license": "MIT",
             "dependencies": {
-                "@jackstenglein/pgn-parser": "^2.0.10",
+                "@jackstenglein/pgn-parser": "^2.0.11",
                 "chess.js": "^1.4.0"
             }
         },
@@ -5545,9 +5545,9 @@
             "link": true
         },
         "node_modules/@jackstenglein/pgn-parser": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@jackstenglein/pgn-parser/-/pgn-parser-2.0.10.tgz",
-            "integrity": "sha512-D/DDo0XtQtahxUhrFvsK5JLmYBMrIQiUAP/3xzRyvCE8PA4dOwDdCIDLGTTGTvvU9WuVnKJJdVU4tnuV9Es54g==",
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@jackstenglein/pgn-parser/-/pgn-parser-2.0.11.tgz",
+            "integrity": "sha512-P/L0feK/jkPASMpUOTpVAC1ovP+8cUgFmyr3G5Y/RvcS3oiWDrJEXIq6OnykvCrIZ/Is3zcQRFWSKvSvsmBhVw==",
             "license": "Apache-2.0",
             "bin": {
                 "pgn-parser": "bin/pgn-to-json.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,7 @@
         "@aws-sdk/s3-request-presigner": "^3.901.0",
         "@aws-sdk/util-dynamodb": "^3.899.0",
         "@googleapis/drive": "^19.2.1",
-        "@jackstenglein/chess": "^2.2.17",
+        "@jackstenglein/chess": "^2.2.18",
         "@jackstenglein/chess-dojo-common": "file:../common",
         "@savi2w/chess-tcn": "^1.0.0",
         "adm-zip": "^0.5.16",

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@jackstenglein/chess": "^2.2.17",
+                "@jackstenglein/chess": "^2.2.18",
                 "ml-regression-simple-linear": "^3.0.1",
                 "stripe": "^17.5.0",
                 "uuid": "^13.0.0",
@@ -269,19 +269,19 @@
             }
         },
         "node_modules/@jackstenglein/chess": {
-            "version": "2.2.17",
-            "resolved": "https://registry.npmjs.org/@jackstenglein/chess/-/chess-2.2.17.tgz",
-            "integrity": "sha512-V8u6vjBkau5i23OigdFMyEXAOZmqFuDgiJcb56Qz1UzBPjTyIUX8YWbPqB2rThs6uEoIm5ux0QAnDILm3BK9Rw==",
+            "version": "2.2.18",
+            "resolved": "https://registry.npmjs.org/@jackstenglein/chess/-/chess-2.2.18.tgz",
+            "integrity": "sha512-qdDhEaJhiwRHzmmc8xnlLCHhe2ezFw4KRKjyWIH0FNWkXTd8oswSr662hXizUTU30Amfq4+/gWRiSXtlYDZJvA==",
             "license": "MIT",
             "dependencies": {
-                "@jackstenglein/pgn-parser": "^2.0.10",
+                "@jackstenglein/pgn-parser": "^2.0.11",
                 "chess.js": "^1.4.0"
             }
         },
         "node_modules/@jackstenglein/pgn-parser": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@jackstenglein/pgn-parser/-/pgn-parser-2.0.10.tgz",
-            "integrity": "sha512-D/DDo0XtQtahxUhrFvsK5JLmYBMrIQiUAP/3xzRyvCE8PA4dOwDdCIDLGTTGTvvU9WuVnKJJdVU4tnuV9Es54g==",
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@jackstenglein/pgn-parser/-/pgn-parser-2.0.11.tgz",
+            "integrity": "sha512-P/L0feK/jkPASMpUOTpVAC1ovP+8cUgFmyr3G5Y/RvcS3oiWDrJEXIq6OnykvCrIZ/Is3zcQRFWSKvSvsmBhVw==",
             "license": "Apache-2.0",
             "bin": {
                 "pgn-parser": "bin/pgn-to-json.js"

--- a/common/package.json
+++ b/common/package.json
@@ -10,7 +10,7 @@
     "author": "jackstenglein",
     "license": "MIT",
     "dependencies": {
-        "@jackstenglein/chess": "^2.2.17",
+        "@jackstenglein/chess": "^2.2.18",
         "ml-regression-simple-linear": "^3.0.1",
         "stripe": "^17.5.0",
         "uuid": "^13.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
                 "@emotion/styled": "^11.14.1",
                 "@fortawesome/free-brands-svg-icons": "^6.7.2",
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
-                "@jackstenglein/chess": "^2.2.17",
+                "@jackstenglein/chess": "^2.2.18",
                 "@jackstenglein/chess-dojo-common": "file:../common",
                 "@jackstenglein/react-scheduler": "^4.0.3",
                 "@mui/icons-material": "^7.3.7",
@@ -4707,12 +4707,12 @@
             }
         },
         "node_modules/@jackstenglein/chess": {
-            "version": "2.2.17",
-            "resolved": "https://registry.npmjs.org/@jackstenglein/chess/-/chess-2.2.17.tgz",
-            "integrity": "sha512-V8u6vjBkau5i23OigdFMyEXAOZmqFuDgiJcb56Qz1UzBPjTyIUX8YWbPqB2rThs6uEoIm5ux0QAnDILm3BK9Rw==",
+            "version": "2.2.18",
+            "resolved": "https://registry.npmjs.org/@jackstenglein/chess/-/chess-2.2.18.tgz",
+            "integrity": "sha512-qdDhEaJhiwRHzmmc8xnlLCHhe2ezFw4KRKjyWIH0FNWkXTd8oswSr662hXizUTU30Amfq4+/gWRiSXtlYDZJvA==",
             "license": "MIT",
             "dependencies": {
-                "@jackstenglein/pgn-parser": "^2.0.10",
+                "@jackstenglein/pgn-parser": "^2.0.11",
                 "chess.js": "^1.4.0"
             }
         },
@@ -4721,9 +4721,9 @@
             "link": true
         },
         "node_modules/@jackstenglein/pgn-parser": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@jackstenglein/pgn-parser/-/pgn-parser-2.0.10.tgz",
-            "integrity": "sha512-D/DDo0XtQtahxUhrFvsK5JLmYBMrIQiUAP/3xzRyvCE8PA4dOwDdCIDLGTTGTvvU9WuVnKJJdVU4tnuV9Es54g==",
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@jackstenglein/pgn-parser/-/pgn-parser-2.0.11.tgz",
+            "integrity": "sha512-P/L0feK/jkPASMpUOTpVAC1ovP+8cUgFmyr3G5Y/RvcS3oiWDrJEXIq6OnykvCrIZ/Is3zcQRFWSKvSvsmBhVw==",
             "license": "Apache-2.0",
             "bin": {
                 "pgn-parser": "bin/pgn-to-json.js"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,7 @@
         "@emotion/styled": "^11.14.1",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
-        "@jackstenglein/chess": "^2.2.17",
+        "@jackstenglein/chess": "^2.2.18",
         "@jackstenglein/chess-dojo-common": "file:../common",
         "@jackstenglein/react-scheduler": "^4.0.3",
         "@mui/icons-material": "^7.3.7",

--- a/frontend/playwright/tests/e2e/games/import/importPgnText.spec.ts
+++ b/frontend/playwright/tests/e2e/games/import/importPgnText.spec.ts
@@ -69,4 +69,29 @@ test.describe('Import Games Page - PGN Text', () => {
         await importPgnText(page, pgn);
         await verifyGame(page, { white: 'JackStenglein', black: 'carson2626', lastMove: 'Nc5' });
     });
+
+    test('submits commands without values', async ({ page }) => {
+        await importPgnText(
+            page,
+            `
+[White "JackStenglein"]
+[Black "carson2626"]
+[Result "1-0"]
+[TimeControl "600"]
+[WhiteElo "1653"]
+[BlackElo "1149"]
+[Termination "JackStenglein won by resignation"]
+[ECO "A50"]
+[EndDate "2026.02.09"]
+[Link "https://www.chess.com/game/daily/926728269"]
+
+1. e4 {[%clk 0:10:00]} 1... Nf6 {[%clk 0:05:20][%EOG]}`,
+        );
+        await verifyGame(page, {
+            white: 'JackStenglein',
+            black: 'carson2626',
+            lastMove: 'Nf6',
+            lastMoveClock: { white: '0:10:00', black: '0:05:20' },
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Allows importing PGNs with commands that have no value (like [%EOG])

## Related Issues

Fixes #1869

## Type of change

*   [X] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [x] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}} 

## Demo

N/A
