### PR TITLE
feat: add currently acitve filter to this week panel

### DIFF
--- a/frontend/src/components/profile/trainingPlan/useTrainingPlan.ts
+++ b/frontend/src/components/profile/trainingPlan/useTrainingPlan.ts
@@ -263,7 +263,7 @@ function isEmpty(suggestionsByDay: SuggestedTask[][]) {
  * @param tasks The suggested tasks for the given timeframe.
  * @param timeline The user's timeline to use when calculating progress.
  * @returns The goal, the time worked on the suggested tasks, the total time worked
- * including extra tasks, and the ids of any extra tasks worked on.
+ * including extra tasks, the ids of any extra tasks worked on, and whether the suggested tasks have been worked on.
  */
 export function useTrainingPlanProgress({
     startDate,
@@ -275,13 +275,14 @@ export function useTrainingPlanProgress({
     endDate: string;
     tasks?: SuggestedTask[];
     timeline: TimelineEntry[];
-}): [number, number, number, Set<string>] {
+}): [number, number, number, Set<string>, boolean] {
     return useMemo(() => {
         const goalMinutes = tasks?.reduce((sum, { goalMinutes }) => sum + goalMinutes, 0) ?? 0;
         const extraTaskIds = new Set<string>();
 
         let suggestedTimeWorked = 0;
         let totalTimeWorked = 0;
+        let hasWorked = false;
         for (const entry of timeline) {
             const date = entry.date || entry.createdAt;
             const isSuggestedTask = tasks?.some(({ task }) => task.id === entry.requirementId);
@@ -291,10 +292,11 @@ export function useTrainingPlanProgress({
                     extraTaskIds.add(entry.requirementId);
                 } else {
                     suggestedTimeWorked += entry.minutesSpent;
+                    hasWorked = true;
                 }
             }
         }
 
-        return [goalMinutes, suggestedTimeWorked, totalTimeWorked, extraTaskIds];
+        return [goalMinutes, suggestedTimeWorked, totalTimeWorked, extraTaskIds, hasWorked];
     }, [tasks, startDate, endDate, timeline]);
 }

--- a/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
@@ -78,7 +78,7 @@ export function WeeklyTrainingPlan() {
                     </IconButton>
                 </Tooltip>
 
-                <Typography variant='h5' fontWeight='bold' ml={0.5} sx={{ mr: 'auto' }}>
+                <Typography variant='h5' fontWeight='bold' ml={0.5} mr={2}>
                     This Week
                 </Typography>
 
@@ -94,33 +94,28 @@ export function WeeklyTrainingPlan() {
 
             <Collapse in={expanded}>
                 <Stack spacing={2} mb={1}>
-                    <Box sx={{ ml: 5 }}>
-                        <Tooltip
-                            title="Hide tasks you haven't logged time for this week"
-                            placement='right'
-                        >
-                            <FormControlLabel
-                                control={
-                                    <Switch
-                                        checked={activeOnly}
-                                        onChange={(e) => setActiveOnly(e.target.checked)}
-                                        size='small'
-                                    />
-                                }
-                                label={
-                                    <Typography variant='body2' color='text.secondary'>
-                                        Active Only
-                                    </Typography>
-                                }
-                                sx={{ ml: 1, width: 'fit-content' }}
-                            />
-                        </Tooltip>
-                    </Box>
+                    <Tooltip title='Only show tasks you have updated this week' placement='right'>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={activeOnly}
+                                    onChange={(e) => setActiveOnly(e.target.checked)}
+                                    size='small'
+                                />
+                            }
+                            label={
+                                <Typography variant='body2' color='text.secondary'>
+                                    Active Only
+                                </Typography>
+                            }
+                            sx={{ ml: 1, width: 'fit-content' }}
+                        />
+                    </Tooltip>
 
                     {isLoading ? (
                         <LoadingPage />
                     ) : (
-                        <Grid container columns={7}>
+                        <Grid container columns={7} sx={{ minHeight: '158px' }}>
                             {days.map((_, i) => (
                                 <Grid key={i} size={1}>
                                     <WeeklyTrainingPlanDay
@@ -230,7 +225,7 @@ function WeeklyTrainingPlanDay({
                             onOpenTask={onOpenTask}
                             startDate={dayStart}
                             endDate={dayEnd}
-                            activeOnly={activeOnly}
+                            activeOnly={false} // Extra tasks are always active
                         />
                     ))}
                 </Stack>
@@ -255,7 +250,7 @@ function WeeklyTrainingPlanItem({
     const { task } = suggestion;
     const { isCurrentUser, user, timeline } = use(TrainingPlanContext);
     const tasks = useMemo(() => [suggestion], [suggestion]);
-    const [goalMinutes, timeWorked] = useTrainingPlanProgress({
+    const [goalMinutes, timeWorked, _, __, active] = useTrainingPlanProgress({
         startDate,
         endDate,
         tasks,
@@ -264,7 +259,7 @@ function WeeklyTrainingPlanItem({
 
     const isComplete = timeWorked >= goalMinutes;
 
-    if (activeOnly && timeWorked <= 0) {
+    if (activeOnly && !active) {
         return null;
     }
 

--- a/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
@@ -10,9 +10,11 @@ import {
     Card,
     Chip,
     Collapse,
+    FormControlLabel,
     Grid,
     IconButton,
     Stack,
+    Switch,
     Tooltip,
     Typography,
 } from '@mui/material';
@@ -40,6 +42,10 @@ export function WeeklyTrainingPlan() {
     });
 
     const [expanded, setExpanded] = useLocalStorage<boolean>('training-plan-weekly-expanded', true);
+    const [activeOnly, setActiveOnly] = useLocalStorage<boolean>(
+        'training-plan-weekly-active-only',
+        false,
+    );
 
     const [selectedTask, setSelectedTask] = useState<Requirement | CustomTask>();
     const [taskDialogView, setTaskDialogView] = useState<TaskDialogView>();
@@ -72,7 +78,7 @@ export function WeeklyTrainingPlan() {
                     </IconButton>
                 </Tooltip>
 
-                <Typography variant='h5' fontWeight='bold' ml={0.5} mr={2}>
+                <Typography variant='h5' fontWeight='bold' ml={0.5} sx={{ mr: 'auto' }}>
                     This Week
                 </Typography>
 
@@ -87,20 +93,46 @@ export function WeeklyTrainingPlan() {
             </Stack>
 
             <Collapse in={expanded}>
-                {isLoading ? (
-                    <LoadingPage />
-                ) : (
-                    <Grid container columns={7}>
-                        {days.map((_, i) => (
-                            <Grid key={i} size={1}>
-                                <WeeklyTrainingPlanDay
-                                    dayIndex={(i + user.weekStart) % 7}
-                                    onOpenTask={onOpenTask}
-                                />
-                            </Grid>
-                        ))}
-                    </Grid>
-                )}
+                <Stack spacing={2} mb={1}>
+                    <Box sx={{ ml: 5 }}>
+                        <Tooltip
+                            title="Hide tasks you haven't logged time for this week"
+                            placement='right'
+                        >
+                            <FormControlLabel
+                                control={
+                                    <Switch
+                                        checked={activeOnly}
+                                        onChange={(e) => setActiveOnly(e.target.checked)}
+                                        size='small'
+                                    />
+                                }
+                                label={
+                                    <Typography variant='body2' color='text.secondary'>
+                                        Active Only
+                                    </Typography>
+                                }
+                                sx={{ ml: 1, width: 'fit-content' }}
+                            />
+                        </Tooltip>
+                    </Box>
+
+                    {isLoading ? (
+                        <LoadingPage />
+                    ) : (
+                        <Grid container columns={7}>
+                            {days.map((_, i) => (
+                                <Grid key={i} size={1}>
+                                    <WeeklyTrainingPlanDay
+                                        dayIndex={(i + user.weekStart) % 7}
+                                        onOpenTask={onOpenTask}
+                                        activeOnly={activeOnly}
+                                    />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    )}
+                </Stack>
             </Collapse>
 
             {taskDialogView && selectedTask && (
@@ -120,9 +152,11 @@ export function WeeklyTrainingPlan() {
 function WeeklyTrainingPlanDay({
     dayIndex,
     onOpenTask,
+    activeOnly,
 }: {
     dayIndex: number;
     onOpenTask: (task: Requirement | CustomTask, view: TaskDialogView) => void;
+    activeOnly: boolean;
 }) {
     const { suggestionsByDay, startDate, timeline, user, allRequirements, pinnedTasks } =
         use(TrainingPlanContext);
@@ -184,6 +218,7 @@ function WeeklyTrainingPlanDay({
                                     onOpenTask={onOpenTask}
                                     startDate={dayStart}
                                     endDate={dayEnd}
+                                    activeOnly={activeOnly}
                                 />
                             ),
                     )}
@@ -195,6 +230,7 @@ function WeeklyTrainingPlanDay({
                             onOpenTask={onOpenTask}
                             startDate={dayStart}
                             endDate={dayEnd}
+                            activeOnly={activeOnly}
                         />
                     ))}
                 </Stack>
@@ -208,11 +244,13 @@ function WeeklyTrainingPlanItem({
     onOpenTask,
     startDate,
     endDate,
+    activeOnly,
 }: {
     suggestion: SuggestedTask;
     onOpenTask: (task: Requirement | CustomTask, view: TaskDialogView) => void;
     startDate: string;
     endDate: string;
+    activeOnly: boolean;
 }) {
     const { task } = suggestion;
     const { isCurrentUser, user, timeline } = use(TrainingPlanContext);
@@ -225,6 +263,10 @@ function WeeklyTrainingPlanItem({
     });
 
     const isComplete = timeWorked >= goalMinutes;
+
+    if (activeOnly && timeWorked <= 0) {
+        return null;
+    }
 
     const onOpenProgress = (e: React.MouseEvent<HTMLDivElement>) => {
         e.preventDefault();


### PR DESCRIPTION
## Summary

adds a toggle to the WeeklyTrainingPlan component that allows users
to hide tasks they haven't logged any time for yet. 
uses local storage to persist the user's toggle preference.
preserves empty day columns to maintain grid layout stability.



## Demo
<img width="1341" height="692" alt="image" src="https://github.com/user-attachments/assets/da22807c-21c0-492b-9428-abd966216502" />


closes #2163
