### PR TITLE
fix: replace undefined PageProps with explicit param types in blog pages

### DIFF
--- a/frontend/src/app/(blog)/blog/[...id]/page.tsx
+++ b/frontend/src/app/(blog)/blog/[...id]/page.tsx
@@ -15,7 +15,11 @@ async function fetchBlog(id: string) {
     return response.data;
 }
 
-export async function generateMetadata({ params }: PageProps<'/blog/[...id]'>): Promise<Metadata> {
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ id: string[] }>;
+}): Promise<Metadata> {
     const { id: idSegments } = await params;
     const id = idSegments.join('/');
     const blog = await fetchBlog(id);
@@ -34,7 +38,7 @@ export async function generateMetadata({ params }: PageProps<'/blog/[...id]'>): 
     };
 }
 
-export default async function BlogPage({ params }: PageProps<'/blog/[...id]'>) {
+export default async function BlogPage({ params }: { params: Promise<{ id: string[] }> }) {
     const { id: idSegments } = await params;
     const id = idSegments.join('/');
     const blog = await fetchBlog(id);

--- a/frontend/src/app/(scoreboard)/admin/blog/[...id]/page.tsx
+++ b/frontend/src/app/(scoreboard)/admin/blog/[...id]/page.tsx
@@ -1,6 +1,6 @@
 import { EditBlogPage } from './EditBlogPage';
 
-export default async function Page({ params }: PageProps<'/admin/blog/[...id]'>) {
+export default async function Page({ params }: { params: Promise<{ id: string[] }> }) {
     const { id: idSegments } = await params;
     const id = idSegments.join('/');
     return <EditBlogPage id={id} />;


### PR DESCRIPTION
## Summary

- Replace undefined `PageProps` type with explicit inline `{ params: Promise<{ id: string[] }> }` in blog page components
- Fixes TypeScript compilation errors

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to type-only change with no runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)