### PR TITLE
 fix: add request timeout handling to game fetches

### DIFF
--- a/frontend/src/api/external/chesscom.ts
+++ b/frontend/src/api/external/chesscom.ts
@@ -103,9 +103,12 @@ export function useChesscomGames(): [
     return [request.data, requestGames, request];
 }
 
+const ARCHIVE_TIMEOUT_MS = 30_000;
+
 export async function fetchChesscomArchiveGames(username: string, year: string, month: string) {
     const resp = await axiosService.get<ChesscomGamesResponse>(
         `https://api.chess.com/pub/player/${username}/games/${year}/${month}`,
+        { timeout: ARCHIVE_TIMEOUT_MS },
     );
     return resp.data.games;
 }

--- a/frontend/src/board/pgn/explorer/player/OpeningTreeLoader.ts
+++ b/frontend/src/board/pgn/explorer/player/OpeningTreeLoader.ts
@@ -11,6 +11,9 @@ import { expose, proxy } from 'comlink';
 import { OpeningTree } from './OpeningTree';
 import { Color, MIN_DOWNLOAD_LIMIT, PlayerSource, SourceType } from './PlayerSource';
 
+/** Timeout in milliseconds for Chess.com and Lichess API requests. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 interface ChesscomListArchivesResponse {
     /**
      * A list of URLs in the form https://api.chess.com/pub/player/{username}/{year}/{month}
@@ -97,6 +100,7 @@ export class OpeningTreeLoader {
 
         const archiveResponse = await axiosService.get<ChesscomListArchivesResponse>(
             `https://api.chess.com/pub/player/${source.username}/games/archives`,
+            { timeout: REQUEST_TIMEOUT_MS },
         );
         const archives = archiveResponse.data.archives?.toReversed() ?? [];
 
@@ -176,12 +180,18 @@ export class OpeningTreeLoader {
             );
         }
 
+        const controller = new AbortController();
+        const connectionTimer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
         const response = await fetch(
             `https://lichess.org/api/games/user/${source.username}?pgnInJson=true`,
             {
                 headers: { Accept: 'application/x-ndjson' },
+                signal: controller.signal,
             },
         );
+
+        clearTimeout(connectionTimer);
 
         const reader = response.body?.getReader();
         if (!reader) {


### PR DESCRIPTION
## Summary
  - Add 30s timeout to Chess.com archive list and game archive requests via axios `timeout` option
  - Add 30s connection timeout to Lichess streaming via `AbortController`
  - Prevents hung/slow API requests from blocking the opening tree indefinitely

  Relates to #2019

  ## Test plan
  - [ ] Verify Chess.com requests fail gracefully after 30s if the API is unresponsive
  - [ ] Verify Lichess streaming aborts after 30s if no connection is established
  - [ ] Verify normal-speed requests are unaffected