### PR TITLE
Fix issue 1969 pinned rows

### DIFF
--- a/frontend/src/style/ThemeProvider.tsx
+++ b/frontend/src/style/ThemeProvider.tsx
@@ -94,6 +94,7 @@ declare module '@mui/material/styles' {
             headerBg: string;
             pinnedBg: string;
         };
+
         // Calendar colors
         tomato: Palette['primary'];
         flamingo: Palette['primary'];


### PR DESCRIPTION
## Summary

Fixed the pinned rows bug of #1969. There are two places that use pinned rows: [scoreboards](https://www.chessdojo.club/scoreboard/1700-1800) and the [positions database](https://www.chessdojo.club/games/analysis)  (the "sum" row is pinned to the bottom, but the grid does not scroll in that case, so I don't believe we will notice an effect there.)

## Demo


https://github.com/user-attachments/assets/bd2aa4a5-e2c4-4067-bfb5-aabdac1f0af4


