### PR TITLE
feat(#1259): add merge-multiple games backend endpoint

### DIFF
--- a/backend/pgnService/game/mergeMultiple.test.ts
+++ b/backend/pgnService/game/mergeMultiple.test.ts
@@ -1,0 +1,826 @@
+'use strict';
+
+import { marshall } from '@aws-sdk/util-dynamodb';
+import { MergeMultipleSchema } from '@jackstenglein/chess-dojo-common/src/pgn/merge';
+import { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { assert, beforeEach, describe, test, vi, expect } from 'vitest';
+import { Game } from './types';
+
+// vi.hoisted runs before vi.mock hoisting, so mockSend is available in the factory
+const { mockSend } = vi.hoisted(() => {
+    const mockSend = vi.fn();
+    // Set frontendHost before module import so the module-level const captures it
+    process.env['frontendHost'] = 'https://www.chessdojo.club';
+    return { mockSend };
+});
+
+vi.mock('@aws-sdk/client-dynamodb', async () => {
+    const actual = await vi.importActual<typeof import('@aws-sdk/client-dynamodb')>(
+        '@aws-sdk/client-dynamodb',
+    );
+    class MockDynamoDBClient {
+        send = mockSend;
+    }
+    return {
+        ...actual,
+        DynamoDBClient: MockDynamoDBClient,
+    };
+});
+
+// Mock uuid to produce deterministic IDs
+vi.mock('uuid', () => ({ v4: () => 'test-uuid-1234' }));
+
+import { handler } from './mergeMultiple';
+
+/** Helper: build a minimal Game object. */
+function makeGame(overrides: Partial<Game> & { cohort: string; id: string; pgn: string }): Game {
+    return {
+        white: '?',
+        black: '?',
+        date: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        owner: 'test-user',
+        ownerDisplayName: 'Test User',
+        ownerPreviousCohort: '',
+        headers: {},
+        orientation: 'white',
+        comments: [],
+        positionComments: {},
+        unlisted: false,
+        ...overrides,
+    };
+}
+
+/** Helper: build a fake API Gateway event with the given body and username. */
+function makeEvent(body: object, username = 'test-user'): APIGatewayProxyEventV2 {
+    return {
+        body: JSON.stringify(body),
+        requestContext: {
+            authorizer: {
+                jwt: {
+                    claims: { 'cognito:username': username },
+                },
+            },
+        } as any,
+        headers: {},
+        isBase64Encoded: false,
+        rawPath: '',
+        rawQueryString: '',
+        routeKey: '',
+        version: '2.0',
+    } as APIGatewayProxyEventV2;
+}
+
+/** Helper to build a game key with a unique id (for schema tests). */
+function gameKey(index: number) {
+    return { cohort: '2000-2100', id: `2025-01-01_game${index}` };
+}
+
+/** Helper: set up mockSend to return the given games via BatchGetItem. */
+function mockDynamoGames(games: Game[]) {
+    mockSend.mockImplementation((command: any) => {
+        const commandName = command.constructor.name;
+
+        if (commandName === 'BatchGetItemCommand') {
+            const requestItems = command.input?.RequestItems;
+            const tableName = Object.keys(requestItems)[0];
+            const keys = requestItems[tableName].Keys;
+
+            const items = keys
+                .map((key: any) => {
+                    const cohort = key.cohort?.S;
+                    const id = key.id?.S;
+                    return games.find((g) => g.cohort === cohort && g.id === id);
+                })
+                .filter(Boolean)
+                .map((g: Game) => marshall(g, { removeUndefinedValues: true }));
+
+            return {
+                Responses: { [tableName]: items },
+                UnprocessedKeys: {},
+            };
+        }
+
+        // PutItemCommand returns nothing meaningful
+        return {};
+    });
+}
+
+beforeEach(() => {
+    mockSend.mockReset();
+});
+
+describe('MergeMultipleSchema', () => {
+    test('rejects fewer than 2 games', () => {
+        const result = MergeMultipleSchema.safeParse({
+            games: [gameKey(1)],
+            headerSource: gameKey(1),
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('accepts exactly 2 games', () => {
+        const result = MergeMultipleSchema.safeParse({
+            games: [gameKey(1), gameKey(2)],
+            headerSource: gameKey(1),
+        });
+        expect(result.success).toBe(true);
+    });
+
+    test('accepts exactly 20 games', () => {
+        const games = Array.from({ length: 20 }, (_, i) => gameKey(i + 1));
+        const result = MergeMultipleSchema.safeParse({
+            games,
+            headerSource: games[0],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    test('rejects more than 20 games', () => {
+        const games = Array.from({ length: 21 }, (_, i) => gameKey(i + 1));
+        const result = MergeMultipleSchema.safeParse({
+            games,
+            headerSource: games[0],
+        });
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects duplicate cohort/id pairs', () => {
+        const result = MergeMultipleSchema.safeParse({
+            games: [gameKey(1), gameKey(1)],
+            headerSource: gameKey(1),
+        });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('mergeMultiple handler', () => {
+    test('happy path: merges two games with overlapping lines', async () => {
+        const game1 = makeGame({
+            cohort: '2000-2100',
+            id: 'game-1',
+            pgn: '[White "Alice"]\n[Black "Bob"]\n[Date "2024.01.01"]\n[Result "*"]\n\n1. e4 e5 2. Nf3 *',
+        });
+        const game2 = makeGame({
+            cohort: '2000-2100',
+            id: 'game-2',
+            pgn: '1. e4 e5 2. Bc4 *',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: '2000-2100', id: 'game-1' },
+                { cohort: '2000-2100', id: 'game-2' },
+            ],
+            headerSource: { cohort: '2000-2100', id: 'game-1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        const body = JSON.parse((result as any).body);
+
+        assert.equal((result as any).statusCode, 200);
+        assert.equal(body.cohort, '2000-2100');
+        assert.include(body.id, 'test-uuid-1234');
+
+        // The PutItemCommand should have been called with the merged PGN
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        assert.isDefined(putCall, 'should save the merged game');
+
+        // Verify the merged PGN contains move trees from both games
+        const pgn = putCall![0].input.Item.pgn.S as string;
+        assert.include(pgn, 'Nf3', 'merged PGN should contain Nf3 from game1');
+        assert.include(pgn, 'Bc4', 'merged PGN should contain Bc4 from game2');
+    });
+
+    test('happy path: merges three games, all lines present in result', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 *',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. d4 *',
+        });
+        const game3 = makeGame({
+            cohort: 'c1',
+            id: 'g3',
+            pgn: '1. c4 *',
+        });
+        mockDynamoGames([game1, game2, game3]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+                { cohort: 'c1', id: 'g3' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        // Verify the merged PGN contains all three opening moves
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        assert.isDefined(putCall, 'should save the merged game');
+        const pgn = putCall![0].input.Item.pgn.S as string;
+        assert.include(pgn, 'e4', 'merged PGN should contain e4 from game1');
+        assert.include(pgn, 'd4', 'merged PGN should contain d4 from game2');
+        assert.include(pgn, 'c4', 'merged PGN should contain c4 from game3');
+    });
+
+    test('rejects when caller does not own a private (unlisted) game', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 *',
+            owner: 'test-user',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. d4 *',
+            owner: 'someone-else',
+            unlisted: true, // private game owned by someone else
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 403);
+    });
+
+    test('allows merging public games not owned by caller', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 *',
+            owner: 'test-user',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. d4 *',
+            owner: 'someone-else',
+            unlisted: false, // public game
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+    });
+
+    test('returns 400 when games have mismatched starting positions', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 *', // standard starting position
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '[SetUp "1"]\n[FEN "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"]\n\n1... e5 *', // position after 1. e4
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 400);
+
+        const body = JSON.parse((result as any).body);
+        assert.include(body.message, 'same position');
+    });
+
+    test('returns 400 when headerSource is not in the games list', async () => {
+        const game1 = makeGame({ cohort: 'c1', id: 'g1', pgn: '1. e4 *' });
+        const game2 = makeGame({ cohort: 'c1', id: 'g2', pgn: '1. d4 *' });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'not-in-list' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 400);
+
+        const body = JSON.parse((result as any).body);
+        assert.include(body.message, 'headerSource');
+    });
+
+    test('returns 404 when a game is not found in DynamoDB', async () => {
+        const game1 = makeGame({ cohort: 'c1', id: 'g1', pgn: '1. e4 *' });
+        // game2 does not exist in the mock
+        mockDynamoGames([game1]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'missing-game' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 404);
+
+        const body = JSON.parse((result as any).body);
+        assert.include(body.message, 'not found');
+    });
+
+    test('returns 400 when body is missing required fields', async () => {
+        const event = makeEvent({
+            // Missing games and headerSource
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 400);
+    });
+
+    test('returns 400 when fewer than 2 games provided', async () => {
+        const event = makeEvent({
+            games: [{ cohort: 'c1', id: 'g1' }],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 400);
+    });
+
+    test('uses headers from the headerSource game', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '[White "Alice"]\n[Black "Bob"]\n[Date "2024.06.15"]\n[Result "*"]\n\n1. e4 *',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '[White "Charlie"]\n[Black "Dana"]\n\n1. d4 *',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        // Verify PutItemCommand was called and the saved game has correct white/black from headers
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        assert.isDefined(putCall);
+        const item = putCall![0].input.Item;
+        // white/black in the saved Game are lowercased header values
+        assert.equal(item.white.S, 'alice');
+        assert.equal(item.black.S, 'bob');
+    });
+
+    test('new game is always unlisted', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 *',
+            unlisted: false,
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. d4 *',
+            unlisted: false,
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        assert.isDefined(putCall);
+        const item = putCall![0].input.Item;
+        assert.deepEqual(item.unlisted, { BOOL: true });
+    });
+
+    test('merge with OVERWRITE comment mode replaces comments', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 {original comment} *',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. e4 {new comment} *',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+            commentMergeType: 'OVERWRITE',
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        const item = putCall![0].input.Item;
+        const pgn = item.pgn.S as string;
+        assert.include(pgn, 'new comment');
+        assert.notInclude(pgn, 'original comment');
+    });
+
+    test('merge with DISCARD comment mode keeps only target comments', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 {keep this} *',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. e4 {discard this} *',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+            commentMergeType: 'DISCARD',
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        const pgn = putCall![0].input.Item.pgn.S as string;
+        assert.include(pgn, 'keep this');
+        assert.notInclude(pgn, 'discard this');
+    });
+
+    test('merge with MERGE comment mode appends comments', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 {first} *',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. e4 {second} *',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+            commentMergeType: 'MERGE',
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        const pgn = putCall![0].input.Item.pgn.S as string;
+        assert.include(pgn, 'first');
+        assert.include(pgn, 'second');
+    });
+
+    test('empty PGN game is handled gracefully', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '*',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '*',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+    });
+
+    test('single-move games merge correctly', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 *',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. d4 *',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: 'c1', id: 'g1' },
+                { cohort: 'c1', id: 'g2' },
+            ],
+            headerSource: { cohort: 'c1', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        const pgn = putCall![0].input.Item.pgn.S as string;
+        assert.include(pgn, 'e4');
+        assert.include(pgn, 'd4');
+    });
+
+    test('merged game owner is the calling user', async () => {
+        const game1 = makeGame({
+            cohort: 'c1',
+            id: 'g1',
+            pgn: '1. e4 *',
+            owner: 'test-user',
+        });
+        const game2 = makeGame({
+            cohort: 'c1',
+            id: 'g2',
+            pgn: '1. d4 *',
+            owner: 'someone-else',
+            unlisted: false,
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent(
+            {
+                games: [
+                    { cohort: 'c1', id: 'g1' },
+                    { cohort: 'c1', id: 'g2' },
+                ],
+                headerSource: { cohort: 'c1', id: 'g1' },
+            },
+            'calling-user',
+        );
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        const putCall = mockSend.mock.calls.find(
+            (call) => call[0].constructor.name === 'PutItemCommand',
+        );
+        const item = putCall![0].input.Item;
+        assert.equal(item.owner.S, 'calling-user');
+    });
+
+    test('cohort of merged game matches headerSource game', async () => {
+        const game1 = makeGame({
+            cohort: '1500-1600',
+            id: 'g1',
+            pgn: '1. e4 *',
+        });
+        const game2 = makeGame({
+            cohort: '2000-2100',
+            id: 'g2',
+            pgn: '1. d4 *',
+        });
+        mockDynamoGames([game1, game2]);
+
+        const event = makeEvent({
+            games: [
+                { cohort: '1500-1600', id: 'g1' },
+                { cohort: '2000-2100', id: 'g2' },
+            ],
+            headerSource: { cohort: '1500-1600', id: 'g1' },
+        });
+
+        const result = await handler(event, {} as any, () => {});
+        assert.equal((result as any).statusCode, 200);
+
+        const body = JSON.parse((result as any).body);
+        assert.equal(body.cohort, '1500-1600');
+    });
+
+    describe('citeSource', () => {
+        test('appends citation comment with player names, ratings, date, and game URL', async () => {
+            const game1 = makeGame({
+                cohort: 'c1',
+                id: 'g1',
+                pgn: '1. e4 *',
+            });
+            const game2 = makeGame({
+                cohort: 'c1',
+                id: 'g2',
+                pgn: `[White "Magnus Carlsen"]
+[WhiteElo "2850"]
+[Black "Ian Nepomniachtchi"]
+[BlackElo "2789"]
+[Date "2024.01.15"]
+
+1. e4 e5 *`,
+            });
+            mockDynamoGames([game1, game2]);
+
+            const event = makeEvent({
+                games: [
+                    { cohort: 'c1', id: 'g1' },
+                    { cohort: 'c1', id: 'g2' },
+                ],
+                headerSource: { cohort: 'c1', id: 'g1' },
+                citeSource: true,
+            });
+
+            const result = await handler(event, {} as any, () => {});
+            assert.equal((result as any).statusCode, 200);
+
+            const putCall = mockSend.mock.calls.find(
+                (call) => call[0].constructor.name === 'PutItemCommand',
+            );
+            const pgn = putCall![0].input.Item.pgn.S as string;
+
+            assert.include(pgn, 'Magnus Carlsen (2850)');
+            assert.include(pgn, 'Ian Nepomniachtchi (2789)');
+            assert.include(pgn, '2024.01.15');
+            assert.include(pgn, 'chessdojo.club/games/c1/g2');
+        });
+
+        test('no citation when citeSource is false', async () => {
+            const game1 = makeGame({
+                cohort: 'c1',
+                id: 'g1',
+                pgn: '1. e4 *',
+            });
+            const game2 = makeGame({
+                cohort: 'c1',
+                id: 'g2',
+                pgn: `[White "Player1"]
+[Black "Player2"]
+
+1. e4 e5 *`,
+            });
+            mockDynamoGames([game1, game2]);
+
+            const event = makeEvent({
+                games: [
+                    { cohort: 'c1', id: 'g1' },
+                    { cohort: 'c1', id: 'g2' },
+                ],
+                headerSource: { cohort: 'c1', id: 'g1' },
+                citeSource: false,
+            });
+
+            const result = await handler(event, {} as any, () => {});
+            assert.equal((result as any).statusCode, 200);
+
+            const putCall = mockSend.mock.calls.find(
+                (call) => call[0].constructor.name === 'PutItemCommand',
+            );
+            const pgn = putCall![0].input.Item.pgn.S as string;
+
+            assert.notInclude(pgn, 'chessdojo.club');
+            assert.notInclude(pgn, 'Player1');
+        });
+
+        test('no citation when citeSource is omitted', async () => {
+            const game1 = makeGame({
+                cohort: 'c1',
+                id: 'g1',
+                pgn: '1. e4 *',
+            });
+            const game2 = makeGame({
+                cohort: 'c1',
+                id: 'g2',
+                pgn: `[White "Player1"]
+[Black "Player2"]
+
+1. e4 e5 *`,
+            });
+            mockDynamoGames([game1, game2]);
+
+            const event = makeEvent({
+                games: [
+                    { cohort: 'c1', id: 'g1' },
+                    { cohort: 'c1', id: 'g2' },
+                ],
+                headerSource: { cohort: 'c1', id: 'g1' },
+                // citeSource not provided
+            });
+
+            const result = await handler(event, {} as any, () => {});
+            assert.equal((result as any).statusCode, 200);
+
+            const putCall = mockSend.mock.calls.find(
+                (call) => call[0].constructor.name === 'PutItemCommand',
+            );
+            const pgn = putCall![0].input.Item.pgn.S as string;
+
+            assert.notInclude(pgn, 'chessdojo.club');
+        });
+
+        test('citation falls back to NN for missing player names and omits rating', async () => {
+            const game1 = makeGame({
+                cohort: 'c1',
+                id: 'g1',
+                pgn: '1. e4 *',
+            });
+            const game2 = makeGame({
+                cohort: 'c1',
+                id: 'g2',
+                // No White/Black/WhiteElo/BlackElo headers
+                pgn: '1. e4 e5 *',
+            });
+            mockDynamoGames([game1, game2]);
+
+            const event = makeEvent({
+                games: [
+                    { cohort: 'c1', id: 'g1' },
+                    { cohort: 'c1', id: 'g2' },
+                ],
+                headerSource: { cohort: 'c1', id: 'g1' },
+                citeSource: true,
+            });
+
+            const result = await handler(event, {} as any, () => {});
+            assert.equal((result as any).statusCode, 200);
+
+            const putCall = mockSend.mock.calls.find(
+                (call) => call[0].constructor.name === 'PutItemCommand',
+            );
+            const pgn = putCall![0].input.Item.pgn.S as string;
+
+            // Should fall back to 'NN' for both players
+            assert.include(pgn, 'NN - NN');
+            assert.include(pgn, 'chessdojo.club/games/c1/g2');
+        });
+    });
+});

--- a/backend/pgnService/game/mergeMultiple.ts
+++ b/backend/pgnService/game/mergeMultiple.ts
@@ -1,0 +1,187 @@
+import { BatchGetItemCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { Chess } from '@jackstenglein/chess';
+import { MergeMultipleSchema } from '@jackstenglein/chess-dojo-common/src/pgn/merge';
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
+import {
+    ApiError,
+    errToApiGatewayProxyResultV2,
+    parseBody,
+    requireUserInfo,
+} from '../../directoryService/api';
+import { dynamo, gamesTable, success } from './create';
+import { recursiveMergeLine } from './mergeUtils';
+import { Game } from './types';
+
+/**
+ * Lambda handler that merges multiple games into a single new game.
+ * @param event The event that triggered the Lambda.
+ * @returns The cohort and id of the newly created game.
+ */
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+    try {
+        console.log('Event: %j', event);
+
+        const userInfo = requireUserInfo(event);
+        const request = parseBody(event, MergeMultipleSchema);
+
+        // Fetch all games
+        const games = await fetchGames(request.games);
+
+        // Verify the caller can access all games (must be owner or game must be public)
+        for (const game of games) {
+            if (game.owner !== userInfo.username && game.unlisted) {
+                throw new ApiError({
+                    statusCode: 403,
+                    publicMessage:
+                        'Permission denied: you can only merge your own games or public games',
+                });
+            }
+        }
+
+        // Find the header source game
+        const headerSourceGame = games.find(
+            (g) =>
+                g.cohort === request.headerSource.cohort &&
+                g.id === request.headerSource.id,
+        );
+        if (!headerSourceGame) {
+            throw new ApiError({
+                statusCode: 400,
+                publicMessage:
+                    'Invalid request: headerSource must be one of the games in the list',
+            });
+        }
+
+        // Start with the header source game as the base
+        const target = new Chess({ pgn: headerSourceGame.pgn });
+        target.seek(null);
+
+        // Merge all other games into the target
+        for (const game of games) {
+            if (game.cohort === headerSourceGame.cohort && game.id === headerSourceGame.id) {
+                continue;
+            }
+
+            const source = new Chess({ pgn: game.pgn });
+            source.seek(null);
+
+            if (source.normalizedFen() !== target.normalizedFen()) {
+                throw new ApiError({
+                    statusCode: 400,
+                    publicMessage:
+                        'Unable to merge: the games do not start from the same position',
+                });
+            }
+
+            const citation = request.citeSource
+                ? { source, cohort: game.cohort, id: game.id }
+                : undefined;
+
+            recursiveMergeLine(source.history(), target, null, {
+                commentMergeType: request.commentMergeType,
+                nagMergeType: request.nagMergeType,
+                drawableMergeType: request.drawableMergeType,
+                citation,
+            });
+        }
+
+        // Create a new game with the merged PGN
+        const mergedPgn = target.renderPgn();
+        const now = new Date();
+        const uploadDate = now.toISOString().slice(0, '2024-01-01'.length);
+        const headers = target.header().valueMap();
+
+        const newGame: Game = {
+            cohort: headerSourceGame.cohort,
+            id: `${uploadDate.replaceAll('-', '.')}_${uuidv4()}`,
+            white: headers.White?.toLowerCase() || '?',
+            black: headers.Black?.toLowerCase() || '?',
+            date: headers.Date || '',
+            createdAt: now.toISOString(),
+            updatedAt: now.toISOString(),
+            owner: userInfo.username,
+            ownerDisplayName: headerSourceGame.ownerDisplayName || '',
+            ownerPreviousCohort: headerSourceGame.ownerPreviousCohort || '',
+            headers,
+            pgn: mergedPgn,
+            orientation: headerSourceGame.orientation || 'white',
+            comments: [],
+            positionComments: {},
+            unlisted: true,
+        };
+
+        await putGame(newGame);
+
+        return success({ cohort: newGame.cohort, id: newGame.id });
+    } catch (err) {
+        return errToApiGatewayProxyResultV2(err);
+    }
+};
+
+/**
+ * Fetches all games with the provided keys from DynamoDB using BatchGetItem.
+ * @param gameKeys The cohort/id pairs to fetch.
+ * @returns The fetched games.
+ */
+async function fetchGames(
+    gameKeys: { cohort: string; id: string }[],
+): Promise<Game[]> {
+    const games: Game[] = [];
+    const allKeys: Record<string, { S: string }>[] = gameKeys.map(({ cohort, id }) => ({
+        cohort: { S: cohort },
+        id: { S: id },
+    }));
+
+    for (let i = 0; i < allKeys.length; i += 100) {
+        let keys = allKeys.slice(i, i + 100);
+
+        while (keys.length > 0) {
+            const response = await dynamo.send(
+                new BatchGetItemCommand({
+                    RequestItems: {
+                        [gamesTable]: {
+                            Keys: keys,
+                        },
+                    },
+                }),
+            );
+
+            const items = response.Responses?.[gamesTable] ?? [];
+            for (const item of items) {
+                games.push(unmarshall(item) as Game);
+            }
+
+            keys = (response.UnprocessedKeys?.[gamesTable]?.Keys ?? []) as typeof keys;
+        }
+    }
+
+    if (games.length !== gameKeys.length) {
+        const foundKeys = new Set(games.map((g) => `${g.cohort}/${g.id}`));
+        const missing = gameKeys.find(
+            ({ cohort, id }) => !foundKeys.has(`${cohort}/${id}`),
+        );
+        throw new ApiError({
+            statusCode: 404,
+            publicMessage: `Game ${missing?.cohort}/${missing?.id} not found`,
+        });
+    }
+
+    return games;
+}
+
+/**
+ * Saves a game to DynamoDB.
+ * @param game The game to save.
+ */
+async function putGame(game: Game) {
+    await dynamo.send(
+        new PutItemCommand({
+            Item: marshall(game, { removeUndefinedValues: true }),
+            TableName: gamesTable,
+        }),
+    );
+}
+
+

--- a/backend/pgnService/game/mergeMultiple.ts
+++ b/backend/pgnService/game/mergeMultiple.ts
@@ -70,8 +70,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
             if (source.normalizedFen() !== target.normalizedFen()) {
                 throw new ApiError({
                     statusCode: 400,
-                    publicMessage:
-                        'Unable to merge: the games do not start from the same position',
+                    publicMessage: `Unable to merge: game ${game.cohort}/${game.id} does not start from the same position as the header source game`,
                 });
             }
 

--- a/backend/pgnService/game/mergePgn.ts
+++ b/backend/pgnService/game/mergePgn.ts
@@ -1,6 +1,6 @@
 import { GetItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
-import { Chess, Move } from '@jackstenglein/chess';
+import { Chess } from '@jackstenglein/chess';
 import {
     PgnMergeRequest,
     PgnMergeSchema,
@@ -14,10 +14,8 @@ import {
     success,
 } from '../../directoryService/api';
 import { dynamo, gamesTable } from './create';
-import { getPlayer, mergeComments, mergeDrawables, mergeNags } from './mergeUtils';
+import { recursiveMergeLine } from './mergeUtils';
 import { Game } from './types';
-
-const frontendHost = process.env['frontendHost'];
 
 /**
  * Lambda handler that merges a PGN into an existing game.
@@ -128,59 +126,17 @@ export function mergePgn(source: Chess, target: Chess, request: PgnMergeRequest)
         });
     }
 
-    recursiveMergeLine(source.history(), source, target, null, request);
+    const citation =
+        request.citeSource && request.sourceCohort && request.sourceId
+            ? { source, cohort: request.sourceCohort, id: request.sourceId }
+            : undefined;
+
+    recursiveMergeLine(source.history(), target, null, {
+        commentMergeType: request.commentMergeType,
+        nagMergeType: request.nagMergeType,
+        drawableMergeType: request.drawableMergeType,
+        citation,
+    });
     return target.renderPgn();
-}
-
-/**
- * Recursively merges the given line into the target Chess instance.
- * @param line The line to merge into the Chess instance.
- * @param source The source Chess to merge into the target.
- * @param target The target Chess to merge the line into.
- * @param currentTargetMove The current move to start from in the target Chess.
- * @param request The merge options.
- */
-function recursiveMergeLine(
-    line: Move[],
-    source: Chess,
-    target: Chess,
-    currentTargetMove: Move | null,
-    request: PgnMergeRequest,
-) {
-    for (const move of line) {
-        const newTargetMove = target.move(move.san, {
-            previousMove: currentTargetMove,
-            skipSeek: true,
-        });
-        if (!newTargetMove) {
-            throw new ApiError({
-                statusCode: 400,
-                publicMessage: `Unable to merge: invalid move ${move.san} at ply ${move.ply}`,
-            });
-        }
-
-        mergeComments(move, newTargetMove, request.commentMergeType);
-        mergeNags(move, newTargetMove, request.nagMergeType);
-        mergeDrawables(move, newTargetMove, request.drawableMergeType);
-
-        for (const variation of move.variations) {
-            recursiveMergeLine(variation, source, target, currentTargetMove, request);
-        }
-
-        currentTargetMove = newTargetMove;
-    }
-
-    if (request.citeSource && request.sourceCohort && request.sourceId && currentTargetMove) {
-        const white = getPlayer(source.header().tags.White, source.header().tags.WhiteElo?.value);
-        const black = getPlayer(source.header().tags.Black, source.header().tags.BlackElo?.value);
-        const date = source.header().getRawValue('Date');
-        const comment = `[${white} - ${black}${date ? ` ${date}` : ''}](${frontendHost}/games/${request.sourceCohort}/${request.sourceId})`;
-
-        if (currentTargetMove.commentAfter) {
-            currentTargetMove.commentAfter += `\n\n${comment}`;
-        } else {
-            currentTargetMove.commentAfter = comment;
-        }
-    }
 }
 

--- a/backend/pgnService/game/mergeUtils.ts
+++ b/backend/pgnService/game/mergeUtils.ts
@@ -1,8 +1,24 @@
-import { DiagramComment, Move } from '@jackstenglein/chess';
+import { Chess, DiagramComment, Move } from '@jackstenglein/chess';
 import {
     PgnMergeType,
     PgnMergeTypes,
 } from '@jackstenglein/chess-dojo-common/src/pgn/merge';
+import { ApiError } from '../../directoryService/api';
+
+const frontendHost = process.env['frontendHost'];
+
+/** Options for recursiveMergeLine controlling how move data is merged and cited. */
+export interface MergeLineOptions {
+    commentMergeType: PgnMergeType;
+    nagMergeType: PgnMergeType;
+    drawableMergeType: PgnMergeType;
+    /** If provided, a citation comment is appended to the last move of the line. */
+    citation?: {
+        source: Chess;
+        cohort: string;
+        id: string;
+    };
+}
 
 /**
  * Merges the comments from the given source move into the target move.
@@ -106,4 +122,55 @@ export function getPlayer(name: string | undefined, elo: string | undefined): st
         return `${result} (${elo})`;
     }
     return result;
+}
+
+/**
+ * Recursively merges the given line into the target Chess instance.
+ * @param line The line to merge into the Chess instance.
+ * @param target The target Chess to merge the line into.
+ * @param currentTargetMove The current move to start from in the target Chess.
+ * @param options Controls how move data is merged and whether to add a citation comment.
+ */
+export function recursiveMergeLine(
+    line: Move[],
+    target: Chess,
+    currentTargetMove: Move | null,
+    options: MergeLineOptions,
+) {
+    for (const move of line) {
+        const newTargetMove = target.move(move.san, {
+            previousMove: currentTargetMove,
+            skipSeek: true,
+        });
+        if (!newTargetMove) {
+            throw new ApiError({
+                statusCode: 400,
+                publicMessage: `Unable to merge: invalid move ${move.san} at ply ${move.ply}`,
+            });
+        }
+
+        mergeComments(move, newTargetMove, options.commentMergeType);
+        mergeNags(move, newTargetMove, options.nagMergeType);
+        mergeDrawables(move, newTargetMove, options.drawableMergeType);
+
+        for (const variation of move.variations) {
+            recursiveMergeLine(variation, target, currentTargetMove, options);
+        }
+
+        currentTargetMove = newTargetMove;
+    }
+
+    if (options.citation && currentTargetMove) {
+        const { source, cohort, id } = options.citation;
+        const white = getPlayer(source.header().tags.White, source.header().tags.WhiteElo?.value);
+        const black = getPlayer(source.header().tags.Black, source.header().tags.BlackElo?.value);
+        const date = source.header().getRawValue('Date');
+        const comment = `[${white} - ${black}${date ? ` ${date}` : ''}](${frontendHost}/games/${cohort}/${id})`;
+
+        if (currentTargetMove.commentAfter) {
+            currentTargetMove.commentAfter += `\n\n${comment}`;
+        } else {
+            currentTargetMove.commentAfter = comment;
+        }
+    }
 }

--- a/backend/pgnService/serverless.yml
+++ b/backend/pgnService/serverless.yml
@@ -304,6 +304,27 @@ functions:
         Resource:
           - ${param:GamesTableArn}
 
+  mergeMultiple:
+    timeout: 28
+    handler: game/mergeMultiple.handler
+    environment:
+      frontendHost: ${file(../config-${sls:stage}.yml):frontendHost}
+    events:
+      - httpApi:
+          path: /game/merge-multiple
+          method: post
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+          - dynamodb:PutItem
+        Resource:
+          - ${param:GamesTableArn}
+
 resources:
   Conditions:
     IsProd: !Equals ['${sls:stage}', 'prod']

--- a/common/src/pgn/merge.ts
+++ b/common/src/pgn/merge.ts
@@ -49,3 +49,55 @@ export const PgnMergeSchema = z.object({
 
 /** A request to merge a PGN into a game. */
 export type PgnMergeRequest = z.infer<typeof PgnMergeSchema>;
+
+/** Identifies a game by its cohort and id. */
+const gameKeySchema = z.object({
+    /** The cohort of the game. */
+    cohort: z.string(),
+
+    /** The id of the game. */
+    id: z.string(),
+});
+
+/** Verifies a request to merge multiple games into a single new game. */
+export const MergeMultipleSchema = z.object({
+    /** The games to merge. Must contain at least 2 games with unique cohort/id pairs. */
+    games: z
+        .array(gameKeySchema)
+        .min(2)
+        .max(20)
+        .refine(
+            (games) => {
+                const keys = new Set<string>();
+                for (const g of games) {
+                    const key = `${g.cohort}/${g.id}`;
+                    if (keys.has(key)) return false;
+                    keys.add(key);
+                }
+                return true;
+            },
+            { message: 'games array must not contain duplicate cohort/id pairs' },
+        ),
+
+    /** Which game's headers to use for the merged game. Must be one of the games in the list. */
+    headerSource: gameKeySchema,
+
+    /** How to handle the comments from the merged games. Defaults to MERGE. */
+    commentMergeType: pgnMergeType
+        .optional()
+        .transform((val) => val || PgnMergeTypes.MERGE),
+
+    /** How to handle the NAGs from the merged games. Defaults to MERGE. */
+    nagMergeType: pgnMergeType.optional().transform((val) => val || PgnMergeTypes.MERGE),
+
+    /** How to handle the drawables from the merged games. Defaults to MERGE. */
+    drawableMergeType: pgnMergeType
+        .optional()
+        .transform((val) => val || PgnMergeTypes.MERGE),
+
+    /** Whether to cite each source game in a comment at the end of its main line. Defaults to false. */
+    citeSource: z.boolean().optional(),
+});
+
+/** A request to merge multiple games into a single new game. */
+export type MergeMultipleRequest = z.infer<typeof MergeMultipleSchema>;

--- a/common/src/pgn/merge.ts
+++ b/common/src/pgn/merge.ts
@@ -65,6 +65,8 @@ export const MergeMultipleSchema = z.object({
     games: z
         .array(gameKeySchema)
         .min(2)
+        // Cap at 20 to limit Lambda execution time (recursive PGN merge is CPU-bound)
+        // while still covering realistic use cases like merging a full tournament.
         .max(20)
         .refine(
             (games) => {
@@ -83,17 +85,13 @@ export const MergeMultipleSchema = z.object({
     headerSource: gameKeySchema,
 
     /** How to handle the comments from the merged games. Defaults to MERGE. */
-    commentMergeType: pgnMergeType
-        .optional()
-        .transform((val) => val || PgnMergeTypes.MERGE),
+    commentMergeType: pgnMergeType.default(PgnMergeTypes.MERGE),
 
     /** How to handle the NAGs from the merged games. Defaults to MERGE. */
-    nagMergeType: pgnMergeType.optional().transform((val) => val || PgnMergeTypes.MERGE),
+    nagMergeType: pgnMergeType.default(PgnMergeTypes.MERGE),
 
     /** How to handle the drawables from the merged games. Defaults to MERGE. */
-    drawableMergeType: pgnMergeType
-        .optional()
-        .transform((val) => val || PgnMergeTypes.MERGE),
+    drawableMergeType: pgnMergeType.default(PgnMergeTypes.MERGE),
 
     /** Whether to cite each source game in a comment at the end of its main line. Defaults to false. */
     citeSource: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds a new `POST /game/merge-multiple` Lambda endpoint that merges 2–20 selected games into a single new game. Validates same starting position, access control (owner or public), and header-source selection. Includes Zod request schema in `common/src/pgn/merge.ts`.

## Related Issues

Part of #1259 (2 of 3 PRs, follows [PR #2123](https://github.com/jackstenglein/chess-dojo/pull/2123))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] New unit tests (vitest) were added
- [ ] New playwright tests were added
- [ ] It was not necessary to add tests due to {{reason}}

## Demo

N/A — no user-facing changes. Backend endpoint only.