### PR TITLE
feat(#2137): Updates 'My Games' in navbar to directly link to the 'My Games' folder

### DIFF
--- a/frontend/src/components/navigation/navbar/NavbarMenu.tsx
+++ b/frontend/src/components/navigation/navbar/NavbarMenu.tsx
@@ -146,7 +146,7 @@ function allStartItems(toggleExpansion: (item: string) => void): NavbarItem[] {
                     id: 'my-games',
                     name: 'My Games',
                     icon: <AccountCircle />,
-                    href: '/profile?view=games',
+                    href: '/profile?view=games&directory=mygames',
                 },
                 {
                     id: 'repertoire-spy',


### PR DESCRIPTION
## Summary

Updates the navbar **My Games** link to include the `directory=mygames` query parameter, so users land directly in their My Games folder instead of the general home directory.

## Related Issues

Fixes #2137

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to the change being a single query parameter addition to an existing navigation link