### PR TITLE
Feat/2019 training screen space

### DIFF
--- a/frontend/src/components/profile/trainingPlan/TrainingPlanTab.tsx
+++ b/frontend/src/components/profile/trainingPlan/TrainingPlanTab.tsx
@@ -40,7 +40,10 @@ export function TrainingPlanTab({ user }: { user: User }) {
                             width: dailyExpanded ? 1 : { xs: 1, sm: 'calc(50% - 8px)' },
                         }}
                     >
-                        <DailyTrainingPlan expanded={dailyExpanded} setExpanded={setDailyExpanded} />
+                        <DailyTrainingPlan
+                            expanded={dailyExpanded}
+                            setExpanded={setDailyExpanded}
+                        />
                     </Box>
                     {!hideWeekly && (
                         <Box

--- a/frontend/src/components/profile/trainingPlan/TrainingPlanTab.tsx
+++ b/frontend/src/components/profile/trainingPlan/TrainingPlanTab.tsx
@@ -1,7 +1,8 @@
 import { RequestSnackbar } from '@/api/Request';
 import { User } from '@/database/user';
-import { Stack, useMediaQuery } from '@mui/material';
+import { Box, Stack, useMediaQuery } from '@mui/material';
 import { createContext } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
 import { DailyTrainingPlan } from './daily/DailyTrainingPlan';
 import { FullTrainingPlan } from './full/FullTrainingPlan';
 import { useWeeklyTrainingPlan, UseWeeklyTrainingPlanResponse } from './useTrainingPlan';
@@ -14,13 +15,46 @@ export function TrainingPlanTab({ user }: { user: User }) {
     const hideWeekly = useMediaQuery((theme) => theme.breakpoints.down('sm'));
     const trainingPlan = useWeeklyTrainingPlan(user);
 
+    const [dailyExpanded, setDailyExpanded] = useLocalStorage('training-plan-daily-expanded', true);
+    const [weeklyExpanded, setWeeklyExpanded] = useLocalStorage(
+        'training-plan-weekly-expanded',
+        true,
+    );
+
     return (
         <Stack alignItems='start' mb={6} spacing={6}>
             <RequestSnackbar request={trainingPlan.request} />
 
             <TrainingPlanContext value={trainingPlan}>
-                <DailyTrainingPlan />
-                {!hideWeekly && <WeeklyTrainingPlan />}
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        rowGap: 6,
+                        columnGap: 2,
+                        width: 1,
+                    }}
+                >
+                    <Box
+                        sx={{
+                            width: dailyExpanded ? 1 : { xs: 1, sm: 'calc(50% - 8px)' },
+                        }}
+                    >
+                        <DailyTrainingPlan expanded={dailyExpanded} setExpanded={setDailyExpanded} />
+                    </Box>
+                    {!hideWeekly && (
+                        <Box
+                            sx={{
+                                width: weeklyExpanded ? 1 : { xs: 1, sm: 'calc(50% - 8px)' },
+                            }}
+                        >
+                            <WeeklyTrainingPlan
+                                expanded={weeklyExpanded}
+                                setExpanded={setWeeklyExpanded}
+                            />
+                        </Box>
+                    )}
+                </Box>
                 <FullTrainingPlan />
             </TrainingPlanContext>
         </Stack>

--- a/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
@@ -47,9 +47,14 @@ import { WorkGoalSettingsEditor } from '../WorkGoalSettingsEditor';
 import { GraduationTask } from './GraduationTask';
 import { TaskTimerIconButton } from './TaskTimerIconButton';
 
-export function DailyTrainingPlan() {
-    const [expanded, setExpanded] = useLocalStorage('training-plan-daily-expanded', true);
+interface DailyTrainingPlanProps {
+    /** Whether the section is expanded. */
+    expanded: boolean;
+    /** A callback function to toggle the expanded state. */
+    setExpanded: (v: boolean | ((v: boolean) => boolean)) => void;
+}
 
+export function DailyTrainingPlan({ expanded, setExpanded }: DailyTrainingPlanProps) {
     const [startDate, endDate] = useMemo(() => {
         const startDate = new Date();
         startDate.setHours(0, 0, 0, 0);

--- a/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
@@ -34,7 +34,6 @@ import {
     Typography,
 } from '@mui/material';
 import { use, useMemo, useState } from 'react';
-import { useLocalStorage } from 'usehooks-ts';
 import { displayProgress } from '../full/FullTrainingPlanItem';
 import { ScheduleClassicalGameDaily } from '../ScheduleClassicalGame';
 import { SCHEDULE_CLASSICAL_GAME_TASK_ID, SuggestedTask } from '../suggestedTasks';

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
@@ -27,8 +27,8 @@ import {
     VisibilityOff,
 } from '@mui/icons-material';
 import {
-    Button,
     Box,
+    Button,
     IconButton,
     MenuItem,
     Stack,
@@ -308,7 +308,9 @@ export function FullTrainingPlan() {
                     </Stack>
                 </Stack>
 
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', rowGap: 0.5, columnGap: 1, width: 1 }}>
+                <Box
+                    sx={{ display: 'flex', flexWrap: 'wrap', rowGap: 0.5, columnGap: 1, width: 1 }}
+                >
                     {sections.map((section) => (
                         <FullTrainingPlanSection
                             key={section.category}

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
@@ -28,6 +28,7 @@ import {
 } from '@mui/icons-material';
 import {
     Button,
+    Box,
     IconButton,
     MenuItem,
     Stack,
@@ -228,7 +229,7 @@ export function FullTrainingPlan() {
                     flexWrap='wrap'
                     alignItems='end'
                     mt={3}
-                    mb={expanded[sections[0].category] ? -2 : 0}
+                    mb={0}
                 >
                     <TextField
                         id='training-plan-cohort-select'
@@ -307,21 +308,23 @@ export function FullTrainingPlan() {
                     </Stack>
                 </Stack>
 
-                {sections.map((section) => (
-                    <FullTrainingPlanSection
-                        key={section.category}
-                        section={section}
-                        expanded={expanded[section.category]}
-                        toggleExpand={toggleExpand}
-                        user={user}
-                        isCurrentUser={isCurrentUser}
-                        cohort={cohort}
-                        togglePin={togglePin}
-                        pinnedTasks={pinnedTasks}
-                        showCompleted={showCompleted}
-                        setShowCompleted={setShowCompleted}
-                    />
-                ))}
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', rowGap: 0.5, columnGap: 1, width: 1 }}>
+                    {sections.map((section) => (
+                        <FullTrainingPlanSection
+                            key={section.category}
+                            section={section}
+                            expanded={expanded[section.category]}
+                            toggleExpand={toggleExpand}
+                            user={user}
+                            isCurrentUser={isCurrentUser}
+                            cohort={cohort}
+                            togglePin={togglePin}
+                            pinnedTasks={pinnedTasks}
+                            showCompleted={showCompleted}
+                            setShowCompleted={setShowCompleted}
+                        />
+                    ))}
+                </Box>
             </Stack>
         </Stack>
     );

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
@@ -168,7 +168,6 @@ export function FullTrainingPlanSection({
                             maxWidth: { sm: 400, md: 500, lg: 600 },
                         }}
                     >
-
                         {section.progressBar !== undefined && (
                             <ScoreboardProgress
                                 value={section.progressBar}
@@ -186,10 +185,7 @@ export function FullTrainingPlanSection({
                     >
                         <ProgressText
                             value={section.completedTasks.length}
-                            max={
-                                section.completedTasks.length +
-                                section.uncompletedTasks.length
-                            }
+                            max={section.completedTasks.length + section.uncompletedTasks.length}
                             min={0}
                         />
                     </Grid>

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
@@ -97,13 +97,43 @@ export function FullTrainingPlanSection({
             key={section.category}
             expanded={expanded}
             onChange={() => toggleExpand(section.category)}
-            sx={{ width: 1 }}
+            disableGutters
+            sx={{
+                width: expanded ? 1 : { xs: 1, sm: 'calc(50% - 4px)' },
+                '&.Mui-expanded': {
+                    width: 1,
+                },
+                '&:before': {
+                    display: 'none',
+                },
+                backgroundColor: (theme) =>
+                    theme.palette.mode === 'dark'
+                        ? 'rgba(255, 255, 255, .05)'
+                        : 'rgba(0, 0, 0, .03)',
+                backgroundImage: 'none',
+            }}
         >
             <AccordionSummary
                 expandIcon={<ExpandMoreIcon />}
                 aria-controls={`${section.category.replaceAll(' ', '-')}-content`}
                 id={`${section.category.replaceAll(' ', '-')}-header`}
                 data-testid={`${section.category.replaceAll(' ', '-')}-header`}
+                sx={{
+                    position: 'sticky',
+                    top: 'calc(var(--navbar-height) - 1px)',
+                    zIndex: 1,
+                    backgroundColor: 'inherit',
+                    '& .MuiAccordionSummary-content': {
+                        width: 1,
+                        my: 1.5,
+                    },
+                    '&.Mui-expanded': {
+                        minHeight: 0,
+                    },
+                    '&.Mui-expanded .MuiAccordionSummary-content': {
+                        my: 1.5,
+                    },
+                }}
             >
                 <Grid
                     container
@@ -113,7 +143,10 @@ export function FullTrainingPlanSection({
                     sx={{ mr: 2 }}
                     columnGap={3}
                 >
-                    <Grid size={{ xs: 'auto', sm: 5.5, lg: 5, xl: 3 }}>
+                    <Grid
+                        size={{ xs: 'auto', sm: 'auto' }}
+                        sx={{ flexBasis: { sm: '200px' }, flexShrink: 0 }}
+                    >
                         <Typography fontWeight='bold' sx={{ whiteSpace: 'nowrap' }}>
                             <TrainingPlanIcon
                                 category={section.category}
@@ -130,8 +163,12 @@ export function FullTrainingPlanSection({
                     <Grid
                         size={{ xs: 0, sm: 'grow' }}
                         color={section.color}
-                        sx={{ display: { xs: 'none', sm: 'initial' } }}
+                        sx={{
+                            display: { xs: 'none', sm: 'initial' },
+                            maxWidth: { sm: 400, md: 500, lg: 600 },
+                        }}
                     >
+
                         {section.progressBar !== undefined && (
                             <ScoreboardProgress
                                 value={section.progressBar}
@@ -149,13 +186,19 @@ export function FullTrainingPlanSection({
                     >
                         <ProgressText
                             value={section.completedTasks.length}
-                            max={section.completedTasks.length + section.uncompletedTasks.length}
+                            max={
+                                section.completedTasks.length +
+                                section.uncompletedTasks.length
+                            }
                             min={0}
                         />
                     </Grid>
                 </Grid>
             </AccordionSummary>
-            <AccordionDetails data-testid={`progress-category-${section.category}`}>
+            <AccordionDetails
+                data-testid={`progress-category-${section.category}`}
+                sx={{ pt: 0, backgroundColor: 'inherit' }}
+            >
                 <Divider />
 
                 <TaskList

--- a/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
@@ -17,7 +17,6 @@ import {
     Typography,
 } from '@mui/material';
 import { use, useMemo, useState } from 'react';
-import { useLocalStorage } from 'usehooks-ts';
 import { taskTitle } from '../daily/DailyTrainingPlan';
 import { SuggestedTask } from '../suggestedTasks';
 import { TaskDialog, TaskDialogView } from '../TaskDialog';

--- a/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
@@ -28,7 +28,14 @@ import { WorkGoalSettingsEditor } from '../WorkGoalSettingsEditor';
 
 const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'];
 
-export function WeeklyTrainingPlan() {
+interface WeeklyTrainingPlanProps {
+    /** Whether the section is expanded. */
+    expanded: boolean;
+    /** A callback function to toggle the expanded state. */
+    setExpanded: (v: boolean | ((v: boolean) => boolean)) => void;
+}
+
+export function WeeklyTrainingPlan({ expanded, setExpanded }: WeeklyTrainingPlanProps) {
     const { startDate, endDate, weekSuggestions, timeline, isCurrentUser, isLoading, user } =
         use(TrainingPlanContext);
 
@@ -38,8 +45,6 @@ export function WeeklyTrainingPlan() {
         tasks: weekSuggestions,
         timeline,
     });
-
-    const [expanded, setExpanded] = useLocalStorage<boolean>('training-plan-weekly-expanded', true);
 
     const [selectedTask, setSelectedTask] = useState<Requirement | CustomTask>();
     const [taskDialogView, setTaskDialogView] = useState<TaskDialogView>();


### PR DESCRIPTION
## Summary

When a training section ("Today" or "This Week") is collapsed, its header now shrinks to half-width and flows inline next to the other section header, rather than occupying a full row. Expanded sections continue to take full width. Collapse state is persisted via localStorage. On mobile, sections always stack full-width regardless of state.

* Lifted expanded state for both daily and weekly sections up to TrainingPlanTab so layout can react to both states simultaneously
* Replaced fixed-width wrappers with flexWrap containers — collapsed sections shrink to calc(50% - 8px) and sit side-by-side, expanded sections take full width
* Converted expanded/setExpanded from local state to props in DailyTrainingPlan and WeeklyTrainingPlan
* Applied the same responsive reflow to FullTrainingPlanSection accordions, with disableGutters and removed default divider for a cleaner collapsed appearance
* Made AccordionSummary headers sticky (offset by navbar height) so titles stay visible when scrolling long expanded sections

## Related Issues

Fixes [# (2019)](https://github.com/jackstenglein/chess-dojo/issues/2109)

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to not being sure if those changes are what was mean by issue 

## Demo

<img width="2560" height="1336" alt="thorium_tp8kMgbquW" src="https://github.com/user-attachments/assets/da42812c-95cf-4e31-8594-efa0b3950d96" />
