### PR TITLE
feat(#1829) Add task expiration date

### DIFF
--- a/frontend/src/components/profile/trainingPlan/TaskDialog.tsx
+++ b/frontend/src/components/profile/trainingPlan/TaskDialog.tsx
@@ -299,8 +299,7 @@ function DetailsDialog({ task, onClose, cohort, setView }: DetailsDialogProps) {
                                     title={`${task.name} Video ${idx + 1}`}
                                     allow='accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share'
                                     allowFullScreen={true}
-                                    style={{ width: '100%', height: '100%' }}
-                                    frameBorder={0}
+                                    style={{ width: '100%', height: '100%', border: 0 }}
                                 />
                             </Box>
                         ))}
@@ -426,25 +425,18 @@ function ExpirationChip({
 
     const value = expirationYears >= 1 ? expirationYears : Math.round(expirationYears * 12);
 
+    let chipLabel = `${value} ${expirationYears >= 1 ? 'year' : 'month'}${value !== 1 ? 's' : ''}`;
     let title = `Progress on this task expires after ${value} ${
         expirationYears >= 1 ? 'year' : 'month'
-    }${value !== 1 ? 's' : ''}.`;
+    }${value !== 1 ? 's' : ''}`;
 
     // Add exact expiration date if progress exists
     if (progress?.updatedAt) {
         const expirationDate = new Date(progress.updatedAt);
         expirationDate.setDate(expirationDate.getDate() + requirement.expirationDays);
         const formattedDate = expirationDate.toLocaleDateString();
-        title = `Progress on this task expires after ${value} ${
-            expirationYears >= 1 ? 'year' : 'month'
-        }${value !== 1 ? 's' : ''} (on ${formattedDate}).`;
-    }
-
-    let chipLabel = `${value} ${expirationYears >= 1 ? 'year' : 'month'}${value !== 1 ? 's' : ''}`;
-    if (progress?.updatedAt) {
-        const expirationDate = new Date(progress.updatedAt);
-        expirationDate.setDate(expirationDate.getDate() + requirement.expirationDays);
-        chipLabel += ` (expires ${expirationDate.toLocaleDateString()})`;
+        chipLabel += ` (expires ${formattedDate})`;
+        title += ` (on ${formattedDate})`;
     }
 
     return (

--- a/frontend/src/components/profile/trainingPlan/TaskDialog.tsx
+++ b/frontend/src/components/profile/trainingPlan/TaskDialog.tsx
@@ -271,7 +271,7 @@ function DetailsDialog({ task, onClose, cohort, setView }: DetailsDialogProps) {
                     {isRequirement(task) && (
                         <Stack direction='row' spacing={2} flexWrap='wrap' rowGap={1}>
                             <DojoPointChip requirement={task} cohort={selectedCohort} />
-                            <ExpirationChip requirement={task} />
+                            <ExpirationChip requirement={task} progress={progress} />
                             <RepeatChip requirement={task} />
                             {task.blockers && <BlockerChips requirement={task} />}
                         </Stack>
@@ -396,7 +396,13 @@ function DojoPointChip({ requirement, cohort }: { requirement: Requirement; coho
     );
 }
 
-function ExpirationChip({ requirement }: { requirement: Requirement }) {
+function ExpirationChip({
+    requirement,
+    progress,
+}: {
+    requirement: Requirement;
+    progress?: RequirementProgress;
+}) {
     if (!isRequirement(requirement)) {
         return null;
     }
@@ -420,19 +426,30 @@ function ExpirationChip({ requirement }: { requirement: Requirement }) {
 
     const value = expirationYears >= 1 ? expirationYears : Math.round(expirationYears * 12);
 
-    const title = `Progress on this task expires after ${value} ${
+    let title = `Progress on this task expires after ${value} ${
         expirationYears >= 1 ? 'year' : 'month'
     }${value !== 1 ? 's' : ''}.`;
 
+    // Add exact expiration date if progress exists
+    if (progress?.updatedAt) {
+        const expirationDate = new Date(progress.updatedAt);
+        expirationDate.setDate(expirationDate.getDate() + requirement.expirationDays);
+        const formattedDate = expirationDate.toLocaleDateString();
+        title = `Progress on this task expires after ${value} ${
+            expirationYears >= 1 ? 'year' : 'month'
+        }${value !== 1 ? 's' : ''} (on ${formattedDate}).`;
+    }
+
+    let chipLabel = `${value} ${expirationYears >= 1 ? 'year' : 'month'}${value !== 1 ? 's' : ''}`;
+    if (progress?.updatedAt) {
+        const expirationDate = new Date(progress.updatedAt);
+        expirationDate.setDate(expirationDate.getDate() + requirement.expirationDays);
+        chipLabel += ` (expires ${expirationDate.toLocaleDateString()})`;
+    }
+
     return (
         <Tooltip title={title}>
-            <Chip
-                color='secondary'
-                icon={<AccessAlarm />}
-                label={`${value} ${expirationYears >= 1 ? 'year' : 'month'}${
-                    value !== 1 ? 's' : ''
-                }`}
-            />
+            <Chip color='secondary' icon={<AccessAlarm />} label={chipLabel} />
         </Tooltip>
     );
 }


### PR DESCRIPTION
## Summary

Adds the exact expiration date to the task expiration chip in the training plan task dialog. Previously, users only saw a relative duration like "5 years" with no way to know the exact expiration date. The chip now shows "5 years (expires 3/23/2031)" when the user has progress on the task, and the tooltip provides additional context.

The expiration date is calculated from the user's last progress update (`updatedAt`) plus the task's `expirationDays`, consistent with the existing `isExpired()` logic.

## Related Issues

Fixes #1829

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to the change being a minor UI enhancement with no logic changes to expiration behavior

### Manual testing steps

- [x] Navigate to the Training Plan page
- [x] Click on a task that has an expiration period (e.g., Polgar Mates in 3)
- [x] Verify the expiration chip shows the exact date when progress exists (e.g., "5 years (expires 3/23/2031)")
- [x] Verify the chip shows only the duration when no progress exists (e.g., "5 years")
- [x] Hover over the chip and verify the tooltip provides additional context

## Demo

<img width="516" height="195" alt="image" src="https://github.com/user-attachments/assets/0ab3c5a7-a324-401b-ac59-a4f3ff23399d" />
