### PR TITLE
Fix profile calendar reset

### DIFF
--- a/frontend/src/components/calendar/filters/CalendarFilters.tsx
+++ b/frontend/src/components/calendar/filters/CalendarFilters.tsx
@@ -169,8 +169,6 @@ export function useFilters(): Filters {
                 JSON.parse(searchParams.get('tournaments') || '[]') as TimeControlType[],
             );
         }
-
-        
     }, [searchParams, setSearchParams, setSessions, setTypes, setTournamentTimeControls]);
 
     const weekStartOn = user?.weekStart ?? originalWeekStartOn;


### PR DESCRIPTION
This PR is to resolve issue #2021 

Tracked this to frontend/src/components/calendar/filters/CalendarFilters.tsx. 

There was a setSearchParams({}) call in the form flow that cleared all query params, including view=activity on the profile page. 

That caused /profile?view=activity to fall back to /profile and default to the progress tab. 

Removing that specific call fixed the issue, and calendar filtering still appears to work normally.