### PR TITLE
fix: resolve pre-existing test failures due to missing env vars

### DIFF
--- a/backend/liveClassService/meetingInfo.ts
+++ b/backend/liveClassService/meetingInfo.ts
@@ -77,7 +77,7 @@ export const MEETING_INFO: Record<string, Record<string, MeetingInfo>> = {
 };
 
 function init() {
-    if (process.env.CI === 'true') {
+    if (process.env.CI === 'true' || process.env.VITEST === 'true') {
         return;
     }
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     plugins: [react()],
+    envPrefix: 'NEXT_PUBLIC_',
     resolve: {
         alias: {
             '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- Skip `meetingInfo` `init()` when `VITEST` env var is set, same as the existing `CI` check
- Add `envPrefix: 'NEXT_PUBLIC_'` to vitest config so `NEXT_PUBLIC_*` env vars are available in tests

These 2 test files were failing at config parse time due to missing environment variables — not related to any feature work.

## Test plan
- [ ] Run `npm run test:unit` — verify both previously-failing test files now pass
- [ ] Verify existing CI tests still pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)