### PR TITLE
fix(backend): generate stripe billing portal link if user subscribes …

### DIFF
--- a/backend/paymentService/payment.go
+++ b/backend/paymentService/payment.go
@@ -385,6 +385,15 @@ func GetBillingPortalSession(paymentInfo *database.PaymentInfo, tier database.Su
 	}
 
 	session, err := bpsession.New(params)
+	if err != nil && strings.Contains(err.Error(), "does not include the price") {
+		params.FlowData = &stripe.BillingPortalSessionFlowDataParams{
+			Type: stripe.String("subscription_update"),
+			SubscriptionUpdate: &stripe.BillingPortalSessionFlowDataSubscriptionUpdateParams{
+				Subscription: stripe.String(paymentInfo.GetSubscriptionId()),
+			},
+		}
+		session, err = bpsession.New(params)
+	}
 	if err != nil {
 		return nil, errors.Wrap(500, "Failed to create Stripe Billing Portal session", "", err)
 	}


### PR DESCRIPTION
…to deprecated price

*Please familiarize yourself with our [contribution guide](https://github.com/jackstenglein/chess-dojo/blob/main/docs/contributing.md) if you have not already.*

## Summary

Fixes a 500 server error when generating a stripe billing portal session if the user is subscribed to a deprecated price id.

## Related Issues

N/A. Issue sent to support email

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}} 

## Demo

N/A
