### PR TITLE
feat: add spellcheck in annotation input

### DIFF
--- a/frontend/src/board/pgn/boardTools/underboard/Editor.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/Editor.tsx
@@ -237,6 +237,7 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
                         multiline
                         minRows={isMainline ? 3 : 7}
                         value={comment}
+                        spellCheck={true}
                         onChange={(event) =>
                             chess.setComment(
                                 event.target.value,


### PR DESCRIPTION
added native browser spellcheck to the main pgn annotation editor. left the other comment fields alone for now, let me know if those need it too.

closes #2122 