### PR TITLE
Adding rest day support for mobile + bug fixes

### DIFF
--- a/frontend/src/components/profile/info/Heatmap.tsx
+++ b/frontend/src/components/profile/info/Heatmap.tsx
@@ -31,7 +31,15 @@ import {
 } from '@mui/material';
 import { DateTime } from 'luxon';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import { cloneElement, useEffect, useMemo, useState } from 'react';
+import {
+    cloneElement,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import {
     ActivityCalendar,
     Activity as BaseActivity,
@@ -39,6 +47,7 @@ import {
     DayIndex,
 } from 'react-activity-calendar';
 import { GiCrossedSwords } from 'react-icons/gi';
+import { LongPressEventType, LongPressReactEvents, useLongPress } from 'use-long-press';
 import { useTimelineContext } from '../activity/useTimeline';
 import { DEFAULT_WORK_GOAL } from '../trainingPlan/workGoal';
 import { MIN_BLOCK_SIZE } from './HeatmapCard';
@@ -178,6 +187,8 @@ export function Heatmap({
     const timeline = useTimelineContext();
     const editable = viewer?.username === timeline.owner;
     const request = useRequest();
+    const scrollerRef = useRef<HTMLDivElement | null>(null);
+    const preservedScrollLeftRef = useRef(0);
     const [, setCalendarRef] = useState<HTMLElement | null>(null);
     const [contextMenu, setContextMenu] = useState<
         | {
@@ -207,15 +218,22 @@ export function Heatmap({
     }, [entries, minDate, maxDate, viewer, weekEndOn]);
 
     useEffect(() => {
-        const scroller = document.getElementById('heatmap-scroll-container');
+        const scroller = scrollerRef.current;
         if (scroller) {
             scroller.scrollLeft = scroller.scrollWidth;
         }
-    });
+    }, [maxDate, minDate, weekStartOn]);
 
-    const closeContextMenu = () => setContextMenu(undefined);
+    useLayoutEffect(() => {
+        const scroller = scrollerRef.current;
+        if (scroller) {
+            scroller.scrollLeft = preservedScrollLeftRef.current;
+        }
+    }, [contextMenu]);
 
-    const onBlockContextMenu = (
+    const closeContextMenu = useCallback(() => setContextMenu(undefined), []);
+
+    const onBlockContextMenu = useCallback((
         event: ReactMouseEvent<SVGElement>,
         activity: Activity | ExtendedBaseActivity,
     ) => {
@@ -224,6 +242,7 @@ export function Heatmap({
             return;
         }
 
+        preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
         setContextMenu({
             activity,
             position: {
@@ -231,20 +250,45 @@ export function Heatmap({
                 left: event.clientX,
             },
         });
-    };
+    }, [editable]);
+
+    const onBlockLongPress = useCallback((
+        event: LongPressReactEvents<SVGElement>,
+        activity: Activity | ExtendedBaseActivity,
+    ) => {
+        event.preventDefault();
+        if (!editable || !canManageRestDay(activity)) {
+            return;
+        }
+
+        const touch = 'touches' in event ? event.touches[0] : undefined;
+        if (!touch) {
+            return;
+        }
+
+        preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
+        setContextMenu({
+            activity,
+            position: {
+                top: touch.clientY,
+                left: touch.clientX,
+            },
+        });
+    }, [editable]);
 
     const currentRestDayEntry =
         contextMenu && viewer
             ? findRestDayEntry(entries, contextMenu.activity.date, viewer)
             : undefined;
 
-    const saveRestDay = async () => {
-        if (!viewer || !contextMenu || currentRestDayEntry) {
+    const saveRestDay = async (date: string) => {
+        if (!viewer || findRestDayEntry(entries, date, viewer)) {
             return;
         }
 
         request.onStart();
-        const entry = createRestDayEntry(viewer, contextMenu.activity.date);
+        const entry = createRestDayEntry(viewer, date);
+        timeline.onEditEntries([entry]);
 
         try {
             await api.updateUserTimeline({
@@ -258,12 +302,20 @@ export function Heatmap({
                 updated: [entry],
                 deleted: [],
             });
-            timeline.onEditEntries([entry]);
             request.onSuccess();
-            closeContextMenu();
         } catch (err) {
+            timeline.onDeleteEntries([entry]);
             request.onFailure(err);
         }
+    };
+
+    const saveContextMenuRestDay = async () => {
+        if (!contextMenu || currentRestDayEntry) {
+            return;
+        }
+
+        closeContextMenu();
+        await saveRestDay(contextMenu.activity.date);
     };
 
     const clearRestDay = async () => {
@@ -272,6 +324,8 @@ export function Heatmap({
         }
 
         request.onStart();
+        closeContextMenu();
+        timeline.onDeleteEntries([currentRestDayEntry]);
         try {
             await api.updateUserTimeline({
                 requirementId: TimelineSpecialRequirementId.RestDay,
@@ -284,32 +338,16 @@ export function Heatmap({
                 updated: [],
                 deleted: [currentRestDayEntry],
             });
-            timeline.onDeleteEntries([currentRestDayEntry]);
             request.onSuccess();
-            closeContextMenu();
         } catch (err) {
+            timeline.onEditEntries([currentRestDayEntry]);
             request.onFailure(err);
         }
     };
 
-    return (
-        <Stack
-            maxWidth={1}
-            sx={{
-                '& .react-activity-calendar__scroll-container': {
-                    paddingTop: '1px',
-                    paddingBottom: '10px',
-                    overflow: 'visible !important',
-                },
-                '& .react-activity-calendar__footer': {
-                    marginLeft: '0 !important',
-                },
-            }}
-        >
-            <RequestSnackbar request={request} />
-            <HeatmapOptions onPopOut={onPopOut} />
-
-            <Stack id='heatmap-scroll-container' direction='row' sx={{ overflowX: 'auto' }}>
+    const calendar = useMemo(
+        () => (
+            <Stack ref={scrollerRef} direction='row' sx={{ overflowX: 'auto' }}>
                 <Paper
                     elevation={1}
                     sx={{ position: 'sticky', left: 0, pr: 0.75, borderRadius: 0, pb: 4 }}
@@ -370,6 +408,7 @@ export function Heatmap({
                                 maxDate={maxDate}
                                 editable={editable}
                                 onContextMenu={onBlockContextMenu}
+                                onLongPress={onBlockLongPress}
                             />
                         )}
                         maxLevel={MAX_LEVEL}
@@ -382,6 +421,44 @@ export function Heatmap({
                     <Divider sx={{ mt: '2px' }} />
                 </Stack>
             </Stack>
+        ),
+        [
+            activities,
+            blockSize,
+            clamp,
+            colorMode,
+            editable,
+            field,
+            isLight,
+            maxDate,
+            onBlockContextMenu,
+            onBlockLongPress,
+            slotProps?.weekdayLabelPaper,
+            theme,
+            weekEndOn,
+            weekStartOn,
+            weekSummaries,
+            workGoalHistory,
+        ],
+    );
+
+    return (
+        <Stack
+            maxWidth={1}
+            sx={{
+                '& .react-activity-calendar__scroll-container': {
+                    paddingTop: '1px',
+                    paddingBottom: '10px',
+                    overflow: 'visible !important',
+                },
+                '& .react-activity-calendar__footer': {
+                    marginLeft: '0 !important',
+                },
+            }}
+        >
+            <RequestSnackbar request={request} />
+            <HeatmapOptions onPopOut={onPopOut} />
+            {calendar}
             <Stack
                 direction='row'
                 justifyContent='space-between'
@@ -450,7 +527,10 @@ export function Heatmap({
                         </Stack>
                     </MenuItem>
                 ) : (
-                    <MenuItem onClick={() => void saveRestDay()} disabled={request.isLoading()}>
+                    <MenuItem
+                        onClick={() => void saveContextMenuRestDay()}
+                        disabled={request.isLoading()}
+                    >
                         <Stack direction='row' alignItems='center' gap={1}>
                             <RestDayIcon size={18} />
                             <Typography>Rest Day</Typography>
@@ -576,6 +656,7 @@ function Block({
     maxDate,
     editable,
     onContextMenu,
+    onLongPress,
 }: {
     block: BlockElement;
     activity: Activity | ExtendedBaseActivity;
@@ -590,6 +671,10 @@ function Block({
     editable?: boolean;
     onContextMenu?: (
         event: ReactMouseEvent<SVGElement>,
+        activity: Activity | ExtendedBaseActivity,
+    ) => void;
+    onLongPress?: (
+        event: LongPressReactEvents<SVGElement>,
         activity: Activity | ExtendedBaseActivity,
     ) => void;
 }) {
@@ -629,6 +714,20 @@ function Block({
     const newStyle = color ? { ...block.props.style, fill: color } : block.props.style;
     const icon = Boolean(activity.graduation || activity.gamePlayed || activity.restDay);
     const canOpenContextMenu = editable && canManageRestDay(activity);
+    const longPress = useLongPress<SVGElement>(
+        (event) => {
+            if (canOpenContextMenu) {
+                onLongPress?.(event, activity);
+            }
+        },
+        {
+            detect: LongPressEventType.Touch,
+            threshold: 700,
+            onStart: (event) => {
+                event.preventDefault();
+            },
+        },
+    );
     const blockProps = {
         'data-testid': `heatmap-block-${activity.date}`,
         'data-activity-date': activity.date,
@@ -670,6 +769,7 @@ function Block({
             onContextMenu={
                 canOpenContextMenu ? (event) => onContextMenu?.(event, activity) : undefined
             }
+            {...longPress()}
         />
     ) : (
         cloneElement(block, {
@@ -678,6 +778,7 @@ function Block({
             onContextMenu: canOpenContextMenu
                 ? (event: ReactMouseEvent<SVGElement>) => onContextMenu?.(event, activity)
                 : undefined,
+            ...longPress(),
         })
     );
 

--- a/frontend/src/components/profile/info/Heatmap.tsx
+++ b/frontend/src/components/profile/info/Heatmap.tsx
@@ -233,48 +233,48 @@ export function Heatmap({
 
     const closeContextMenu = useCallback(() => setContextMenu(undefined), []);
 
-    const onBlockContextMenu = useCallback((
-        event: ReactMouseEvent<SVGElement>,
-        activity: Activity | ExtendedBaseActivity,
-    ) => {
-        event.preventDefault();
-        if (!editable || !canManageRestDay(activity)) {
-            return;
-        }
+    const onBlockContextMenu = useCallback(
+        (event: ReactMouseEvent<SVGElement>, activity: Activity | ExtendedBaseActivity) => {
+            event.preventDefault();
+            if (!editable || !canManageRestDay(activity)) {
+                return;
+            }
 
-        preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
-        setContextMenu({
-            activity,
-            position: {
-                top: event.clientY,
-                left: event.clientX,
-            },
-        });
-    }, [editable]);
+            preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
+            setContextMenu({
+                activity,
+                position: {
+                    top: event.clientY,
+                    left: event.clientX,
+                },
+            });
+        },
+        [editable],
+    );
 
-    const onBlockLongPress = useCallback((
-        event: LongPressReactEvents<SVGElement>,
-        activity: Activity | ExtendedBaseActivity,
-    ) => {
-        event.preventDefault();
-        if (!editable || !canManageRestDay(activity)) {
-            return;
-        }
+    const onBlockLongPress = useCallback(
+        (event: LongPressReactEvents<SVGElement>, activity: Activity | ExtendedBaseActivity) => {
+            event.preventDefault();
+            if (!editable || !canManageRestDay(activity)) {
+                return;
+            }
 
-        const touch = 'touches' in event ? event.touches[0] : undefined;
-        if (!touch) {
-            return;
-        }
+            const touch = 'touches' in event ? event.touches[0] : undefined;
+            if (!touch) {
+                return;
+            }
 
-        preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
-        setContextMenu({
-            activity,
-            position: {
-                top: touch.clientY,
-                left: touch.clientX,
-            },
-        });
-    }, [editable]);
+            preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
+            setContextMenu({
+                activity,
+                position: {
+                    top: touch.clientY,
+                    left: touch.clientX,
+                },
+            });
+        },
+        [editable],
+    );
 
     const currentRestDayEntry =
         contextMenu && viewer

--- a/frontend/src/components/profile/info/Heatmap.tsx
+++ b/frontend/src/components/profile/info/Heatmap.tsx
@@ -31,15 +31,7 @@ import {
 } from '@mui/material';
 import { DateTime } from 'luxon';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import {
-    cloneElement,
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import { cloneElement, useEffect, useMemo, useRef, useState } from 'react';
 import {
     ActivityCalendar,
     Activity as BaseActivity,
@@ -188,7 +180,6 @@ export function Heatmap({
     const editable = viewer?.username === timeline.owner;
     const request = useRequest();
     const scrollerRef = useRef<HTMLDivElement | null>(null);
-    const preservedScrollLeftRef = useRef(0);
     const [, setCalendarRef] = useState<HTMLElement | null>(null);
     const [contextMenu, setContextMenu] = useState<
         | {
@@ -222,75 +213,67 @@ export function Heatmap({
         if (scroller) {
             scroller.scrollLeft = scroller.scrollWidth;
         }
-    }, [maxDate, minDate, weekStartOn]);
+    }, []);
 
-    useLayoutEffect(() => {
-        const scroller = scrollerRef.current;
-        if (scroller) {
-            scroller.scrollLeft = preservedScrollLeftRef.current;
+    const closeContextMenu = () => setContextMenu(undefined);
+
+    const onBlockContextMenu = (
+        event: ReactMouseEvent<SVGElement>,
+        activity: Activity | ExtendedBaseActivity,
+    ) => {
+        event.preventDefault();
+        if (!editable || !canManageRestDay(activity)) {
+            return;
         }
-    }, [contextMenu]);
 
-    const closeContextMenu = useCallback(() => setContextMenu(undefined), []);
+        setContextMenu({
+            activity,
+            position: {
+                top: event.clientY,
+                left: event.clientX,
+            },
+        });
+    };
 
-    const onBlockContextMenu = useCallback(
-        (event: ReactMouseEvent<SVGElement>, activity: Activity | ExtendedBaseActivity) => {
-            event.preventDefault();
-            if (!editable || !canManageRestDay(activity)) {
-                return;
-            }
+    const onBlockLongPress = (
+        event: LongPressReactEvents<SVGElement>,
+        activity: Activity | ExtendedBaseActivity,
+    ) => {
+        event.preventDefault();
+        if (!editable || !canManageRestDay(activity)) {
+            return;
+        }
 
-            preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
-            setContextMenu({
-                activity,
-                position: {
-                    top: event.clientY,
-                    left: event.clientX,
-                },
-            });
-        },
-        [editable],
-    );
+        const touch = 'touches' in event ? event.touches[0] : undefined;
+        if (!touch) {
+            return;
+        }
 
-    const onBlockLongPress = useCallback(
-        (event: LongPressReactEvents<SVGElement>, activity: Activity | ExtendedBaseActivity) => {
-            event.preventDefault();
-            if (!editable || !canManageRestDay(activity)) {
-                return;
-            }
-
-            const touch = 'touches' in event ? event.touches[0] : undefined;
-            if (!touch) {
-                return;
-            }
-
-            preservedScrollLeftRef.current = scrollerRef.current?.scrollLeft ?? 0;
-            setContextMenu({
-                activity,
-                position: {
-                    top: touch.clientY,
-                    left: touch.clientX,
-                },
-            });
-        },
-        [editable],
-    );
+        setContextMenu({
+            activity,
+            position: {
+                top: touch.clientY,
+                left: touch.clientX,
+            },
+        });
+    };
 
     const currentRestDayEntry =
         contextMenu && viewer
             ? findRestDayEntry(entries, contextMenu.activity.date, viewer)
             : undefined;
 
-    const saveRestDay = async (date: string) => {
-        if (!viewer || findRestDayEntry(entries, date, viewer)) {
+    const saveRestDay = async () => {
+        if (!viewer || !contextMenu || currentRestDayEntry) {
             return;
         }
 
-        request.onStart();
-        const entry = createRestDayEntry(viewer, date);
+        closeContextMenu();
+        const entry = createRestDayEntry(viewer, contextMenu.activity.date);
         timeline.onEditEntries([entry]);
 
         try {
+            request.onStart();
             await api.updateUserTimeline({
                 requirementId: TimelineSpecialRequirementId.RestDay,
                 progress: {
@@ -309,24 +292,15 @@ export function Heatmap({
         }
     };
 
-    const saveContextMenuRestDay = async () => {
-        if (!contextMenu || currentRestDayEntry) {
-            return;
-        }
-
-        closeContextMenu();
-        await saveRestDay(contextMenu.activity.date);
-    };
-
     const clearRestDay = async () => {
         if (!currentRestDayEntry) {
             return;
         }
 
-        request.onStart();
         closeContextMenu();
         timeline.onDeleteEntries([currentRestDayEntry]);
         try {
+            request.onStart();
             await api.updateUserTimeline({
                 requirementId: TimelineSpecialRequirementId.RestDay,
                 progress: {
@@ -345,8 +319,23 @@ export function Heatmap({
         }
     };
 
-    const calendar = useMemo(
-        () => (
+    return (
+        <Stack
+            maxWidth={1}
+            sx={{
+                '& .react-activity-calendar__scroll-container': {
+                    paddingTop: '1px',
+                    paddingBottom: '10px',
+                    overflow: 'visible !important',
+                },
+                '& .react-activity-calendar__footer': {
+                    marginLeft: '0 !important',
+                },
+            }}
+        >
+            <RequestSnackbar request={request} />
+            <HeatmapOptions onPopOut={onPopOut} />
+
             <Stack ref={scrollerRef} direction='row' sx={{ overflowX: 'auto' }}>
                 <Paper
                     elevation={1}
@@ -421,44 +410,7 @@ export function Heatmap({
                     <Divider sx={{ mt: '2px' }} />
                 </Stack>
             </Stack>
-        ),
-        [
-            activities,
-            blockSize,
-            clamp,
-            colorMode,
-            editable,
-            field,
-            isLight,
-            maxDate,
-            onBlockContextMenu,
-            onBlockLongPress,
-            slotProps?.weekdayLabelPaper,
-            theme,
-            weekEndOn,
-            weekStartOn,
-            weekSummaries,
-            workGoalHistory,
-        ],
-    );
 
-    return (
-        <Stack
-            maxWidth={1}
-            sx={{
-                '& .react-activity-calendar__scroll-container': {
-                    paddingTop: '1px',
-                    paddingBottom: '10px',
-                    overflow: 'visible !important',
-                },
-                '& .react-activity-calendar__footer': {
-                    marginLeft: '0 !important',
-                },
-            }}
-        >
-            <RequestSnackbar request={request} />
-            <HeatmapOptions onPopOut={onPopOut} />
-            {calendar}
             <Stack
                 direction='row'
                 justifyContent='space-between'
@@ -527,10 +479,7 @@ export function Heatmap({
                         </Stack>
                     </MenuItem>
                 ) : (
-                    <MenuItem
-                        onClick={() => void saveContextMenuRestDay()}
-                        disabled={request.isLoading()}
-                    >
+                    <MenuItem onClick={() => void saveRestDay()} disabled={request.isLoading()}>
                         <Stack direction='row' alignItems='center' gap={1}>
                             <RestDayIcon size={18} />
                             <Typography>Rest Day</Typography>


### PR DESCRIPTION
## Summary

Improve rest day interactions on the profile heatmap.

High-level changes:
- prevent the heatmap from jumping back to the current date when opening the rest day menu on older cells
- add mobile support for rest day actions via long press on heatmap cells in the activity tab
- make long press open the same action menu as desktop instead of adding a rest day immediately
- update the heatmap optimistically so add/clear rest day actions feel immediate and the menu closes right away

## Related Issues

Fixes # (issue number)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] New unit tests (vitest) were added
- [ ] New playwright tests were added
- [x] It was not necessary to add tests due to the change being a small UI interaction update that was verified manually on desktop and mobile emulation, and existing type/lint checks passed.

## Demo

Tested locally in the profile activity heatmap:
- desktop right-click on older cells no longer jumps back to the present
- mobile long press opens the same rest day menu
- add/clear rest day updates immediately and closes the menu right away
