### PR TITLE
feat(#2144): save square color drill session after each answer

### DIFF
--- a/backend/puzzleService/squareColor.ts
+++ b/backend/puzzleService/squareColor.ts
@@ -19,7 +19,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
         const result: SquareColorSessionResult = {
             ...request,
             username: userInfo.username,
-            createdAt: new Date().toISOString(),
+            createdAt: request.createdAt ?? new Date().toISOString(),
         };
 
         await dynamo.send(

--- a/common/src/squareColors/api.ts
+++ b/common/src/squareColors/api.ts
@@ -26,6 +26,8 @@ export const submitSquareColorSessionSchema = z.object({
     totalTimeSeconds: z.number(),
     /** The individual questions and answers. */
     questions: z.array(squareColorQuestionSchema),
+    /** Optional client-generated timestamp to allow updating the same session record. */
+    createdAt: z.string().datetime().optional(),
 });
 
 /** A request to submit a square color drill session. */

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -24,6 +24,43 @@ interface SessionSummary {
     questions: SquareColorQuestion[];
 }
 
+/**
+ * Computes aggregate stats for a square color drill session.
+ * @param allQuestions - The list of answered questions.
+ * @param sessionStartTime - The epoch timestamp (ms) when the session started.
+ * @returns The computed session summary stats.
+ */
+function computeSessionStats(
+    allQuestions: SquareColorQuestion[],
+    sessionStartTime: number,
+): SessionSummary {
+    const totalTimeSeconds = Math.round((Date.now() - sessionStartTime) / 1000);
+    const correctCount = allQuestions.filter((q) => q.userAnswer === q.correctAnswer).length;
+    const avgResponseTimeMs = Math.round(
+        allQuestions.reduce((sum, q) => sum + q.responseTimeMs, 0) / allQuestions.length,
+    );
+
+    let bestStreak = 0;
+    let currentStreak = 0;
+    for (const q of allQuestions) {
+        if (q.userAnswer === q.correctAnswer) {
+            currentStreak++;
+            bestStreak = Math.max(bestStreak, currentStreak);
+        } else {
+            currentStreak = 0;
+        }
+    }
+
+    return {
+        totalQuestions: allQuestions.length,
+        correctCount,
+        avgResponseTimeMs,
+        bestStreak,
+        totalTimeSeconds,
+        questions: allQuestions,
+    };
+}
+
 export function SquareColorDrillPage() {
     const { user, status } = useAuth();
 
@@ -46,6 +83,7 @@ function SquareColorDrill() {
     const questionStartRef = useRef<number>(0);
     const sessionStartRef = useRef<number>(0);
     const questionsRef = useRef<SquareColorQuestion[]>([]);
+    const sessionCreatedAtRef = useRef<string>('');
     const [summary, setSummary] = useState<SessionSummary | null>(null);
 
     const nextSquare = useCallback(() => {
@@ -63,6 +101,7 @@ function SquareColorDrill() {
         setSummary(null);
         setDrillState('in_progress');
         sessionStartRef.current = Date.now();
+        sessionCreatedAtRef.current = new Date().toISOString();
         nextSquare();
     }, [nextSquare]);
 
@@ -73,39 +112,16 @@ function SquareColorDrill() {
                 return;
             }
 
-            const totalTimeSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
-            const correctCount = allQuestions.filter(
-                (q) => q.userAnswer === q.correctAnswer,
-            ).length;
-            const avgResponseTimeMs = Math.round(
-                allQuestions.reduce((sum, q) => sum + q.responseTimeMs, 0) / allQuestions.length,
-            );
-
-            let bestStreak = 0;
-            let currentStreak = 0;
-            for (const q of allQuestions) {
-                if (q.userAnswer === q.correctAnswer) {
-                    currentStreak++;
-                    bestStreak = Math.max(bestStreak, currentStreak);
-                } else {
-                    currentStreak = 0;
-                }
-            }
-
-            const result: SessionSummary = {
-                totalQuestions: allQuestions.length,
-                correctCount,
-                avgResponseTimeMs,
-                bestStreak,
-                totalTimeSeconds,
-                questions: allQuestions,
-            };
+            const result = computeSessionStats(allQuestions, sessionStartRef.current);
 
             setSummary(result);
             setDrillState('complete');
 
             submitRequest.onStart();
-            submitSquareColorSession(result).then(
+            submitSquareColorSession({
+                ...result,
+                createdAt: sessionCreatedAtRef.current,
+            }).then(
                 () => submitRequest.onSuccess(),
                 (err: unknown) => submitRequest.onFailure(err),
             );
@@ -127,11 +143,16 @@ function SquareColorDrill() {
                 responseTimeMs,
             };
 
-            setQuestions((prev) => {
-                const updated = [...prev, question];
-                questionsRef.current = updated;
-                return updated;
-            });
+            const updatedQuestions = [...questionsRef.current, question];
+            questionsRef.current = updatedQuestions;
+            setQuestions(updatedQuestions);
+
+            const stats = computeSessionStats(updatedQuestions, sessionStartRef.current);
+            submitSquareColorSession({
+                ...stats,
+                createdAt: sessionCreatedAtRef.current,
+            }).catch((err: unknown) => console.warn('Intermediate save failed:', err));
+
             setFeedback(answer === correctAnswer ? 'correct' : 'incorrect');
 
             setTimeout(() => {

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -151,7 +151,7 @@ function SquareColorDrill() {
             submitSquareColorSession({
                 ...stats,
                 createdAt: sessionCreatedAtRef.current,
-            }).catch((err: unknown) => console.warn('Intermediate save failed:', err));
+            }).catch(() => {});
 
             setFeedback(answer === correctAnswer ? 'correct' : 'incorrect');
 

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -30,7 +30,7 @@ interface SessionSummary {
  * @param sessionStartTime - The epoch timestamp (ms) when the session started.
  * @returns The computed session summary stats.
  */
-function computeSessionStats(
+export function computeSessionStats(
     allQuestions: SquareColorQuestion[],
     sessionStartTime: number,
 ): SessionSummary {

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -151,7 +151,7 @@ function SquareColorDrill() {
             submitSquareColorSession({
                 ...stats,
                 createdAt: sessionCreatedAtRef.current,
-            }).catch(() => {});
+            }).catch(() => undefined);
 
             setFeedback(answer === correctAnswer ? 'correct' : 'incorrect');
 

--- a/frontend/src/components/puzzles/squareColors/computeSessionStats.test.ts
+++ b/frontend/src/components/puzzles/squareColors/computeSessionStats.test.ts
@@ -1,0 +1,107 @@
+import { SquareColorQuestion } from '@jackstenglein/chess-dojo-common/src/squareColors/api';
+import { describe, expect, it, vi } from 'vitest';
+import { computeSessionStats } from './SquareColorDrillPage';
+
+function makeQuestion(overrides: Partial<SquareColorQuestion> = {}): SquareColorQuestion {
+    return {
+        square: 'e4',
+        correctAnswer: 'white',
+        userAnswer: 'white',
+        responseTimeMs: 500,
+        ...overrides,
+    };
+}
+
+describe('computeSessionStats', () => {
+    it('computes correct count from all-correct answers', () => {
+        const questions = [makeQuestion(), makeQuestion(), makeQuestion()];
+        const result = computeSessionStats(questions, Date.now() - 10_000);
+
+        expect(result.totalQuestions).toBe(3);
+        expect(result.correctCount).toBe(3);
+    });
+
+    it('computes correct count with mixed answers', () => {
+        const questions = [
+            makeQuestion({ userAnswer: 'white', correctAnswer: 'white' }),
+            makeQuestion({ userAnswer: 'black', correctAnswer: 'white' }),
+            makeQuestion({ userAnswer: 'white', correctAnswer: 'white' }),
+        ];
+        const result = computeSessionStats(questions, Date.now());
+
+        expect(result.correctCount).toBe(2);
+    });
+
+    it('computes average response time', () => {
+        const questions = [
+            makeQuestion({ responseTimeMs: 200 }),
+            makeQuestion({ responseTimeMs: 400 }),
+            makeQuestion({ responseTimeMs: 600 }),
+        ];
+        const result = computeSessionStats(questions, Date.now());
+
+        expect(result.avgResponseTimeMs).toBe(400);
+    });
+
+    it('rounds average response time to nearest integer', () => {
+        const questions = [
+            makeQuestion({ responseTimeMs: 100 }),
+            makeQuestion({ responseTimeMs: 200 }),
+            makeQuestion({ responseTimeMs: 300 }),
+            makeQuestion({ responseTimeMs: 401 }),
+        ];
+        const result = computeSessionStats(questions, Date.now());
+
+        expect(result.avgResponseTimeMs).toBe(250);
+    });
+
+    it('computes best streak of consecutive correct answers', () => {
+        const questions = [
+            makeQuestion({ userAnswer: 'white', correctAnswer: 'white' }),
+            makeQuestion({ userAnswer: 'white', correctAnswer: 'white' }),
+            makeQuestion({ userAnswer: 'black', correctAnswer: 'white' }),
+            makeQuestion({ userAnswer: 'white', correctAnswer: 'white' }),
+        ];
+        const result = computeSessionStats(questions, Date.now());
+
+        expect(result.bestStreak).toBe(2);
+    });
+
+    it('returns zero best streak when all answers are wrong', () => {
+        const questions = [
+            makeQuestion({ userAnswer: 'black', correctAnswer: 'white' }),
+            makeQuestion({ userAnswer: 'black', correctAnswer: 'white' }),
+        ];
+        const result = computeSessionStats(questions, Date.now());
+
+        expect(result.bestStreak).toBe(0);
+    });
+
+    it('computes total time in seconds from session start', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-01-01T00:00:30Z'));
+
+        const sessionStart = new Date('2025-01-01T00:00:00Z').getTime();
+        const result = computeSessionStats([makeQuestion()], sessionStart);
+
+        expect(result.totalTimeSeconds).toBe(30);
+
+        vi.useRealTimers();
+    });
+
+    it('returns the original questions array in the result', () => {
+        const questions = [makeQuestion(), makeQuestion()];
+        const result = computeSessionStats(questions, Date.now());
+
+        expect(result.questions).toBe(questions);
+    });
+
+    it('handles a single question', () => {
+        const questions = [makeQuestion({ responseTimeMs: 750 })];
+        const result = computeSessionStats(questions, Date.now());
+
+        expect(result.totalQuestions).toBe(1);
+        expect(result.avgResponseTimeMs).toBe(750);
+        expect(result.bestStreak).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

Save the square color drill session after each answer so that navigating away mid-drill no longer loses progress. Previously, the session was only saved when the user clicked "Stop."

The frontend now generates a `createdAt` timestamp at session start and sends it with every save request. The backend uses this timestamp (falling back to server-generated if absent), so DynamoDB's `PutItem` overwrites the same record instead of creating duplicates. Intermediate saves are fire-and-forget; the final "Stop" save still shows the success/error snackbar.

Also extracted `computeSessionStats` as a shared helper used by both `handleAnswer` and `finishDrill`.

## Related Issues

Fixes #2144

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] New unit tests (vitest) were added
- [ ] New playwright tests were added
- [ ] It was not necessary to add tests due to {{reason}}
