### PR TITLE
fix: start timeline progress bars at task min goal

### DIFF
--- a/frontend/src/components/newsfeed/NewsfeedItem.tsx
+++ b/frontend/src/components/newsfeed/NewsfeedItem.tsx
@@ -1,4 +1,5 @@
 import { useApi } from '@/api/Api';
+import { useRequirement } from '@/api/cache/requirements';
 import { useAuth } from '@/auth/Auth';
 import { ScoreboardDisplay, formatTime } from '@/database/requirement';
 import { TimelineEntry, TimelineSpecialRequirementId } from '@/database/timeline';
@@ -74,6 +75,7 @@ const NewsfeedItem: React.FC<NewsfeedItemProps> = ({
 };
 
 const NewsfeedItemBody: React.FC<Omit<NewsfeedItemProps, 'onEdit'>> = ({ entry }) => {
+    const { requirement } = useRequirement(entry.requirementId);
     if (entry.requirementId === TimelineSpecialRequirementId.Graduation) {
         return <GraduationNewsfeedItem entry={entry} />;
     }
@@ -123,7 +125,7 @@ const NewsfeedItemBody: React.FC<Omit<NewsfeedItemProps, 'onEdit'>> = ({ entry }
             {isSlider && (
                 <ScoreboardProgress
                     value={entry.newCount}
-                    min={0}
+                    min={requirement?.startCount || 0}
                     max={entry.totalCount}
                     suffix={entry.progressBarSuffix}
                 />


### PR DESCRIPTION
fixes the progress bar math on the newsfeed so it actually reflects work done in the current cohort.
the bar was hardcoded to start from 0, so for tasks with a high starting floor (like polgar m3s starting at 3718) it would show 80%+ full after just one puzzle.
the fix hooks into useRequirement in NewsfeedItem.tsx to grab the task's actual startCount and passes it to the min prop of <ScoreboardProgress /> with a fallback to 0. bar now tracks progress accurately within the current goal range.

closes #2056