### PR TITLE
fix(#2165): improvements to game annotation clock editor

### DIFF
--- a/common/src/pgn/clock.test.ts
+++ b/common/src/pgn/clock.test.ts
@@ -1,0 +1,65 @@
+import { Chess, Move } from '@jackstenglein/chess';
+import { describe, expect, it } from 'vitest';
+import { timeControlForMove } from './clock';
+
+function loadChess(timeControl: string | undefined, body: string): Chess {
+    const header = timeControl === undefined ? '' : `[TimeControl "${timeControl}"]\n`;
+    return new Chess({ pgn: `${header}\n${body}` });
+}
+
+function moveAtPly(chess: Chess, ply: number): Move {
+    const move = chess.history().find((m) => m.ply === ply);
+    if (!move) {
+        throw new Error(`No move at ply ${ply}`);
+    }
+    return move;
+}
+
+describe('timeControlForMove', () => {
+    it('returns undefined when the TimeControl tag is absent', () => {
+        const chess = loadChess(undefined, '1. e4 e5 *');
+        expect(timeControlForMove(chess, moveAtPly(chess, 1))).toBeUndefined();
+    });
+
+    it('returns the only segment for a single-period control', () => {
+        const chess = loadChess('600+0', '1. e4 e5 2. Nf3 *');
+        const tc = timeControlForMove(chess, moveAtPly(chess, 3));
+        expect(tc?.value).toBe('600+0');
+        expect(tc?.seconds).toBe(600);
+    });
+
+    it('returns the first segment immediately when it has no move limit', () => {
+        const chess = loadChess('600+0', '1. e4 *');
+        const tc = timeControlForMove(chess, moveAtPly(chess, 1));
+        expect(tc?.value).toBe('600+0');
+    });
+
+    it('uses the first phase while the full-move number is within that phase', () => {
+        const chess = loadChess('2/7200:3600', '1. e4 e5 2. Nf3 Nc6 3. Bb5 *');
+        expect(timeControlForMove(chess, moveAtPly(chess, 1))?.value).toBe('2/7200');
+        expect(timeControlForMove(chess, moveAtPly(chess, 4))?.value).toBe('2/7200');
+    });
+
+    it('switches to the next phase after the allotted full moves', () => {
+        const chess = loadChess('2/7200:3600', '1. e4 e5 2. Nf3 Nc6 3. Bb5 *');
+        expect(timeControlForMove(chess, moveAtPly(chess, 5))?.value).toBe('3600');
+    });
+
+    it('selects the correct segment across three phased controls', () => {
+        const chess = loadChess(
+            '2/7200:2/3600:1800',
+            '1. e4 e5 2. Nf3 Nc6 3. Bb5 Bc5 4. c3 Nf6 5. d4 *',
+        );
+        expect(timeControlForMove(chess, moveAtPly(chess, 1))?.value).toBe('2/7200');
+        expect(timeControlForMove(chess, moveAtPly(chess, 5))?.value).toBe('2/3600');
+        expect(timeControlForMove(chess, moveAtPly(chess, 9))?.value).toBe('1800');
+    });
+
+    it('returns the last segment when the move count exceeds all limited phases', () => {
+        const chess = loadChess('1/60:2/120', '1. e4 e5 2. Nf3 Nc6 3. Bb5 Bc5 4. c3 *');
+        expect(timeControlForMove(chess, moveAtPly(chess, 1))?.value).toBe('1/60');
+        expect(timeControlForMove(chess, moveAtPly(chess, 2))?.value).toBe('1/60');
+        expect(timeControlForMove(chess, moveAtPly(chess, 3))?.value).toBe('2/120');
+        expect(timeControlForMove(chess, moveAtPly(chess, 7))?.value).toBe('2/120');
+    });
+});

--- a/common/src/pgn/clock.ts
+++ b/common/src/pgn/clock.ts
@@ -1,3 +1,5 @@
+import { Chess, Move, TimeControl } from '@jackstenglein/chess';
+
 /**
  * Converts the given clock string in the format hh:mm:ss to an
  * equivalent number of seconds. Returns undefined if clk is undefined
@@ -57,4 +59,32 @@ export function secondsToClock(value: number): string {
     const seconds = (value % 3600) % 60;
     result += seconds.toLocaleString(undefined, { minimumIntegerDigits: 2 });
     return result;
+}
+
+/**
+ * Returns the time control for the given move in the given chess instance.
+ * @param chess The chess instance to get the time control for.
+ * @param move The move to get the time control for.
+ */
+export function timeControlForMove(chess: Chess, move: Move | undefined): TimeControl | undefined {
+    const timeControls = chess.header().tags.TimeControl?.items;
+    if (!timeControls) return undefined;
+    if (!move) return timeControls[0];
+
+    let moveNumber = Math.floor(move.ply / 2);
+    if (move.ply % 2) {
+        moveNumber += 1;
+    }
+
+    let moveCount = 0;
+    for (const timeControl of timeControls) {
+        if (!timeControl.moves) {
+            return timeControl;
+        }
+        if (timeControl.moves + moveCount >= moveNumber) {
+            return timeControl;
+        }
+        moveCount += timeControl.moves;
+    }
+    return timeControls[timeControls.length - 1];
 }

--- a/frontend/src/app/(scoreboard)/games/analysis/AnalysisBoard.tsx
+++ b/frontend/src/app/(scoreboard)/games/analysis/AnalysisBoard.tsx
@@ -20,7 +20,7 @@ import {
 } from '@jackstenglein/chess-dojo-common/src/database/game';
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 import { useNavigationGuard } from 'next-navigation-guard';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const gameUrlRegex = /^\/games\/.*\/.*/;
 
@@ -48,6 +48,17 @@ export default function AnalysisBoard() {
         onSubmit,
         request,
     } = useUnsavedGame(chess);
+
+    useEffect(() => {
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            // Modern browsers ignore custom messages, but returnValue must be set
+            event.returnValue = '';
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, []);
 
     if (status === AuthStatus.Loading) {
         return <LoadingPage />;

--- a/frontend/src/app/(scoreboard)/games/analysis/AnalysisBoard.tsx
+++ b/frontend/src/app/(scoreboard)/games/analysis/AnalysisBoard.tsx
@@ -20,7 +20,7 @@ import {
 } from '@jackstenglein/chess-dojo-common/src/database/game';
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 import { useNavigationGuard } from 'next-navigation-guard';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const gameUrlRegex = /^\/games\/.*\/.*/;
 
@@ -48,17 +48,6 @@ export default function AnalysisBoard() {
         onSubmit,
         request,
     } = useUnsavedGame(chess);
-
-    useEffect(() => {
-        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-            event.preventDefault();
-            // Modern browsers ignore custom messages, but returnValue must be set
-            event.returnValue = '';
-        };
-
-        window.addEventListener('beforeunload', handleBeforeUnload);
-        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-    }, []);
 
     if (status === AuthStatus.Loading) {
         return <LoadingPage />;

--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockEditor.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockEditor.tsx
@@ -1,6 +1,6 @@
 import { useChess } from '@/board/pgn/PgnBoard';
 import { Chess, Move } from '@jackstenglein/chess';
-import { clockToSeconds } from '@jackstenglein/chess-dojo-common/src/pgn/clock';
+import { clockToSeconds, timeControlForMove } from '@jackstenglein/chess-dojo-common/src/pgn/clock';
 import { Edit } from '@mui/icons-material';
 import { Grid, IconButton, MenuItem, Stack, TextField, Tooltip, Typography } from '@mui/material';
 import { DateTime } from 'luxon';
@@ -54,11 +54,17 @@ const ClockEditor = ({
     const grid = [];
     const isThreeField = clockFieldFormat === ClockFieldFormat.ThreeField;
 
+    let whitePrevMoveSeconds = timeControlForMove(chess, moves[0])?.seconds;
+    let blackPrevMoveSeconds = whitePrevMoveSeconds;
+
     for (let i = 0; i < moves.length; i += 2) {
-        // Get previous move's clock for validation (previous black move for white, previous white move for black)
-        const whitePrevMoveSeconds =
-            i >= 2 ? clockToSeconds(moves[i - 1]?.commentDiag?.clk) : undefined;
-        const blackPrevMoveSeconds = clockToSeconds(moves[i]?.commentDiag?.clk);
+        // Get previous move's clock for validation
+        whitePrevMoveSeconds =
+            clockToSeconds(moves[i - 2]?.commentDiag?.clk) ?? whitePrevMoveSeconds;
+        blackPrevMoveSeconds =
+            clockToSeconds(moves[i - 1]?.commentDiag?.clk) ?? blackPrevMoveSeconds;
+        const timeControl = timeControlForMove(chess, moves[i - 2]);
+        const increment = timeControl?.increment ?? 0;
 
         if (isThreeField) {
             grid.push(
@@ -75,7 +81,7 @@ const ClockEditor = ({
                 <ClockTextField
                     label={`${i / 2 + 1}. ${moves[i].san}`}
                     move={moves[i]}
-                    previousMoveSeconds={whitePrevMoveSeconds}
+                    maxSeconds={whitePrevMoveSeconds ? whitePrevMoveSeconds + increment : undefined}
                 />
             </Grid>,
         );
@@ -96,7 +102,9 @@ const ClockEditor = ({
                     <ClockTextField
                         label={`${i / 2 + 1}... ${moves[i + 1].san}`}
                         move={moves[i + 1]}
-                        previousMoveSeconds={blackPrevMoveSeconds}
+                        maxSeconds={
+                            blackPrevMoveSeconds ? blackPrevMoveSeconds + increment : undefined
+                        }
                     />
                 </Grid>,
             );
@@ -104,7 +112,7 @@ const ClockEditor = ({
     }
 
     return (
-        <Grid container columnSpacing={1} rowGap={3} alignItems='center' pb={2}>
+        <Grid container columnSpacing={1} rowGap={3} alignItems='baseline' pb={2}>
             <Grid size={12}>
                 <Stack direction='row' alignItems='center' spacing={0.5}>
                     <Typography variant='subtitle1'>Time Control</Typography>

--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockEditor.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockEditor.tsx
@@ -1,5 +1,6 @@
 import { useChess } from '@/board/pgn/PgnBoard';
 import { Chess, Move } from '@jackstenglein/chess';
+import { clockToSeconds } from '@jackstenglein/chess-dojo-common/src/pgn/clock';
 import { Edit } from '@mui/icons-material';
 import { Grid, IconButton, MenuItem, Stack, TextField, Tooltip, Typography } from '@mui/material';
 import { DateTime } from 'luxon';
@@ -54,6 +55,11 @@ const ClockEditor = ({
     const isThreeField = clockFieldFormat === ClockFieldFormat.ThreeField;
 
     for (let i = 0; i < moves.length; i += 2) {
+        // Get previous move's clock for validation (previous black move for white, previous white move for black)
+        const whitePrevMoveSeconds =
+            i >= 2 ? clockToSeconds(moves[i - 1]?.commentDiag?.clk) : undefined;
+        const blackPrevMoveSeconds = clockToSeconds(moves[i]?.commentDiag?.clk);
+
         if (isThreeField) {
             grid.push(
                 <Grid key={`${i}-white-label`} size={3}>
@@ -66,7 +72,11 @@ const ClockEditor = ({
 
         grid.push(
             <Grid key={`${i}-white`} size={isThreeField ? 9 : 6}>
-                <ClockTextField label={`${i / 2 + 1}. ${moves[i].san}`} move={moves[i]} />
+                <ClockTextField
+                    label={`${i / 2 + 1}. ${moves[i].san}`}
+                    move={moves[i]}
+                    previousMoveSeconds={whitePrevMoveSeconds}
+                />
             </Grid>,
         );
 
@@ -86,6 +96,7 @@ const ClockEditor = ({
                     <ClockTextField
                         label={`${i / 2 + 1}... ${moves[i + 1].san}`}
                         move={moves[i + 1]}
+                        previousMoveSeconds={blackPrevMoveSeconds}
                     />
                 </Grid>,
             );

--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.test.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.test.tsx
@@ -1,0 +1,262 @@
+import { ChessContext } from '@/board/pgn/PgnBoard';
+import { Chess, Move } from '@jackstenglein/chess';
+import { secondsToClock } from '@jackstenglein/chess-dojo-common/src/pgn/clock';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterLuxon } from '@mui/x-date-pickers-pro/AdapterLuxon';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClockFieldFormat, ClockFieldFormatKey } from '../settings/EditorSettings';
+import ClockTextField from './ClockTextField';
+
+vi.mock('@/board/pgn/PgnBoard', async () => {
+    const React = await import('react');
+    const ChessContext = React.createContext({});
+    return {
+        ChessContext,
+        BlockBoardKeyboardShortcuts: 'blockBoardKeyboardShortcuts',
+        useChess: () => React.useContext(ChessContext),
+    };
+});
+
+vi.mock('../settings/EditorSettings', () => ({
+    ClockFieldFormatKey: 'clockFieldFormat',
+    ClockFieldFormat: {
+        SingleField: 'SINGLE_FIELD',
+        ThreeField: 'THREE_FIELD',
+        SingleFieldInTotalMinutes: 'SINGLE_FIELD_IN_TOTAL_MINUTES',
+    },
+}));
+
+vi.mock('./ClockUsage', async () => {
+    const { secondsToClock: toClock } =
+        await import('@jackstenglein/chess-dojo-common/src/pgn/clock');
+    return { formatTime: toClock };
+});
+
+const mockUseLocalStorage = vi.fn();
+
+vi.mock('usehooks-ts', () => ({
+    useLocalStorage: (key: string, initialValue: unknown) =>
+        mockUseLocalStorage(key, initialValue) as [string, (value: string) => void],
+}));
+
+const theme = createTheme();
+
+function TestProviders({ children }: { children: React.ReactNode }) {
+    return (
+        <ThemeProvider theme={theme}>
+            <LocalizationProvider dateAdapter={AdapterLuxon}>{children}</LocalizationProvider>
+        </ThemeProvider>
+    );
+}
+
+function makeMove(overrides: Partial<Move> = {}): Move {
+    return {
+        san: 'e4',
+        ply: 1,
+        commentDiag: {},
+        ...overrides,
+    } as Move;
+}
+
+function renderWithChess(ui: React.ReactElement, chess: Chess | undefined) {
+    return render(
+        <ChessContext.Provider value={{ chess }}>
+            <TestProviders>{ui}</TestProviders>
+        </ChessContext.Provider>,
+    );
+}
+
+describe('ClockTextField', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('renders nothing when chess is undefined', () => {
+        mockUseLocalStorage.mockImplementation((key) => {
+            if (key === ClockFieldFormatKey) {
+                return [ClockFieldFormat.ThreeField, vi.fn()];
+            }
+            return ['', vi.fn()];
+        });
+        const { container } = renderWithChess(<ClockTextField move={makeMove()} />, undefined);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('three-field: shows hours, minutes, and seconds from the move clock', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.ThreeField, vi.fn()]);
+        const chess = { setCommand: vi.fn() } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '1:05:07' } });
+
+        renderWithChess(<ClockTextField move={move} />, chess);
+
+        expect(screen.getByTestId('clock-hours-field')).toHaveValue('1');
+        expect(screen.getByTestId('clock-minutes-field')).toHaveValue('5');
+        expect(screen.getByTestId('clock-seconds-field')).toHaveValue('7');
+    });
+
+    it('three-field: parses mm:ss clocks with zero hours', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.ThreeField, vi.fn()]);
+        const chess = { setCommand: vi.fn() } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '03:45' } });
+
+        renderWithChess(<ClockTextField move={move} />, chess);
+
+        expect(screen.getByTestId('clock-hours-field')).toHaveValue('0');
+        expect(screen.getByTestId('clock-minutes-field')).toHaveValue('3');
+        expect(screen.getByTestId('clock-seconds-field')).toHaveValue('45');
+    });
+
+    it('three-field: updates clock via setCommand when minutes change', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.ThreeField, vi.fn()]);
+        const setCommand = vi.fn();
+        const chess = { setCommand } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:01:00' } });
+
+        renderWithChess(<ClockTextField move={move} />, chess);
+
+        fireEvent.change(screen.getByTestId('clock-minutes-field'), { target: { value: '90' } });
+
+        expect(setCommand).toHaveBeenCalledWith('clk', secondsToClock(90 * 60), move);
+    });
+
+    it('three-field: shows error helper when seconds exceed maxSeconds', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.ThreeField, vi.fn()]);
+        const chess = { setCommand: vi.fn() } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:10:00' } });
+
+        renderWithChess(<ClockTextField move={move} maxSeconds={300} />, chess);
+
+        expect(
+            screen.getByText('Gained more time than possible according to time control'),
+        ).toBeInTheDocument();
+    });
+
+    it('three-field: ArrowRight moves focus from hours to minutes', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.ThreeField, vi.fn()]);
+        const chess = { setCommand: vi.fn() } as unknown as Chess;
+        renderWithChess(<ClockTextField move={makeMove()} />, chess);
+
+        const hours = screen.getByTestId('clock-hours-field');
+        const minutes = screen.getByTestId('clock-minutes-field');
+
+        hours.focus();
+        fireEvent.keyDown(hours, { key: 'ArrowRight' });
+
+        expect(minutes).toHaveFocus();
+    });
+
+    it('three-field: focusing hours redirects to minutes when maxSeconds < 3600', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.ThreeField, vi.fn()]);
+        const chess = { setCommand: vi.fn() } as unknown as Chess;
+        renderWithChess(<ClockTextField move={makeMove()} maxSeconds={120} />, chess);
+
+        const hours = screen.getByTestId('clock-hours-field');
+        const minutes = screen.getByTestId('clock-minutes-field');
+
+        fireEvent.focus(hours);
+
+        expect(minutes).toHaveFocus();
+    });
+
+    it('total minutes: displays floored minutes and writes clock on change', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.SingleFieldInTotalMinutes, vi.fn()]);
+        const setCommand = vi.fn();
+        const chess = { setCommand } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:05:30' } });
+
+        renderWithChess(<ClockTextField move={move} />, chess);
+
+        expect(screen.getByPlaceholderText('Total minutes')).toHaveValue('5');
+
+        fireEvent.change(screen.getByPlaceholderText('Total minutes'), { target: { value: '12' } });
+
+        expect(setCommand).toHaveBeenCalledWith('clk', secondsToClock(12 * 60), move);
+    });
+
+    it('total minutes: empty input resets clock to zero', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.SingleFieldInTotalMinutes, vi.fn()]);
+        const setCommand = vi.fn();
+        const chess = { setCommand } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:01:00' } });
+
+        renderWithChess(<ClockTextField move={move} />, chess);
+
+        fireEvent.change(screen.getByPlaceholderText('Total minutes'), { target: { value: '' } });
+
+        expect(setCommand).toHaveBeenCalledWith('clk', secondsToClock(0), move);
+    });
+
+    it('total minutes: ignores non-numeric input', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.SingleFieldInTotalMinutes, vi.fn()]);
+        const setCommand = vi.fn();
+        const chess = { setCommand } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:01:00' } });
+
+        renderWithChess(<ClockTextField move={move} />, chess);
+        setCommand.mockClear();
+
+        fireEvent.change(screen.getByPlaceholderText('Total minutes'), {
+            target: { value: 'abc' },
+        });
+
+        expect(setCommand).not.toHaveBeenCalled();
+    });
+
+    it('total minutes: clamps minutes above 999', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.SingleFieldInTotalMinutes, vi.fn()]);
+        const setCommand = vi.fn();
+        const chess = { setCommand } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:00:00' } });
+
+        renderWithChess(<ClockTextField move={move} />, chess);
+
+        fireEvent.change(screen.getByPlaceholderText('Total minutes'), {
+            target: { value: '2000' },
+        });
+
+        expect(setCommand).toHaveBeenCalledWith('clk', secondsToClock(999 * 60), move);
+    });
+
+    it('total minutes: shows error when clock exceeds maxSeconds', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.SingleFieldInTotalMinutes, vi.fn()]);
+        const chess = { setCommand: vi.fn() } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:10:00' } });
+
+        renderWithChess(<ClockTextField move={move} maxSeconds={300} />, chess);
+
+        expect(
+            screen.getByText('Gained more time than possible according to time control'),
+        ).toBeInTheDocument();
+    });
+
+    it('single time field: renders and updates clock on change', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.SingleField, vi.fn()]);
+        const setCommand = vi.fn();
+        const chess = { setCommand } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:00:45' } });
+
+        renderWithChess(<ClockTextField move={move} label='Clock' />, chess);
+
+        const input = screen.getByDisplayValue('00:00:45');
+        expect(input).toHaveAttribute('id', 'blockBoardKeyboardShortcuts');
+
+        fireEvent.change(input, { target: { value: '00:01:30' } });
+
+        expect(setCommand).toHaveBeenCalledWith('clk', secondsToClock(90), move);
+    });
+
+    it('single time field: shows error when clock exceeds maxSeconds', () => {
+        mockUseLocalStorage.mockReturnValue([ClockFieldFormat.SingleField, vi.fn()]);
+        const chess = { setCommand: vi.fn() } as unknown as Chess;
+        const move = makeMove({ commentDiag: { clk: '0:10:00' } });
+
+        renderWithChess(<ClockTextField move={move} maxSeconds={300} />, chess);
+
+        expect(
+            screen.getByText('Gained more time than possible according to time control'),
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.test.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.test.tsx
@@ -4,7 +4,7 @@ import { secondsToClock } from '@jackstenglein/chess-dojo-common/src/pgn/clock';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { LocalizationProvider } from '@mui/x-date-pickers-pro';
 import { AdapterLuxon } from '@mui/x-date-pickers-pro/AdapterLuxon';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ClockFieldFormat, ClockFieldFormatKey } from '../settings/EditorSettings';
 import ClockTextField from './ClockTextField';
@@ -148,7 +148,7 @@ describe('ClockTextField', () => {
         expect(minutes).toHaveFocus();
     });
 
-    it('three-field: focusing hours redirects to minutes when maxSeconds < 3600', () => {
+    it('three-field: focusing hours redirects to minutes when maxSeconds < 3600', async () => {
         mockUseLocalStorage.mockReturnValue([ClockFieldFormat.ThreeField, vi.fn()]);
         const chess = { setCommand: vi.fn() } as unknown as Chess;
         renderWithChess(<ClockTextField move={makeMove()} maxSeconds={120} />, chess);
@@ -158,7 +158,9 @@ describe('ClockTextField', () => {
 
         fireEvent.focus(hours);
 
-        expect(minutes).toHaveFocus();
+        await waitFor(() => {
+            expect(minutes).toHaveFocus();
+        });
     });
 
     it('total minutes: displays floored minutes and writes clock on change', () => {

--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.tsx
@@ -4,6 +4,7 @@ import { clockToSeconds } from '@jackstenglein/chess-dojo-common/src/pgn/clock';
 import { Stack, TextField } from '@mui/material';
 import { TimeField } from '@mui/x-date-pickers';
 import { DateTime } from 'luxon';
+import { useRef } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
 import { ClockFieldFormat, ClockFieldFormatKey } from '../settings/EditorSettings';
 import { convertSecondsToDateTime, onChangeClock } from './ClockEditor';
@@ -17,14 +18,21 @@ const defaultDateTime = DateTime.fromJSDate(d);
 interface ClockTextFieldProps {
     move: Move;
     label?: string;
+    /** Previous move's clock time in seconds, used for validation */
+    previousMoveSeconds?: number;
 }
 
-const ClockTextField: React.FC<ClockTextFieldProps> = ({ move, label }) => {
+const ClockTextField = ({ move, label, previousMoveSeconds }: ClockTextFieldProps) => {
     const { chess } = useChess();
     const [clockFieldFormat] = useLocalStorage<string>(
         ClockFieldFormatKey,
         ClockFieldFormat.SingleField,
     );
+
+    const hoursRef = useRef<HTMLInputElement>(null);
+    const minutesRef = useRef<HTMLInputElement>(null);
+    const secondsRef = useRef<HTMLInputElement>(null);
+    const hoursRedirected = useRef(false);
 
     if (!chess) {
         return null;
@@ -85,6 +93,51 @@ const ClockTextField: React.FC<ClockTextFieldProps> = ({ move, label }) => {
     if (clockFieldFormat === ClockFieldFormat.ThreeField) {
         const timeSlots = getTimeSlotsFromMove(move);
 
+        // Check if hours exceed previous move's total hours (for validation)
+        const previousMoveHours =
+            previousMoveSeconds !== undefined ? Math.floor(previousMoveSeconds / 3600) : undefined;
+        const hoursExceedPrevious =
+            previousMoveHours !== undefined && timeSlots.hours > previousMoveHours;
+
+        // Auto-focus minutes if previous move was under 1 hour
+        const shouldAutoFocusMinutes =
+            previousMoveSeconds !== undefined && previousMoveSeconds < 3600;
+
+        const handleHoursFocus = () => {
+            if (shouldAutoFocusMinutes && !hoursRedirected.current) {
+                hoursRedirected.current = true;
+                requestAnimationFrame(() => {
+                    minutesRef.current?.focus();
+                    minutesRef.current?.select();
+                });
+            }
+        };
+
+        const handleKeyDown = (
+            e: React.KeyboardEvent<HTMLInputElement>,
+            currentField: 'hours' | 'minutes' | 'seconds',
+        ) => {
+            if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                if (currentField === 'hours') {
+                    minutesRef.current?.focus();
+                    minutesRef.current?.select();
+                } else if (currentField === 'minutes') {
+                    secondsRef.current?.focus();
+                    secondsRef.current?.select();
+                }
+            } else if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                if (currentField === 'seconds') {
+                    minutesRef.current?.focus();
+                    minutesRef.current?.select();
+                } else if (currentField === 'minutes') {
+                    hoursRef.current?.focus();
+                    hoursRef.current?.select();
+                }
+            }
+        };
+
         return (
             <Stack direction='row' spacing={1}>
                 <TextField
@@ -92,10 +145,21 @@ const ClockTextField: React.FC<ClockTextFieldProps> = ({ move, label }) => {
                     id={BlockBoardKeyboardShortcuts}
                     value={timeSlots.hours}
                     disabled={!move}
+                    error={hoursExceedPrevious}
                     onChange={(event) =>
                         onChangeTimeSlot('hours', event.target.value, timeSlots, chess, move)
                     }
+                    onKeyDown={(e) =>
+                        handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'hours')
+                    }
+                    onFocus={handleHoursFocus}
                     fullWidth
+                    slotProps={{
+                        htmlInput: {
+                            ref: hoursRef,
+                            'data-testid': 'clock-hours-field',
+                        },
+                    }}
                 />
                 <TextField
                     label='Minutes'
@@ -105,7 +169,16 @@ const ClockTextField: React.FC<ClockTextFieldProps> = ({ move, label }) => {
                     onChange={(event) =>
                         onChangeTimeSlot('minutes', event.target.value, timeSlots, chess, move)
                     }
+                    onKeyDown={(e) =>
+                        handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'minutes')
+                    }
                     fullWidth
+                    slotProps={{
+                        htmlInput: {
+                            ref: minutesRef,
+                            'data-testid': 'clock-minutes-field',
+                        },
+                    }}
                 />
                 <TextField
                     label='Seconds'
@@ -115,7 +188,16 @@ const ClockTextField: React.FC<ClockTextFieldProps> = ({ move, label }) => {
                     onChange={(event) =>
                         onChangeTimeSlot('seconds', event.target.value, timeSlots, chess, move)
                     }
+                    onKeyDown={(e) =>
+                        handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'seconds')
+                    }
                     fullWidth
+                    slotProps={{
+                        htmlInput: {
+                            ref: secondsRef,
+                            'data-testid': 'clock-seconds-field',
+                        },
+                    }}
                 />
             </Stack>
         );

--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.tsx
@@ -1,7 +1,7 @@
 import { BlockBoardKeyboardShortcuts, useChess } from '@/board/pgn/PgnBoard';
 import { Chess, Move } from '@jackstenglein/chess';
 import { clockToSeconds } from '@jackstenglein/chess-dojo-common/src/pgn/clock';
-import { Stack, TextField } from '@mui/material';
+import { FormHelperText, Stack, TextField } from '@mui/material';
 import { TimeField } from '@mui/x-date-pickers';
 import { DateTime } from 'luxon';
 import { useRef } from 'react';
@@ -18,11 +18,14 @@ const defaultDateTime = DateTime.fromJSDate(d);
 interface ClockTextFieldProps {
     move: Move;
     label?: string;
-    /** Previous move's clock time in seconds, used for validation */
-    previousMoveSeconds?: number;
+    /**
+     * The maximum time in seconds this move's clock can have, based on the time control.
+     * If not undefined, it will be used to validate the user's input.
+     */
+    maxSeconds?: number;
 }
 
-const ClockTextField = ({ move, label, previousMoveSeconds }: ClockTextFieldProps) => {
+const ClockTextField = ({ move, label, maxSeconds }: ClockTextFieldProps) => {
     const { chess } = useChess();
     const [clockFieldFormat] = useLocalStorage<string>(
         ClockFieldFormatKey,
@@ -69,39 +72,43 @@ const ClockTextField = ({ move, label, previousMoveSeconds }: ClockTextFieldProp
                 slotProps={{
                     htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
                 }}
+                error={Boolean(maxSeconds && seconds > maxSeconds)}
+                helperText={
+                    maxSeconds && seconds > maxSeconds
+                        ? 'Gained more time than possible according to time control'
+                        : undefined
+                }
             />
         );
     }
 
     if (clockFieldFormat === ClockFieldFormat.SingleField) {
+        const seconds = clockToSeconds(move.commentDiag?.clk) ?? 0;
         return (
             <TimeField
                 id={BlockBoardKeyboardShortcuts}
                 label={label || 'Clock (hh:mm:ss)'}
                 format='HH:mm:ss'
-                value={
-                    convertSecondsToDateTime(clockToSeconds(move.commentDiag?.clk)) ||
-                    defaultDateTime
-                }
+                value={convertSecondsToDateTime(seconds) || defaultDateTime}
                 onChange={(value) => onChangeClock(chess, move, value)}
                 fullWidth
                 className={BlockBoardKeyboardShortcuts}
+                error={Boolean(maxSeconds && seconds > maxSeconds)}
+                helperText={
+                    maxSeconds && seconds > maxSeconds
+                        ? 'Gained more time than possible according to time control'
+                        : undefined
+                }
             />
         );
     }
 
     if (clockFieldFormat === ClockFieldFormat.ThreeField) {
         const timeSlots = getTimeSlotsFromMove(move);
+        const seconds = timeSlots.hours * 3600 + timeSlots.minutes * 60 + timeSlots.seconds;
 
-        // Check if hours exceed previous move's total hours (for validation)
-        const previousMoveHours =
-            previousMoveSeconds !== undefined ? Math.floor(previousMoveSeconds / 3600) : undefined;
-        const hoursExceedPrevious =
-            previousMoveHours !== undefined && timeSlots.hours > previousMoveHours;
-
-        // Auto-focus minutes if previous move was under 1 hour
-        const shouldAutoFocusMinutes =
-            previousMoveSeconds !== undefined && previousMoveSeconds < 3600;
+        const error = maxSeconds !== undefined && seconds > maxSeconds;
+        const shouldAutoFocusMinutes = maxSeconds !== undefined && maxSeconds < 3600;
 
         const handleHoursFocus = () => {
             if (shouldAutoFocusMinutes && !hoursRedirected.current) {
@@ -139,66 +146,75 @@ const ClockTextField = ({ move, label, previousMoveSeconds }: ClockTextFieldProp
         };
 
         return (
-            <Stack direction='row' spacing={1}>
-                <TextField
-                    label='Hours'
-                    id={BlockBoardKeyboardShortcuts}
-                    value={timeSlots.hours}
-                    disabled={!move}
-                    error={hoursExceedPrevious}
-                    onChange={(event) =>
-                        onChangeTimeSlot('hours', event.target.value, timeSlots, chess, move)
-                    }
-                    onKeyDown={(e) =>
-                        handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'hours')
-                    }
-                    onFocus={handleHoursFocus}
-                    fullWidth
-                    slotProps={{
-                        htmlInput: {
-                            ref: hoursRef,
-                            'data-testid': 'clock-hours-field',
-                        },
-                    }}
-                />
-                <TextField
-                    label='Minutes'
-                    id={BlockBoardKeyboardShortcuts}
-                    value={timeSlots.minutes}
-                    disabled={!move}
-                    onChange={(event) =>
-                        onChangeTimeSlot('minutes', event.target.value, timeSlots, chess, move)
-                    }
-                    onKeyDown={(e) =>
-                        handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'minutes')
-                    }
-                    fullWidth
-                    slotProps={{
-                        htmlInput: {
-                            ref: minutesRef,
-                            'data-testid': 'clock-minutes-field',
-                        },
-                    }}
-                />
-                <TextField
-                    label='Seconds'
-                    id={BlockBoardKeyboardShortcuts}
-                    value={timeSlots.seconds}
-                    disabled={!move}
-                    onChange={(event) =>
-                        onChangeTimeSlot('seconds', event.target.value, timeSlots, chess, move)
-                    }
-                    onKeyDown={(e) =>
-                        handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'seconds')
-                    }
-                    fullWidth
-                    slotProps={{
-                        htmlInput: {
-                            ref: secondsRef,
-                            'data-testid': 'clock-seconds-field',
-                        },
-                    }}
-                />
+            <Stack>
+                <Stack direction='row' spacing={1}>
+                    <TextField
+                        label='Hours'
+                        id={BlockBoardKeyboardShortcuts}
+                        value={timeSlots.hours}
+                        disabled={!move}
+                        error={error}
+                        onChange={(event) =>
+                            onChangeTimeSlot('hours', event.target.value, timeSlots, chess, move)
+                        }
+                        onKeyDown={(e) =>
+                            handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'hours')
+                        }
+                        onFocus={handleHoursFocus}
+                        fullWidth
+                        slotProps={{
+                            htmlInput: {
+                                ref: hoursRef,
+                                'data-testid': 'clock-hours-field',
+                            },
+                        }}
+                    />
+                    <TextField
+                        label='Minutes'
+                        id={BlockBoardKeyboardShortcuts}
+                        value={timeSlots.minutes}
+                        disabled={!move}
+                        error={error}
+                        onChange={(event) =>
+                            onChangeTimeSlot('minutes', event.target.value, timeSlots, chess, move)
+                        }
+                        onKeyDown={(e) =>
+                            handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'minutes')
+                        }
+                        fullWidth
+                        slotProps={{
+                            htmlInput: {
+                                ref: minutesRef,
+                                'data-testid': 'clock-minutes-field',
+                            },
+                        }}
+                    />
+                    <TextField
+                        label='Seconds'
+                        id={BlockBoardKeyboardShortcuts}
+                        value={timeSlots.seconds}
+                        disabled={!move}
+                        error={error}
+                        onChange={(event) =>
+                            onChangeTimeSlot('seconds', event.target.value, timeSlots, chess, move)
+                        }
+                        onKeyDown={(e) =>
+                            handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>, 'seconds')
+                        }
+                        fullWidth
+                        slotProps={{
+                            htmlInput: {
+                                ref: secondsRef,
+                                'data-testid': 'clock-seconds-field',
+                            },
+                        }}
+                    />
+                </Stack>
+                {error && (
+                    <FormHelperText error>
+                        Gained more time than possible according to time control
+                    </FormHelperText>
+                )}
             </Stack>
         );
     }


### PR DESCRIPTION
## Summary

Improves the game annotation clock editor based on user feedback. Adds arrow key navigation between clock fields, visual validation when hours exceed the previous move, auto-focus to the minutes field for sub-1-hour time controls, and restores the browser warning when refreshing with unsaved analysis.

## Related Issues

Fixes #2165

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to UI interaction changes best verified through manual testing

### Manual testing steps

- [x] Import a game and navigate to the Clocks tab in the analysis board
- [x] Switch to the three-field clock format (Hours/Minutes/Seconds) in editor settings
- [x] Click into the Hours field and press Right Arrow — cursor should move to Minutes, then to Seconds
- [x] From Seconds, press Left Arrow — cursor should move back through Minutes to Hours
- [x] Enter a time where hours exceed the previous move's hours — the Hours field should highlight red
- [x] For a game with a sub-1-hour time control, click into a clock row — cursor should auto-focus to Minutes on first click
- [x] Click the Hours field again — cursor should stay on Hours (redirect only happens once)
- [x] Make changes to the analysis, then try to refresh the browser — a "Changes may not be saved" warning should appear
- [x] Cancel the refresh and verify your changes are still intact

### Notes

- The browser only allows its native "Leave site?" prompt on refresh — the custom Save/Delete dialog is only possible for in-app navigation due to browser security restrictions. The native prompt still prevents accidental data loss.
- Focus redirects from Hours to Minutes on first click when the previous move's clock is under 1 hour. Clicking Hours a second time stays on Hours, and Left Arrow from Minutes also reaches Hours. This is per-player — if one player is under an hour but the other isn't, each row behaves appropriately.
- The hours validation (red highlight) assumes a live game where clock time decreases. For correspondence games where time can increase between moves, the red highlight may be a false positive. This is a visual hint only — it does not prevent saving.

## Demo

<img width="411" height="235" alt="image" src="https://github.com/user-attachments/assets/fdc0b16e-e980-49a6-a1d1-d709ee10082a" />
