### PR TITLE
Fix #2031: Filter out zeros from rating graphs on profile + bugfixes

### DIFF
--- a/frontend/src/components/profile/stats/RatingCard.test.ts
+++ b/frontend/src/components/profile/stats/RatingCard.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getChartData } from './RatingCard';
 
 interface ChartData {
@@ -14,18 +14,16 @@ function stringifyDate(date: Date): string {
 }
 
 function simplify(chartData: ChartData[]) {
-
-    if(!chartData || chartData.length === 0) {
+    if (!chartData || chartData.length === 0) {
         return [];
     }
 
     return chartData[0].data.map((datum) => {
         return {
-            date : stringifyDate(datum.date),
-            rating : datum.rating
-        }
+            date: stringifyDate(datum.date),
+            rating: datum.rating,
+        };
     });
-
 }
 
 function subtractDays(date: Date, days: number): Date {
@@ -35,36 +33,25 @@ function subtractDays(date: Date, days: number): Date {
 }
 
 describe('RatingCard.tsx', () => {
-
     describe('getChartData', () => {
-
         beforeEach(() => {
-
             vi.useFakeTimers();
             vi.setSystemTime(new Date('2024-06-01T12:00:00Z'));
-
         });
 
         afterEach(() => {
-
             vi.useRealTimers();
-
         });
 
         it('assigns the correct label to the chart data', () => {
-
             const today = new Date();
 
-            const history = [
-                { date: stringifyDate(today), rating: 1500 }
-            ];
-            
-            expect(getChartData(history, 1500)[0].label).toBe('Rating');
+            const history = [{ date: stringifyDate(today), rating: 1500 }];
 
+            expect(getChartData(history, 1500)[0].label).toBe('Rating');
         });
 
         it('provides correct data for a normal sample case', () => {
-
             const today = new Date();
 
             const history = [
@@ -84,23 +71,17 @@ describe('RatingCard.tsx', () => {
             expect(result[3].date).toBe(stringifyDate(today));
             expect(result[3].rating).toBe(1400);
             expect(result.length).toBe(4);
-            
         });
 
         it('returns an empty array when history is undefined', () => {
-            
             expect(getChartData(undefined, 1500)).toEqual([]);
-
         });
 
         it('returns an empty array when history is empty', () => {
-
             expect(getChartData([], 1500)).toEqual([]);
-
         });
 
         it('returns an empty array when all ratings are zero', () => {
-
             const today = new Date();
 
             const history = [
@@ -111,11 +92,9 @@ describe('RatingCard.tsx', () => {
             const result = getChartData(history, 1500);
 
             expect(result).toEqual([]);
-
         });
 
         it('strips out zero ratings', () => {
-
             const today = new Date();
 
             const history = [
@@ -128,11 +107,9 @@ describe('RatingCard.tsx', () => {
             const result = simplify(getChartData(history, 1300));
 
             expect(result.every((datum) => datum.rating > 0)).toBe(true);
-
         });
 
-        it('starts chart at first date with a nonzero rating', () =>{
-
+        it('starts chart at first date with a nonzero rating', () => {
             const today = new Date();
 
             const history = [
@@ -145,11 +122,9 @@ describe('RatingCard.tsx', () => {
             const result = simplify(getChartData(history, 1400));
 
             expect(result[0].date).toBe(stringifyDate(subtractDays(today, 8)));
-
         });
 
         it('adds current rating if no ratings in past seven days', () => {
-
             const today = new Date();
 
             const history = [
@@ -160,11 +135,9 @@ describe('RatingCard.tsx', () => {
             const result = simplify(getChartData(history, 1300));
 
             expect(result[result.length - 1].rating).toBe(1300);
-
         });
 
         it('adds current rating if there was a rating in the past seven days but not today', () => {
-
             const today = new Date();
 
             const history = [
@@ -176,11 +149,9 @@ describe('RatingCard.tsx', () => {
             const result = simplify(getChartData(history, 1400));
 
             expect(result[result.length - 1].rating).toBe(1400);
-
         });
 
         it('does not add current rating if there was a rating today', () => {
-
             const today = new Date();
 
             const history = [
@@ -192,13 +163,11 @@ describe('RatingCard.tsx', () => {
             const result = simplify(getChartData(history, 1400));
 
             expect(result[result.length - 1].rating).toBe(1300);
-
         });
 
         it('fills in missing weeks', () => {
-
             const today = new Date();
-            
+
             const history = [
                 { date: stringifyDate(subtractDays(today, 21)), rating: 1100 },
                 { date: stringifyDate(subtractDays(today, 7)), rating: 1200 },
@@ -207,11 +176,9 @@ describe('RatingCard.tsx', () => {
             const result = simplify(getChartData(history, 1300));
 
             expect(result[1].date).toBe(stringifyDate(subtractDays(today, 14)));
-
         });
 
         it('fills in missing weeks with last known rating', () => {
-
             const today = new Date();
 
             const history = [
@@ -222,13 +189,11 @@ describe('RatingCard.tsx', () => {
             const result = simplify(getChartData(history, 1300));
 
             expect(result[1].rating).toBe(1100);
-
         });
 
         it('fills in zero-rated weeks with last known rating', () => {
-
             const today = new Date();
-            
+
             const history = [
                 { date: stringifyDate(subtractDays(today, 21)), rating: 1100 },
                 { date: stringifyDate(subtractDays(today, 14)), rating: 0 },
@@ -239,27 +204,23 @@ describe('RatingCard.tsx', () => {
 
             expect(result[1].date).toBe(stringifyDate(subtractDays(today, 14)));
             expect(result[1].rating).toBe(1100);
-
         });
 
         it('has correct data for the week before a missing week', () => {
-
             const today = new Date();
-            
+
             const history = [
                 { date: stringifyDate(subtractDays(today, 21)), rating: 1100 },
                 { date: stringifyDate(subtractDays(today, 7)), rating: 1200 },
             ];
 
             const result = simplify(getChartData(history, 1300));
-            
+
             expect(result[2].date).toBe(stringifyDate(subtractDays(today, 7)));
             expect(result[2].rating).toBe(1200);
-
         });
 
         it('has correct data for the week after a missing week', () => {
-
             const today = new Date();
 
             const history = [
@@ -268,36 +229,27 @@ describe('RatingCard.tsx', () => {
             ];
 
             const result = simplify(getChartData(history, 1300));
-            
+
             expect(result[0].date).toBe(stringifyDate(subtractDays(today, 21)));
             expect(result[0].rating).toBe(1100);
-
         });
 
         it('uses current rating instead last known rating for today when last known rating was an integer multiple of seven days ago', () => {
-
             const today = new Date();
-            
-            const history = [
-                { date: stringifyDate(subtractDays(today, 7)), rating: 1200 },
-            ];
+
+            const history = [{ date: stringifyDate(subtractDays(today, 7)), rating: 1200 }];
 
             const result = simplify(getChartData(history, 1300));
-            
+
             expect(result[1].date).toBe(stringifyDate(today));
             expect(result[1].rating).toBe(1300);
 
-            const history2 = [
-                { date: stringifyDate(subtractDays(today, 14)), rating: 1200 },
-            ];
+            const history2 = [{ date: stringifyDate(subtractDays(today, 14)), rating: 1200 }];
 
             const result2 = simplify(getChartData(history2, 1300));
-            
+
             expect(result2[2].date).toBe(stringifyDate(today));
             expect(result2[2].rating).toBe(1300);
-
         });
-
     });
-
 });

--- a/frontend/src/components/profile/stats/RatingCard.tsx
+++ b/frontend/src/components/profile/stats/RatingCard.tsx
@@ -64,7 +64,6 @@ function everySevenDays(startDate: Date, endDate: Date): Date[] {
 }
 
 function datesAreSameDay(first: Date, second: Date) {
-
     return (
         first.getUTCFullYear() === second.getUTCFullYear() &&
         first.getUTCMonth() === second.getUTCMonth() &&
@@ -73,7 +72,6 @@ function datesAreSameDay(first: Date, second: Date) {
 }
 
 export function getChartData(ratingHistory: RatingHistory[] | undefined, currentRating: number) {
-
     if (!ratingHistory) {
         return [];
     }
@@ -125,7 +123,6 @@ export function getChartData(ratingHistory: RatingHistory[] | undefined, current
     }
 
     return [{ label: 'Rating', data }];
-
 }
 
 function RatingProfileLink({


### PR DESCRIPTION
## Summary

Fix #2031 : Filter out zeros from rating graphs on profile. Rating history data points with a zero rating are now stripped from the chart data before it is displayed.

Added unit tests for frontend/src/components/profile/stats/RatingCard.tsx:getChartData().

Fixed additional issues with getChartData() exposed under testing:
- Profile rating graphs erroneously used the current rating for today's rating even when there was already a saved rating for today in the rating history.
- Profile rating graphs erroneously used old rating data for today instead of the current rating when the last rating saved in the rating history occurred an integer multiple of seven days ago.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}} 
