### PR TITLE
feat: add membership link to shop dropdown in navbar

### DIFF
--- a/frontend/src/components/navigation/navbar/NavbarMenu.tsx
+++ b/frontend/src/components/navigation/navbar/NavbarMenu.tsx
@@ -21,6 +21,7 @@ import {
     CalendarToday,
     Checklist,
     ChevronRight,
+    Diamond,
     ExpandLess,
     ExpandMore,
     Feed,
@@ -330,6 +331,12 @@ function allStartItems(toggleExpansion: (item: string) => void): NavbarItem[] {
                     name: 'Courses',
                     icon: <ImportContacts />,
                     href: '/courses',
+                },
+                {
+                    id: 'subscribe',
+                    name: 'Membership',
+                    icon: <Diamond />,
+                    href: '/prices',
                 },
                 {
                     id: 'merch',


### PR DESCRIPTION
added a direct "Membership" link to the shop dropdown in the navbar that routes to /prices. makes it easier for free users to find and upgrade their subscription without having to navigate through profile settings.

Demo:
<img width="783" height="287" alt="image" src="https://github.com/user-attachments/assets/584ae469-8a8a-47c0-946b-9ee0fcaafa62" />

closes #2089 