### PR TITLE
feat: allow viewing champions RR tournaments

### DIFF
--- a/frontend/src/app/(scoreboard)/tournaments/round-robin/TournamentsPage.tsx
+++ b/frontend/src/app/(scoreboard)/tournaments/round-robin/TournamentsPage.tsx
@@ -5,6 +5,7 @@ import { listRoundRobins, RoundRobinListResponse } from '@/api/roundRobinApi';
 import { useAuth } from '@/auth/Auth';
 import { Tournament } from '@/components/tournaments/round-robin/Tournament';
 import { Waitlist } from '@/components/tournaments/round-robin/Waitlist';
+import { MastersCohort } from '@/database/game';
 import { dojoCohorts } from '@/database/user';
 import { useNextSearchParams } from '@/hooks/useNextSearchParams';
 import LoadingPage from '@/loading/LoadingPage';
@@ -125,6 +126,15 @@ export function TournamentsPage({
                             {cohort}
                         </MenuItem>
                     ))}
+                    <MenuItem value='CHAMPIONS'>
+                        <CohortIcon
+                            cohort={MastersCohort}
+                            sx={{ marginRight: '0.6em', verticalAlign: 'middle' }}
+                            tooltip=''
+                            size={25}
+                        />{' '}
+                        Champions' Circuit
+                    </MenuItem>
                 </TextField>
 
                 {waitlistRequest.data?.tournaments.map((t) => (


### PR DESCRIPTION
*Please familiarize yourself with our [contribution guide](https://github.com/jackstenglein/chess-dojo/blob/main/docs/contributing.md) if you have not already.*

## Summary

Allow viewing champion round robin tournaments

## Related Issues

N/A

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [X] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [X] It was not necessary to add tests due to small change to add new cohort to existing round robin pages

## Demo

N/A
