### PR TITLE
fix: make history count label dynamic based on task unit

### DIFF
--- a/frontend/playwright/tests/e2e/profile/trainingPlan/ProgressHistory.spec.ts
+++ b/frontend/playwright/tests/e2e/profile/trainingPlan/ProgressHistory.spec.ts
@@ -316,7 +316,7 @@ test.describe('ProgressHistory', () => {
         await page.getByTestId('task-updater-show-history-button').click();
 
         await expect(page.getByTestId('no-history-text')).toBeVisible();
-        await expect(page.getByText('Total Count: 0. Current Cohort: 0')).toBeVisible();
+        await expect(page.getByTestId('total-count-summary')).toContainText('0. Current Cohort: 0');
         await expect(page.getByText('Total Time: 0h 0m. Current Cohort: 0h 0m')).toBeVisible();
     });
 
@@ -327,9 +327,15 @@ test.describe('ProgressHistory', () => {
             .click();
         await page.getByTestId('task-updater-show-history-button').click();
 
-        await expect(page.getByRole('textbox', { name: 'Count' }).nth(0)).toHaveValue('30');
-        await expect(page.getByRole('textbox', { name: 'Count' }).nth(1)).toHaveValue('20');
-        await expect(page.getByRole('textbox', { name: 'Count' }).nth(2)).toHaveValue('5');
+        await expect(page.getByTestId('task-history-count').locator('input').nth(0)).toHaveValue(
+            '30',
+        );
+        await expect(page.getByTestId('task-history-count').locator('input').nth(1)).toHaveValue(
+            '20',
+        );
+        await expect(page.getByTestId('task-history-count').locator('input').nth(2)).toHaveValue(
+            '5',
+        );
 
         await expect(page.getByRole('textbox', { name: 'Hours' }).nth(0)).toHaveValue('1');
         await expect(page.getByRole('textbox', { name: 'Hours' }).nth(1)).toHaveValue('0');
@@ -339,7 +345,9 @@ test.describe('ProgressHistory', () => {
         await expect(page.getByRole('textbox', { name: 'Minutes' }).nth(1)).toHaveValue('30');
         await expect(page.getByRole('textbox', { name: 'Minutes' }).nth(2)).toHaveValue('10');
 
-        await expect(page.getByText('Total Count: 80. Current Cohort: 80')).toBeVisible();
+        await expect(page.getByTestId('total-count-summary')).toContainText(
+            '80. Current Cohort: 80',
+        );
         await expect(page.getByText('Total Time: 3h 20m. Current Cohort: 2h 10m')).toBeVisible();
     });
 

--- a/frontend/src/components/profile/trainingPlan/ProgressHistory.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistory.tsx
@@ -638,7 +638,7 @@ const ProgressHistory = ({ requirement, onClose, setView }: ProgressHistoryProps
 
             <Stack sx={{ flexGrow: 1, px: 2, pt: 1.5 }}>
                 {!isTimeOnly && (
-                    <Typography color='text.secondary'>
+                    <Typography color='text.secondary' data-testid='total-count-summary'>
                         Total {countLabel} : {totalCount}. Current Cohort: {cohortCount}
                     </Typography>
                 )}


### PR DESCRIPTION
swaps the hardcoded "Count" label in the history modal to dynamically use the task's actual unit (pages, exercises, games, etc.)
changes:

pulls progressBarSuffix from the requirement, trims it, and capitalizes the first letter
applied to both the input field label and the "Total" summary line at the bottom
falls back to "Count" if no suffix is set

testing:
updated the playwright E2E tests in ProgressHistory.spec.ts to use data-testid instead of hardcoded strings so the dynamic labels don't break the CI pipeline.

closes #2100