### PR TITLE
feat(1983): Fix for amount of games shown on grad newsfeed

### DIFF
--- a/backend/database/graduation.go
+++ b/backend/database/graduation.go
@@ -62,7 +62,7 @@ type Graduation struct {
 	// The amount of time spent in minutes on non-dojo tasks in the cohort
 	NonDojoMinutes int `dynamodbav:"nonDojoMinutes,omitempty" json:"nonDojoMinutes,omitempty"`
 
-	// The number of games uploaded in the 2 months before graduation.
+	// The number of games annotated and published in the 2 months before graduation.
 	GamesAnnotated int `dynamodbav:"gamesAnnotated" json:"gamesAnnotated"`
 
 	// A map from a rating system to a slice of RatingHistory objects for that rating system.

--- a/backend/database/graduation.go
+++ b/backend/database/graduation.go
@@ -62,6 +62,9 @@ type Graduation struct {
 	// The amount of time spent in minutes on non-dojo tasks in the cohort
 	NonDojoMinutes int `dynamodbav:"nonDojoMinutes,omitempty" json:"nonDojoMinutes,omitempty"`
 
+	// The number of games uploaded in the 2 months before graduation.
+	GamesAnnotated int `dynamodbav:"gamesAnnotated" json:"gamesAnnotated"`
+
 	// A map from a rating system to a slice of RatingHistory objects for that rating system.
 	RatingHistories map[RatingSystem][]RatingHistory `dynamodbav:"ratingHistories" json:"ratingHistories"`
 }
@@ -71,6 +74,7 @@ type GraduationCreator interface {
 	UserUpdater
 	RequirementLister
 	TimelineEditor
+	GameLister
 
 	// PutGraduation saves the provided Graduation in the database.
 	PutGraduation(graduation *Graduation) error

--- a/backend/serverless-compose.yml
+++ b/backend/serverless-compose.yml
@@ -21,6 +21,7 @@ services:
       NotificationEventQueueArn: ${notificationService.NotificationEventQueueArn}
       NotificationEventQueueUrl: ${notificationService.NotificationEventQueueUrl}
       DirectoriesTableArn: ${directoryService.DirectoriesTableArn}
+      GamesTableArn: ${chess-dojo-scheduler.GamesTableArn}
 
   discordAuthService:
     path: discordAuthService

--- a/backend/user/graduate/main.go
+++ b/backend/user/graduate/main.go
@@ -76,12 +76,14 @@ func Handler(ctx context.Context, event api.Request) (api.Response, error) {
 	totalTime := user.TimeSpent()
 	dojoTime := user.TimeSpentOnReqs(requirements)
 	nonDojoTime := totalTime - dojoTime
+	log.Debugf("Total Time: %d, Dojo Time: %d, NonDojo Time: %d", totalTime, dojoTime, nonDojoTime)
+
 	gamesAnnotated := 0
 	twoMonthsAgo := now.AddDate(0, -2, 0).Format("2006.01.02")
 	nowDate := now.Format("2006.01.02")
 	var gamesStartKey string
 	for ok := true; ok; ok = gamesStartKey != "" {
-		games, nextKey, err := repository.ListGamesByOwner(true, info.Username, twoMonthsAgo, nowDate, gamesStartKey)
+		games, nextKey, err := repository.ListGamesByOwner(false, info.Username, twoMonthsAgo, nowDate, gamesStartKey)
 		if err != nil {
 			log.Errorf("Failed to list games for graduation count: %v", err)
 			break
@@ -89,8 +91,6 @@ func Handler(ctx context.Context, event api.Request) (api.Response, error) {
 		gamesAnnotated += len(games)
 		gamesStartKey = nextKey
 	}
-
-	log.Debugf("Total Time: %d, Dojo Time: %d, NonDojo Time: %d", totalTime, dojoTime, nonDojoTime)
 
 	ratingHistories := make(map[database.RatingSystem][]database.RatingHistory)
 	for rs, history := range user.RatingHistories {

--- a/backend/user/graduate/main.go
+++ b/backend/user/graduate/main.go
@@ -16,7 +16,6 @@ import (
 )
 
 var repository database.GraduationCreator = database.DynamoDB
-const annotatedGamesRequirementID = "4d23d689-1284-46e6-b2a2-4b4bfdc37174"
 
 type GraduationRequest struct {
 	Comments string `json:"comments"`
@@ -78,8 +77,17 @@ func Handler(ctx context.Context, event api.Request) (api.Response, error) {
 	dojoTime := user.TimeSpentOnReqs(requirements)
 	nonDojoTime := totalTime - dojoTime
 	gamesAnnotated := 0
-	if progress, ok := user.Progress[annotatedGamesRequirementID]; ok && progress != nil {
-		gamesAnnotated = progress.Counts[user.DojoCohort]
+	twoMonthsAgo := now.AddDate(0, -2, 0).Format("2006.01.02")
+	nowDate := now.Format("2006.01.02")
+	var gamesStartKey string
+	for ok := true; ok; ok = gamesStartKey != "" {
+		games, nextKey, err := repository.ListGamesByOwner(true, info.Username, twoMonthsAgo, nowDate, gamesStartKey)
+		if err != nil {
+			log.Errorf("Failed to list games for graduation count: %v", err)
+			break
+		}
+		gamesAnnotated += len(games)
+		gamesStartKey = nextKey
 	}
 
 	log.Debugf("Total Time: %d, Dojo Time: %d, NonDojo Time: %d", totalTime, dojoTime, nonDojoTime)
@@ -115,6 +123,7 @@ func Handler(ctx context.Context, event api.Request) (api.Response, error) {
 		GraduationCohorts:   graduationCohorts,
 		DojoMinutes:         dojoTime,
 		NonDojoMinutes:      nonDojoTime,
+		GamesAnnotated:      gamesAnnotated,
 		RatingHistories:     ratingHistories,
 	}
 	if err := repository.PutGraduation(&graduation); err != nil {

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -739,6 +739,14 @@ functions:
         Action:
           - dynamodb:PutItem
         Resource: ${param:TimelineTableArn}
+      - Effect: Allow
+        Action:
+          - dynamodb:Query
+        Resource:
+          - Fn::Join:
+              - ''
+              - - ${param:GamesTableArn}
+                - '/index/OwnerIdx'
 
   getStatistics:
     handler: statistics/get/main.go

--- a/frontend/playwright/tests/e2e/profile/directories/DirectoriesTab.spec.ts
+++ b/frontend/playwright/tests/e2e/profile/directories/DirectoriesTab.spec.ts
@@ -137,7 +137,7 @@ test.describe('Directories', () => {
             .getByText('Test')
             .last()
             .click({ button: 'right' });
-        await page.getByText('Move').click();
+        await page.getByRole('menuitem', { name: 'Move' }).click();
 
         await expect(page.getByTestId('move-directory-form')).toBeVisible();
     });

--- a/frontend/playwright/tests/e2e/recent/recent.spec.ts
+++ b/frontend/playwright/tests/e2e/recent/recent.spec.ts
@@ -28,6 +28,11 @@ test.describe('Graduations', () => {
         }
     });
 
+    test('displays games annotated count from stored value', async ({ page }) => {
+        const quiteKnightRow = page.getByRole('row', { name: /QuiteKnight/ });
+        await expect(quiteKnightRow.getByText('12')).toBeVisible();
+    });
+
     test('displays correct graduations from past week', async ({ page }) => {
         await expect(
             page.getByTestId('recent-graduates-table').getByText('1–11 of 11'),

--- a/frontend/playwright/tests/fixtures/recent/graduations.json
+++ b/frontend/playwright/tests/fixtures/recent/graduations.json
@@ -6,6 +6,7 @@
             "previousCohort": "1100-1200",
             "newCohort": "1200-1300",
             "score": 17,
+            "gamesAnnotated": 5,
             "ratingSystem": "CHESSCOM",
             "startRating": 1407,
             "currentRating": 1428,
@@ -10641,6 +10642,7 @@
             },
             "numberOfGraduations": 2,
             "graduationCohorts": ["0-300", "300-400"],
+            "gamesAnnotated": 12,
             "startedAt": "2023-07-03T03:04:13Z",
             "createdAt": "2023-09-05T23:49:25Z"
         },

--- a/frontend/src/app/(scoreboard)/recent/RecentGraduates.tsx
+++ b/frontend/src/app/(scoreboard)/recent/RecentGraduates.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useApi } from '@/api/Api';
+import { GameApiContextType } from '@/api/gameApi';
 import { RequestSnackbar, useRequest } from '@/api/Request';
 import { Link } from '@/components/navigation/Link';
 import { Graduation } from '@/database/graduation';
@@ -8,9 +9,17 @@ import { compareCohorts } from '@/database/user';
 import LoadingPage from '@/loading/LoadingPage';
 import Avatar from '@/profile/Avatar';
 import CohortIcon from '@/scoreboard/CohortIcon';
-import { Divider, FormControl, MenuItem, Select, Stack, Typography } from '@mui/material';
+import {
+    CircularProgress,
+    Divider,
+    FormControl,
+    MenuItem,
+    Select,
+    Stack,
+    Typography,
+} from '@mui/material';
 import { DataGridPro, GridColDef, GridRenderCellParams, GridRowParams } from '@mui/x-data-grid-pro';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 function getUniqueGraduations(graduations: Graduation[]): Graduation[] {
     return [...new Map(graduations.map((g) => [g.username, g])).values()];
@@ -59,134 +68,206 @@ function getTimeframeOptions() {
 }
 
 const timeframeOptions = getTimeframeOptions();
-const ANNOTATED_GAMES_TASK_ID = '4d23d689-1284-46e6-b2a2-4b4bfdc37174';
 
-function getAnnotatedGamesCount(graduation: Graduation): number {
-    const progress = graduation.progress?.[ANNOTATED_GAMES_TASK_ID];
-    if (!progress?.counts) {
-        return 0;
-    }
-    return progress.counts[graduation.previousCohort] ?? progress.counts.ALL_COHORTS ?? 0;
+/**
+ * Formats a date as YYYY.MM.DD (the period-separated format used by the games API).
+ */
+function formatGameDate(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}.${m}.${d}`;
 }
 
-const graduateTableColumns: GridColDef<Graduation>[] = [
-    {
-        field: 'displayName',
-        headerName: 'Name',
-        minWidth: 200,
-        flex: 1,
-        renderCell: (params: GridRenderCellParams<Graduation, string>) => {
-            return (
-                <Stack direction='row' spacing={1} alignItems='center'>
-                    <Avatar username={params.row.username} displayName={params.value} size={32} />
-                    <Link href={`/profile/${params.row.username}`}>{params.value}</Link>
-                </Stack>
+/**
+ * Fetches the total game count for a user by paginating through listGamesByOwner.
+ */
+async function fetchGameCount(
+    api: GameApiContextType,
+    owner: string,
+    startDate: string,
+    endDate: string,
+): Promise<number> {
+    let count = 0;
+    let startKey: string | undefined;
+    do {
+        const resp = await api.listGamesByOwner(owner, startKey, startDate, endDate);
+        count += resp.data.games.length;
+        startKey = resp.data.lastEvaluatedKey;
+    } while (startKey);
+    return count;
+}
+
+/**
+ * Cell component that shows the stored gamesAnnotated count, or fetches it live
+ * for old graduation records that don't have it stored.
+ */
+function GamesAnnotatedCell({
+    graduation,
+    api,
+}: {
+    graduation: Graduation;
+    api: GameApiContextType;
+}) {
+    const [count, setCount] = useState<number | null>(
+        graduation.gamesAnnotated !== undefined ? graduation.gamesAnnotated : null,
+    );
+    const fetchedRef = useRef(false);
+
+    const fetchCount = useCallback(async () => {
+        if (fetchedRef.current) return;
+        fetchedRef.current = true;
+        try {
+            const gradDate = new Date(graduation.createdAt);
+            const twoMonthsBefore = new Date(gradDate);
+            twoMonthsBefore.setMonth(twoMonthsBefore.getMonth() - 2);
+            const result = await fetchGameCount(
+                api,
+                graduation.username,
+                formatGameDate(twoMonthsBefore),
+                formatGameDate(gradDate),
             );
+            setCount(result);
+        } catch {
+            setCount(0);
+        }
+    }, [api, graduation.createdAt, graduation.username]);
+
+    useEffect(() => {
+        if (count === null) {
+            fetchCount();
+        }
+    }, [count, fetchCount]);
+
+    if (count === null) {
+        return <CircularProgress size={16} />;
+    }
+    return <>{count}</>;
+}
+
+function getGraduateTableColumns(api: GameApiContextType): GridColDef<Graduation>[] {
+    return [
+        {
+            field: 'displayName',
+            headerName: 'Name',
+            minWidth: 200,
+            flex: 1,
+            renderCell: (params: GridRenderCellParams<Graduation, string>) => {
+                return (
+                    <Stack direction='row' spacing={1} alignItems='center'>
+                        <Avatar
+                            username={params.row.username}
+                            displayName={params.value}
+                            size={32}
+                        />
+                        <Link href={`/profile/${params.row.username}`}>{params.value}</Link>
+                    </Stack>
+                );
+            },
         },
-    },
-    {
-        field: 'graduations',
-        headerName: 'Graduated',
-        align: 'center',
-        headerAlign: 'center',
-        minWidth: 150,
-        flex: 1,
-        valueGetter: (_value, row) => {
-            if (row.graduationCohorts && row.graduationCohorts.length > 0) {
-                return row.graduationCohorts;
-            }
-            return row.previousCohort;
+        {
+            field: 'graduations',
+            headerName: 'Graduated',
+            align: 'center',
+            headerAlign: 'center',
+            minWidth: 150,
+            flex: 1,
+            valueGetter: (_value, row) => {
+                if (row.graduationCohorts && row.graduationCohorts.length > 0) {
+                    return row.graduationCohorts;
+                }
+                return row.previousCohort;
+            },
+            renderCell: (params: GridRenderCellParams<Graduation>) => {
+                const graduationCohorts = [...params.row.graduationCohorts]
+                    .sort(compareCohorts)
+                    .filter((cohort, i, array) => i === array.indexOf(cohort))
+                    .slice(-3);
+                return (
+                    <Stack direction='row' justifyContent='center'>
+                        {graduationCohorts.map((c) => (
+                            <CohortIcon key={c} cohort={c} size={32} />
+                        ))}
+                    </Stack>
+                );
+            },
         },
-        renderCell: (params: GridRenderCellParams<Graduation>) => {
-            const graduationCohorts = [...params.row.graduationCohorts]
-                .sort(compareCohorts)
-                .filter((cohort, i, array) => i === array.indexOf(cohort))
-                .slice(-3);
-            return (
-                <Stack direction='row' justifyContent='center'>
-                    {graduationCohorts.map((c) => (
-                        <CohortIcon key={c} cohort={c} size={32} />
-                    ))}
-                </Stack>
-            );
+        {
+            field: 'previousCohort',
+            headerName: 'Old Cohort',
+            minWidth: 150,
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            valueGetter: (_value, row) => {
+                return parseInt(row.previousCohort.split('-')[0]);
+            },
+            renderCell: (params: GridRenderCellParams<Graduation>) => {
+                return (
+                    <Stack height='30px' justifyContent='center'>
+                        {params.row.previousCohort}
+                    </Stack>
+                );
+            },
         },
-    },
-    {
-        field: 'previousCohort',
-        headerName: 'Old Cohort',
-        minWidth: 150,
-        headerAlign: 'center',
-        align: 'center',
-        flex: 1,
-        valueGetter: (_value, row) => {
-            return parseInt(row.previousCohort.split('-')[0]);
+        {
+            field: 'newCohort',
+            headerName: 'New Cohort',
+            minWidth: 150,
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            valueGetter: (_value, row) => {
+                return parseInt(row.newCohort.replaceAll('+', '').split('-')[0]);
+            },
+            renderCell: (params: GridRenderCellParams<Graduation>) => {
+                return (
+                    <Stack height='30px' justifyContent='center'>
+                        {params.row.newCohort}
+                    </Stack>
+                );
+            },
         },
-        renderCell: (params: GridRenderCellParams<Graduation>) => {
-            return (
+        {
+            field: 'score',
+            headerName: 'Dojo Score',
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            valueFormatter: (value) => Math.round(value * 100) / 100,
+            renderCell: (params) => (
                 <Stack height='30px' justifyContent='center'>
-                    {params.row.previousCohort}
+                    {params.formattedValue}
                 </Stack>
-            );
+            ),
         },
-    },
-    {
-        field: 'newCohort',
-        headerName: 'New Cohort',
-        minWidth: 150,
-        headerAlign: 'center',
-        align: 'center',
-        flex: 1,
-        valueGetter: (_value, row) => {
-            return parseInt(row.newCohort.replaceAll('+', '').split('-')[0]);
-        },
-        renderCell: (params: GridRenderCellParams<Graduation>) => {
-            return (
+        {
+            field: 'gamesAnnotated',
+            headerName: 'Games Annotated',
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            renderCell: (params: GridRenderCellParams<Graduation>) => (
                 <Stack height='30px' justifyContent='center'>
-                    {params.row.newCohort}
+                    <GamesAnnotatedCell graduation={params.row} api={api} />
                 </Stack>
-            );
+            ),
         },
-    },
-    {
-        field: 'score',
-        headerName: 'Dojo Score',
-        headerAlign: 'center',
-        align: 'center',
-        flex: 1,
-        valueFormatter: (value) => Math.round(value * 100) / 100,
-        renderCell: (params) => (
-            <Stack height='30px' justifyContent='center'>
-                {params.formattedValue}
-            </Stack>
-        ),
-    },
-    {
-        field: 'gamesAnnotated',
-        headerName: 'Games Annotated',
-        headerAlign: 'center',
-        align: 'center',
-        flex: 1,
-        valueGetter: (_value, row) => getAnnotatedGamesCount(row),
-        renderCell: (params) => (
-            <Stack height='30px' justifyContent='center'>
-                {params.value}
-            </Stack>
-        ),
-    },
-    {
-        field: 'createdAt',
-        headerName: 'Date',
-        headerAlign: 'center',
-        align: 'center',
-        flex: 1,
-        valueFormatter: (value) => new Date(value).toLocaleDateString(),
-        renderCell: (params) => (
-            <Stack height='30px' justifyContent='center'>
-                {params.formattedValue}
-            </Stack>
-        ),
-    },
-];
+        {
+            field: 'createdAt',
+            headerName: 'Date',
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            valueFormatter: (value) => new Date(value).toLocaleDateString(),
+            renderCell: (params) => (
+                <Stack height='30px' justifyContent='center'>
+                    {params.formattedValue}
+                </Stack>
+            ),
+        },
+    ];
+}
 
 function DetailPanelContent(params: GridRowParams<Graduation>) {
     if (!params.row.comments) {
@@ -207,6 +288,7 @@ const RecentGraduates = () => {
     const api = useApi();
     const request = useRequest<Graduation[]>();
     const [timeframe, setTimeframe] = useState<Timeframe>(timeframeOptions[0]?.value);
+    const columns = useMemo(() => getGraduateTableColumns(api), [api]);
 
     useEffect(() => {
         if (!request.isSent()) {
@@ -273,7 +355,7 @@ const RecentGraduates = () => {
             ) : (
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
                     <DataGridPro
-                        columns={graduateTableColumns}
+                        columns={columns}
                         rows={graduations}
                         getRowId={(row: Graduation) => row.username}
                         getRowHeight={() => 'auto'}

--- a/frontend/src/app/(scoreboard)/recent/RecentGraduates.tsx
+++ b/frontend/src/app/(scoreboard)/recent/RecentGraduates.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useApi } from '@/api/Api';
-import { GameApiContextType } from '@/api/gameApi';
 import { RequestSnackbar, useRequest } from '@/api/Request';
 import { Link } from '@/components/navigation/Link';
 import { Graduation } from '@/database/graduation';
@@ -9,17 +8,9 @@ import { compareCohorts } from '@/database/user';
 import LoadingPage from '@/loading/LoadingPage';
 import Avatar from '@/profile/Avatar';
 import CohortIcon from '@/scoreboard/CohortIcon';
-import {
-    CircularProgress,
-    Divider,
-    FormControl,
-    MenuItem,
-    Select,
-    Stack,
-    Typography,
-} from '@mui/material';
+import { Divider, FormControl, MenuItem, Select, Stack, Typography } from '@mui/material';
 import { DataGridPro, GridColDef, GridRenderCellParams, GridRowParams } from '@mui/x-data-grid-pro';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 function getUniqueGraduations(graduations: Graduation[]): Graduation[] {
     return [...new Map(graduations.map((g) => [g.username, g])).values()];
@@ -69,212 +60,124 @@ function getTimeframeOptions() {
 
 const timeframeOptions = getTimeframeOptions();
 
-/**
- * Formats a date as YYYY.MM.DD (the period-separated format used by the games API).
- * @param date The date to format.
- * @returns The date formatted as YYYY.MM.DD.
- */
-function formatGameDate(date: Date): string {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, '0');
-    const d = String(date.getDate()).padStart(2, '0');
-    return `${y}.${m}.${d}`;
-}
-
-/**
- * Fetches the total game count for a user by paginating through listGamesByOwner.
- * @param api The game API context to use for requests.
- * @param owner The username of the game owner.
- * @param startDate The start date filter in YYYY.MM.DD format.
- * @param endDate The end date filter in YYYY.MM.DD format.
- * @returns The total number of games owned by the user in the date range.
- */
-async function fetchGameCount(
-    api: GameApiContextType,
-    owner: string,
-    startDate: string,
-    endDate: string,
-): Promise<number> {
-    let count = 0;
-    let startKey: string | undefined;
-    do {
-        const resp = await api.listGamesByOwner(owner, startKey, startDate, endDate);
-        count += resp.data.games.length;
-        startKey = resp.data.lastEvaluatedKey;
-    } while (startKey);
-    return count;
-}
-
-/**
- * Cell component that shows the stored gamesAnnotated count, or fetches it live
- * for old graduation records that don't have it stored.
- */
-function GamesAnnotatedCell({
-    graduation,
-    api,
-}: {
-    graduation: Graduation;
-    api: GameApiContextType;
-}) {
-    const [count, setCount] = useState<number | null>(
-        graduation.gamesAnnotated !== undefined ? graduation.gamesAnnotated : null,
-    );
-    const fetchedRef = useRef(false);
-
-    const fetchCount = useCallback(async () => {
-        if (fetchedRef.current) return;
-        fetchedRef.current = true;
-        try {
-            const gradDate = new Date(graduation.createdAt);
-            const twoMonthsBefore = new Date(gradDate);
-            twoMonthsBefore.setMonth(twoMonthsBefore.getMonth() - 2);
-            const result = await fetchGameCount(
-                api,
-                graduation.username,
-                formatGameDate(twoMonthsBefore),
-                formatGameDate(gradDate),
+const graduateTableColumns: GridColDef<Graduation>[] = [
+    {
+        field: 'displayName',
+        headerName: 'Name',
+        minWidth: 200,
+        flex: 1,
+        renderCell: (params: GridRenderCellParams<Graduation, string>) => {
+            return (
+                <Stack direction='row' spacing={1} alignItems='center'>
+                    <Avatar username={params.row.username} displayName={params.value} size={32} />
+                    <Link href={`/profile/${params.row.username}`}>{params.value}</Link>
+                </Stack>
             );
-            setCount(result);
-        } catch {
-            setCount(0);
-        }
-    }, [api, graduation.createdAt, graduation.username]);
-
-    useEffect(() => {
-        if (count === null) {
-            fetchCount();
-        }
-    }, [count, fetchCount]);
-
-    if (count === null) {
-        return <CircularProgress size={16} />;
-    }
-    return <>{count}</>;
-}
-
-function getGraduateTableColumns(api: GameApiContextType): GridColDef<Graduation>[] {
-    return [
-        {
-            field: 'displayName',
-            headerName: 'Name',
-            minWidth: 200,
-            flex: 1,
-            renderCell: (params: GridRenderCellParams<Graduation, string>) => {
-                return (
-                    <Stack direction='row' spacing={1} alignItems='center'>
-                        <Avatar
-                            username={params.row.username}
-                            displayName={params.value}
-                            size={32}
-                        />
-                        <Link href={`/profile/${params.row.username}`}>{params.value}</Link>
-                    </Stack>
-                );
-            },
         },
-        {
-            field: 'graduations',
-            headerName: 'Graduated',
-            align: 'center',
-            headerAlign: 'center',
-            minWidth: 150,
-            flex: 1,
-            valueGetter: (_value, row) => {
-                if (row.graduationCohorts && row.graduationCohorts.length > 0) {
-                    return row.graduationCohorts;
-                }
-                return row.previousCohort;
-            },
-            renderCell: (params: GridRenderCellParams<Graduation>) => {
-                const graduationCohorts = [...params.row.graduationCohorts]
-                    .sort(compareCohorts)
-                    .filter((cohort, i, array) => i === array.indexOf(cohort))
-                    .slice(-3);
-                return (
-                    <Stack direction='row' justifyContent='center'>
-                        {graduationCohorts.map((c) => (
-                            <CohortIcon key={c} cohort={c} size={32} />
-                        ))}
-                    </Stack>
-                );
-            },
+    },
+    {
+        field: 'graduations',
+        headerName: 'Graduated',
+        align: 'center',
+        headerAlign: 'center',
+        minWidth: 150,
+        flex: 1,
+        valueGetter: (_value, row) => {
+            if (row.graduationCohorts && row.graduationCohorts.length > 0) {
+                return row.graduationCohorts;
+            }
+            return row.previousCohort;
         },
-        {
-            field: 'previousCohort',
-            headerName: 'Old Cohort',
-            minWidth: 150,
-            headerAlign: 'center',
-            align: 'center',
-            flex: 1,
-            valueGetter: (_value, row) => {
-                return parseInt(row.previousCohort.split('-')[0]);
-            },
-            renderCell: (params: GridRenderCellParams<Graduation>) => {
-                return (
-                    <Stack height='30px' justifyContent='center'>
-                        {params.row.previousCohort}
-                    </Stack>
-                );
-            },
-        },
-        {
-            field: 'newCohort',
-            headerName: 'New Cohort',
-            minWidth: 150,
-            headerAlign: 'center',
-            align: 'center',
-            flex: 1,
-            valueGetter: (_value, row) => {
-                return parseInt(row.newCohort.replaceAll('+', '').split('-')[0]);
-            },
-            renderCell: (params: GridRenderCellParams<Graduation>) => {
-                return (
-                    <Stack height='30px' justifyContent='center'>
-                        {params.row.newCohort}
-                    </Stack>
-                );
-            },
-        },
-        {
-            field: 'score',
-            headerName: 'Dojo Score',
-            headerAlign: 'center',
-            align: 'center',
-            flex: 1,
-            valueFormatter: (value) => Math.round(value * 100) / 100,
-            renderCell: (params) => (
-                <Stack height='30px' justifyContent='center'>
-                    {params.formattedValue}
+        renderCell: (params: GridRenderCellParams<Graduation>) => {
+            const graduationCohorts = [...params.row.graduationCohorts]
+                .sort(compareCohorts)
+                .filter((cohort, i, array) => i === array.indexOf(cohort))
+                .slice(-3);
+            return (
+                <Stack direction='row' justifyContent='center'>
+                    {graduationCohorts.map((c) => (
+                        <CohortIcon key={c} cohort={c} size={32} />
+                    ))}
                 </Stack>
-            ),
+            );
         },
-        {
-            field: 'gamesAnnotated',
-            headerName: 'Games Annotated',
-            headerAlign: 'center',
-            align: 'center',
-            flex: 1,
-            renderCell: (params: GridRenderCellParams<Graduation>) => (
+    },
+    {
+        field: 'previousCohort',
+        headerName: 'Old Cohort',
+        minWidth: 150,
+        headerAlign: 'center',
+        align: 'center',
+        flex: 1,
+        valueGetter: (_value, row) => {
+            return parseInt(row.previousCohort.split('-')[0]);
+        },
+        renderCell: (params: GridRenderCellParams<Graduation>) => {
+            return (
                 <Stack height='30px' justifyContent='center'>
-                    <GamesAnnotatedCell graduation={params.row} api={api} />
+                    {params.row.previousCohort}
                 </Stack>
-            ),
+            );
         },
-        {
-            field: 'createdAt',
-            headerName: 'Date',
-            headerAlign: 'center',
-            align: 'center',
-            flex: 1,
-            valueFormatter: (value) => new Date(value).toLocaleDateString(),
-            renderCell: (params) => (
+    },
+    {
+        field: 'newCohort',
+        headerName: 'New Cohort',
+        minWidth: 150,
+        headerAlign: 'center',
+        align: 'center',
+        flex: 1,
+        valueGetter: (_value, row) => {
+            return parseInt(row.newCohort.replaceAll('+', '').split('-')[0]);
+        },
+        renderCell: (params: GridRenderCellParams<Graduation>) => {
+            return (
                 <Stack height='30px' justifyContent='center'>
-                    {params.formattedValue}
+                    {params.row.newCohort}
                 </Stack>
-            ),
+            );
         },
-    ];
-}
+    },
+    {
+        field: 'score',
+        headerName: 'Dojo Score',
+        headerAlign: 'center',
+        align: 'center',
+        flex: 1,
+        valueFormatter: (value) => Math.round(value * 100) / 100,
+        renderCell: (params) => (
+            <Stack height='30px' justifyContent='center'>
+                {params.formattedValue}
+            </Stack>
+        ),
+    },
+    {
+        field: 'gamesAnnotated',
+        headerName: 'Games Annotated',
+        headerAlign: 'center',
+        align: 'center',
+        flex: 1,
+        valueGetter: (_value, row) => row.gamesAnnotated ?? 0,
+        renderCell: (params) => (
+            <Stack height='30px' justifyContent='center'>
+                {params.value}
+            </Stack>
+        ),
+    },
+    {
+        field: 'createdAt',
+        headerName: 'Date',
+        headerAlign: 'center',
+        align: 'center',
+        flex: 1,
+        valueFormatter: (value) => new Date(value).toLocaleDateString(),
+        renderCell: (params) => (
+            <Stack height='30px' justifyContent='center'>
+                {params.formattedValue}
+            </Stack>
+        ),
+    },
+];
 
 function DetailPanelContent(params: GridRowParams<Graduation>) {
     if (!params.row.comments) {
@@ -295,7 +198,6 @@ const RecentGraduates = () => {
     const api = useApi();
     const request = useRequest<Graduation[]>();
     const [timeframe, setTimeframe] = useState<Timeframe>(timeframeOptions[0]?.value);
-    const columns = useMemo(() => getGraduateTableColumns(api), [api]);
 
     useEffect(() => {
         if (!request.isSent()) {
@@ -362,7 +264,7 @@ const RecentGraduates = () => {
             ) : (
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
                     <DataGridPro
-                        columns={columns}
+                        columns={graduateTableColumns}
                         rows={graduations}
                         getRowId={(row: Graduation) => row.username}
                         getRowHeight={() => 'auto'}

--- a/frontend/src/app/(scoreboard)/recent/RecentGraduates.tsx
+++ b/frontend/src/app/(scoreboard)/recent/RecentGraduates.tsx
@@ -71,6 +71,8 @@ const timeframeOptions = getTimeframeOptions();
 
 /**
  * Formats a date as YYYY.MM.DD (the period-separated format used by the games API).
+ * @param date The date to format.
+ * @returns The date formatted as YYYY.MM.DD.
  */
 function formatGameDate(date: Date): string {
     const y = date.getFullYear();
@@ -81,6 +83,11 @@ function formatGameDate(date: Date): string {
 
 /**
  * Fetches the total game count for a user by paginating through listGamesByOwner.
+ * @param api The game API context to use for requests.
+ * @param owner The username of the game owner.
+ * @param startDate The start date filter in YYYY.MM.DD format.
+ * @param endDate The end date filter in YYYY.MM.DD format.
+ * @returns The total number of games owned by the user in the date range.
  */
 async function fetchGameCount(
     api: GameApiContextType,

--- a/frontend/src/database/graduation.ts
+++ b/frontend/src/database/graduation.ts
@@ -14,6 +14,7 @@ export interface Graduation {
     ratingHistories?: Record<RatingSystem, RatingHistory[]>;
     comments: string;
     progress: Record<string, RequirementProgress>;
+    gamesAnnotated?: number;
     graduationCohorts: string[];
     startedAt: string;
     createdAt: string;


### PR DESCRIPTION
## Summary

The games annotated count on the graduation newsfeed was broken because it relied on a hardcoded task progress ID (`4d23d689-...`), which only worked if the user had specifically updated that task. This PR replaces that approach with a direct query of games uploaded to MyGames in the 2 months before graduation, matching the intended behavior described in the issue.

**Backend:** At graduation time, paginates through `ListGamesByOwner` with a 2-month date window and stores the count in the `Graduation` record and `TimelineGraduationInfo`.

**Frontend:** Reads the stored `gamesAnnotated` value directly instead of deriving it from task progress. Old graduation records without the field will show 0 until they age out of the "recent" view.

## Related Issues

Fixes #1983

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [x] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

Added a Playwright test that verifies the "Games Annotated" column renders the stored `gamesAnnotated` value from fixture data. Updated the graduation fixture to include `gamesAnnotated` on two entries.

## Demo

No visual design changes, the "Games Annotated" column already existed. This PR fixes the data source so it displays correct values instead of 0.
