### PR TITLE
fix: resolve incorrect best win and worst loss rating comparison in player explorer

### DIFF
--- a/frontend/src/board/pgn/explorer/player/OpeningTree.ts
+++ b/frontend/src/board/pgn/explorer/player/OpeningTree.ts
@@ -200,35 +200,60 @@ export class OpeningTree {
                 lastPlayed = game;
             }
 
+            const opponentRating =
+                game.playerColor === Color.White
+                    ? game.normalizedBlackElo
+                    : game.normalizedWhiteElo;
+
             if (game.result === GameResult.White) {
                 white++;
                 if (game.playerColor === Color.White) {
                     playerWins++;
-                    if (game.normalizedBlackElo > (bestWin?.normalizedBlackElo ?? 0)) {
+                    const bestWinOpponentRating = bestWin
+                        ? bestWin.playerColor === Color.White
+                            ? bestWin.normalizedBlackElo
+                            : bestWin.normalizedWhiteElo
+                        : 0;
+                    if (opponentRating > bestWinOpponentRating) {
                         bestWin = game;
                     }
-                } else if (game.normalizedWhiteElo < (worstLoss?.normalizedWhiteElo ?? Infinity)) {
-                    worstLoss = game;
+                } else {
+                    const worstLossOpponentRating = worstLoss
+                        ? worstLoss.playerColor === Color.White
+                            ? worstLoss.normalizedBlackElo
+                            : worstLoss.normalizedWhiteElo
+                        : Infinity;
+                    if (opponentRating < worstLossOpponentRating) {
+                        worstLoss = game;
+                    }
                 }
             } else if (game.result === GameResult.Black) {
                 black++;
                 if (game.playerColor === Color.Black) {
                     playerWins++;
-                    if (game.normalizedWhiteElo > (bestWin?.normalizedWhiteElo ?? 0)) {
+                    const bestWinOpponentRating = bestWin
+                        ? bestWin.playerColor === Color.White
+                            ? bestWin.normalizedBlackElo
+                            : bestWin.normalizedWhiteElo
+                        : 0;
+                    if (opponentRating > bestWinOpponentRating) {
                         bestWin = game;
                     }
-                } else if (game.normalizedBlackElo < (worstLoss?.normalizedBlackElo ?? Infinity)) {
-                    worstLoss = game;
+                } else {
+                    const worstLossOpponentRating = worstLoss
+                        ? worstLoss.playerColor === Color.White
+                            ? worstLoss.normalizedBlackElo
+                            : worstLoss.normalizedWhiteElo
+                        : Infinity;
+                    if (opponentRating < worstLossOpponentRating) {
+                        worstLoss = game;
+                    }
                 }
             } else {
                 draws++;
             }
 
-            if (game.playerColor === Color.White) {
-                totalOpponentRating += game.normalizedBlackElo;
-            } else {
-                totalOpponentRating += game.normalizedWhiteElo;
-            }
+            totalOpponentRating += opponentRating;
         }
 
         const moves = position.moves
@@ -257,39 +282,60 @@ export class OpeningTree {
                         lastPlayed = game;
                     }
 
+                    const opponentRating =
+                        game.playerColor === Color.White
+                            ? game.normalizedBlackElo
+                            : game.normalizedWhiteElo;
+
                     if (game.result === GameResult.White) {
                         white++;
                         if (game.playerColor === Color.White) {
                             playerWins++;
-                            if (game.normalizedBlackElo > (bestWin?.normalizedBlackElo ?? 0)) {
+                            const bestWinOpponentRating = bestWin
+                                ? bestWin.playerColor === Color.White
+                                    ? bestWin.normalizedBlackElo
+                                    : bestWin.normalizedWhiteElo
+                                : 0;
+                            if (opponentRating > bestWinOpponentRating) {
                                 bestWin = game;
                             }
-                        } else if (
-                            game.normalizedWhiteElo < (worstLoss?.normalizedWhiteElo ?? Infinity)
-                        ) {
-                            worstLoss = game;
+                        } else {
+                            const worstLossOpponentRating = worstLoss
+                                ? worstLoss.playerColor === Color.White
+                                    ? worstLoss.normalizedBlackElo
+                                    : worstLoss.normalizedWhiteElo
+                                : Infinity;
+                            if (opponentRating < worstLossOpponentRating) {
+                                worstLoss = game;
+                            }
                         }
                     } else if (game.result === GameResult.Black) {
                         black++;
                         if (game.playerColor === Color.Black) {
                             playerWins++;
-                            if (game.normalizedWhiteElo > (bestWin?.normalizedWhiteElo ?? 0)) {
+                            const bestWinOpponentRating = bestWin
+                                ? bestWin.playerColor === Color.White
+                                    ? bestWin.normalizedBlackElo
+                                    : bestWin.normalizedWhiteElo
+                                : 0;
+                            if (opponentRating > bestWinOpponentRating) {
                                 bestWin = game;
                             }
-                        } else if (
-                            game.normalizedBlackElo < (worstLoss?.normalizedBlackElo ?? Infinity)
-                        ) {
-                            worstLoss = game;
+                        } else {
+                            const worstLossOpponentRating = worstLoss
+                                ? worstLoss.playerColor === Color.White
+                                    ? worstLoss.normalizedBlackElo
+                                    : worstLoss.normalizedWhiteElo
+                                : Infinity;
+                            if (opponentRating < worstLossOpponentRating) {
+                                worstLoss = game;
+                            }
                         }
                     } else {
                         draws++;
                     }
 
-                    if (game.playerColor === Color.White) {
-                        totalOpponentRating += game.normalizedBlackElo;
-                    } else {
-                        totalOpponentRating += game.normalizedWhiteElo;
-                    }
+                    totalOpponentRating += opponentRating;
                 }
                 const result = { ...move, white, black, draws };
                 const totalGames = white + black + draws;


### PR DESCRIPTION
## Summary

  - Fix bestWin and worstLoss calculations in the player explorer's `OpeningTree.getPosition()`
  - The previous logic compared opponent ratings using a field based on the *current* game's player color, which
  returned the wrong value when the stored best/worst game had the player on the opposite color
  - Now consistently derives opponent rating from each game's `playerColor`, ensuring correct comparisons across games
  where the player alternates between white and black

  ## Test plan

  - [ ] Load the player database / repertoire spy in the analysis board
  - [ ] Search a player who has wins as both white and black
  - [ ] Verify "Best Win" shows the win against the highest-rated opponent
  - [ ] Verify "Worst Loss" shows the loss against the lowest-rated opponent
  - [ ] Check both the position-level and per-move performance summaries