### PR TITLE
fix(#2119): filter lapsed memberships from admin game review view

### DIFF
--- a/backend/liveClassService/admin/listGameReviewCohorts.ts
+++ b/backend/liveClassService/admin/listGameReviewCohorts.ts
@@ -48,12 +48,14 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
             userCohortMap.set(u.username, u.dojoCohort);
         }
 
-        // Enrich each cohort member with their dojoCohort
+        // Enrich each cohort member with their dojoCohort and remove lapsed members
         for (const cohort of gameReviewCohorts) {
-            for (const [username, member] of Object.entries(cohort.members)) {
+            for (const username of Object.keys(cohort.members)) {
                 const dojoCohort = userCohortMap.get(username);
                 if (dojoCohort) {
-                    cohort.members[username] = { ...member, dojoCohort };
+                    cohort.members[username] = { ...cohort.members[username], dojoCohort };
+                } else {
+                    delete cohort.members[username];
                 }
             }
         }


### PR DESCRIPTION
## Summary

Filter out lapsed memberships from the admin game review page (`/admin/game-review`). When a user cancels their subscription, their `subscriptionTier` is set to `FREE`, but their entry persists in the live classes cohort records. This change removes cohort members who are no longer on the GameReview tier from the API response, so admins only see active subscribers.

## Related Issues

Fixes #2119

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to this being a small backend-only filtering change in a function with no existing test file.
