### PR TITLE
feat(#2149): Square drill ratings

### DIFF
--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -352,6 +352,9 @@ type User struct {
 	// overall stats will be under the theme OVERALL.
 	Puzzles map[string]PuzzleThemeOverview `dynamodbav:"puzzles,omitempty" json:"puzzles,omitempty"`
 
+	// The user's best-ever square color drill rating (0-1500).
+	SquareColorRating float32 `dynamodbav:"squareColorRating,omitempty" json:"squareColorRating,omitempty"`
+
 	// The id of the user's game review cohort, if they are a member of the Game & Profile Review tier.
 	GameReviewCohortId string `dynamodbav:"gameReviewCohortId,omitempty" json:"gameReviewCohortId,omitempty"`
 

--- a/backend/directoryService/database.ts
+++ b/backend/directoryService/database.ts
@@ -423,6 +423,34 @@ class AndCondition extends Condition {
     }
 }
 
+class OrCondition extends Condition {
+    private conditions: Condition[];
+
+    constructor(...conditions: Condition[]) {
+        super();
+        this.conditions = conditions;
+    }
+
+    build(
+        exprAttrNames: Record<string, string>,
+        exprAttrValues: Record<string, AttributeValue>,
+        reversedExprAttrNames: Record<string, string>,
+        parentAttrIndex = '',
+    ) {
+        const result = this.conditions
+            .map((condition, index) =>
+                condition.build(
+                    exprAttrNames,
+                    exprAttrValues,
+                    reversedExprAttrNames,
+                    `${parentAttrIndex}${index}`,
+                ),
+            )
+            .join(' OR ');
+        return `(${result})`;
+    }
+}
+
 class AttributeExistsCondition extends Condition {
     private path: AttributePathTokens;
 
@@ -528,6 +556,16 @@ export function and(...conditions: Condition[]): Condition {
 }
 
 /**
+ * Returns a condition which verifies that at least one of the nested
+ * conditions is true.
+ * @param conditions The conditions to verify.
+ * @returns A condition that is true when any nested condition is true.
+ */
+export function or(...conditions: Condition[]): Condition {
+    return new OrCondition(...conditions);
+}
+
+/**
  * Returns a condition which verifies that the given attribute path
  * exists on the DynamoDB item.
  * @param path The path to check.
@@ -573,6 +611,17 @@ export function notEqual(path: AttributePath, value: any): Condition {
  */
 export function sizeLessThan(path: AttributePath, value: number): Condition {
     return new SizeCondition(path, value, '<');
+}
+
+/**
+ * Returns a condition which verifies that the given attribute path
+ * is less than the given value.
+ * @param path The path to check.
+ * @param value The value to compare against.
+ * @returns A condition that is true when the attribute is less than the value.
+ */
+export function lessThan(path: AttributePath, value: any): Condition {
+    return new EqualityCondition(path, value, '<');
 }
 
 /** A builder for DynamoDB GetItem commands. */

--- a/backend/puzzleService/serverless.yml
+++ b/backend/puzzleService/serverless.yml
@@ -79,6 +79,10 @@ functions:
         Action:
           - dynamodb:PutItem
         Resource: !GetAtt SquareColorResultsTable.Arn
+      - Effect: Allow
+        Action:
+          - dynamodb:UpdateItem
+        Resource: ${param:UsersTableArn}
 
 resources:
   Conditions:

--- a/backend/puzzleService/squareColor.ts
+++ b/backend/puzzleService/squareColor.ts
@@ -1,15 +1,40 @@
-import { PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { ConditionalCheckFailedException, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import {
     SquareColorSessionResult,
+    SubmitSquareColorSessionResponse,
     submitSquareColorSessionSchema,
 } from '@jackstenglein/chess-dojo-common/src/squareColors/api';
+import {
+    computeSquareColorRating,
+    MIN_QUESTIONS_FOR_RATING,
+} from '@jackstenglein/chess-dojo-common/src/squareColors/rating';
 import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
-import { errToApiGatewayProxyResultV2, parseBody, requireUserInfo, success } from '../directoryService/api';
-import { dynamo } from '../directoryService/database';
+import {
+    errToApiGatewayProxyResultV2,
+    parseBody,
+    requireUserInfo,
+    success,
+} from '../directoryService/api';
+import {
+    UpdateItemBuilder,
+    attributeNotExists,
+    dynamo,
+    lessThan,
+    or,
+} from '../directoryService/database';
 
 const squareColorResultsTable = `${process.env.stage}-square-color-results`;
+const usersTable = `${process.env.stage}-users`;
 
+/**
+ * Handles submission of a square color drill session. Saves the session result
+ * and, if enough questions were answered, computes a rating and conditionally
+ * updates the user's best rating.
+ *
+ * @param event - The API Gateway proxy event.
+ * @returns A response containing the computed rating if applicable, or an empty object.
+ */
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     try {
         console.log('Event: %j', event);
@@ -22,6 +47,19 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
             createdAt: request.createdAt ?? new Date().toISOString(),
         };
 
+        const response: SubmitSquareColorSessionResponse = {};
+
+        if (request.totalQuestions >= MIN_QUESTIONS_FOR_RATING) {
+            const accuracy =
+                (request.correctCount / request.totalQuestions) * 100;
+            const rating = computeSquareColorRating(
+                accuracy,
+                request.avgResponseTimeMs,
+            );
+            result.rating = rating;
+            response.rating = rating;
+        }
+
         await dynamo.send(
             new PutItemCommand({
                 TableName: squareColorResultsTable,
@@ -29,7 +67,28 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
             }),
         );
 
-        return success({ message: 'Session saved' });
+        if (response.rating !== undefined && request.isFinal) {
+            try {
+                const builder = new UpdateItemBuilder()
+                    .key('username', userInfo.username)
+                    .table(usersTable)
+                    .set('squareColorRating', response.rating)
+                    .condition(
+                        or(
+                            attributeNotExists('squareColorRating'),
+                            lessThan('squareColorRating', response.rating),
+                        ),
+                    );
+                await builder.send();
+            } catch (err) {
+                if (!(err instanceof ConditionalCheckFailedException)) {
+                    throw err;
+                }
+                // Existing rating is already higher; no update needed.
+            }
+        }
+
+        return success(response);
     } catch (err) {
         return errToApiGatewayProxyResultV2(err);
     }

--- a/backend/puzzleService/squareColor.ts
+++ b/backend/puzzleService/squareColor.ts
@@ -84,7 +84,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
                 if (!(err instanceof ConditionalCheckFailedException)) {
                     throw err;
                 }
-                // Existing rating is already higher; no update needed.
+
             }
         }
 

--- a/common/src/database/user.ts
+++ b/common/src/database/user.ts
@@ -121,6 +121,9 @@ export interface User {
      */
     puzzles?: Record<string, PuzzleThemeOverview>;
 
+    /** The user's best-ever square color drill rating (0-1500). */
+    squareColorRating?: number;
+
     /** The user's firebase cloud messaging tokens. */
     firebaseTokens?: string[];
 

--- a/common/src/squareColors/api.ts
+++ b/common/src/squareColors/api.ts
@@ -28,6 +28,8 @@ export const submitSquareColorSessionSchema = z.object({
     questions: z.array(squareColorQuestionSchema),
     /** Optional client-generated timestamp to allow updating the same session record. */
     createdAt: z.string().datetime().optional(),
+    /** Optional client-computed rating for this session (0–1500). */
+    rating: z.number().min(0).max(1500).optional(),
 });
 
 /** A request to submit a square color drill session. */

--- a/common/src/squareColors/api.ts
+++ b/common/src/squareColors/api.ts
@@ -28,8 +28,10 @@ export const submitSquareColorSessionSchema = z.object({
     questions: z.array(squareColorQuestionSchema),
     /** Optional client-generated timestamp to allow updating the same session record. */
     createdAt: z.string().datetime().optional(),
-    /** Optional client-computed rating for this session (0–1500). */
+    /** Optional client-computed rating for this session (0-1500). */
     rating: z.number().min(0).max(1500).optional(),
+    /** Whether this is the final submission for the session (triggers rating persistence). */
+    isFinal: z.boolean().optional(),
 });
 
 /** A request to submit a square color drill session. */
@@ -44,4 +46,10 @@ export interface SquareColorSessionResult extends SubmitSquareColorSessionReques
     username: string;
     /** The ISO 8601 timestamp when the session was created. */
     createdAt: string;
+}
+
+/** Response from submitting a square color drill session. */
+export interface SubmitSquareColorSessionResponse {
+    /** The server-computed rating for this session, if enough questions were answered. */
+    rating?: number;
 }

--- a/common/src/squareColors/rating.test.ts
+++ b/common/src/squareColors/rating.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+    SQUARE_COLOR_RATING_CONFIG,
+    MIN_QUESTIONS_FOR_RATING,
+    computeSquareColorRating,
+} from './rating';
+
+const { maxRating, fastMs, slowMs } = SQUARE_COLOR_RATING_CONFIG;
+
+describe('SQUARE_COLOR_RATING_CONFIG', () => {
+    it('has the expected constant values', () => {
+        expect(SQUARE_COLOR_RATING_CONFIG.accuracyWeight).toBe(0.65);
+        expect(SQUARE_COLOR_RATING_CONFIG.timeWeight).toBe(0.35);
+        expect(SQUARE_COLOR_RATING_CONFIG.maxRating).toBe(1500);
+        expect(SQUARE_COLOR_RATING_CONFIG.fastMs).toBe(500);
+        expect(SQUARE_COLOR_RATING_CONFIG.slowMs).toBe(5000);
+    });
+});
+
+describe('MIN_QUESTIONS_FOR_RATING', () => {
+    it('equals 20', () => {
+        expect(MIN_QUESTIONS_FOR_RATING).toBe(20);
+    });
+});
+
+describe('computeSquareColorRating', () => {
+    it('returns the maximum rating (1500) for perfect accuracy and fastest response time', () => {
+        // accuracy=100, time=fastMs => accuracyScore=1, timeScore=1 => 1500 * 1.0 = 1500
+        expect(computeSquareColorRating(100, fastMs)).toBe(maxRating);
+    });
+
+    it('returns the maximum rating when response time is faster than fastMs', () => {
+        // Time below fastMs is clamped to a timeScore of 1
+        expect(computeSquareColorRating(100, 0)).toBe(maxRating);
+    });
+
+    it('returns 0 for zero accuracy and slowest (or slower) response time', () => {
+        // accuracy=0, time=slowMs => accuracyScore=0, timeScore=0 => 0
+        expect(computeSquareColorRating(0, slowMs)).toBe(0);
+    });
+
+    it('returns 0 when response time exceeds slowMs and accuracy is zero', () => {
+        // Time beyond slowMs is clamped to a timeScore of 0
+        expect(computeSquareColorRating(0, slowMs + 1000)).toBe(0);
+    });
+
+    it('returns correct rating for mid-range accuracy and time', () => {
+        // accuracy=50 => accuracyScore=0.5
+        // time=2750ms (midpoint of 500–5000) => timeScore=0.5
+        // rating = round(1500 * (0.65 * 0.5 + 0.35 * 0.5)) = round(1500 * 0.5) = 750
+        const midTime = (fastMs + slowMs) / 2;
+        expect(computeSquareColorRating(50, midTime)).toBe(750);
+    });
+
+    it('weights accuracy more heavily than time', () => {
+        // Perfect accuracy, worst time vs worst accuracy, perfect time
+        const highAccuracyRating = computeSquareColorRating(100, slowMs);
+        const highTimeRating = computeSquareColorRating(0, fastMs);
+        expect(highAccuracyRating).toBeGreaterThan(highTimeRating);
+    });
+
+    it('returns an integer rating', () => {
+        const rating = computeSquareColorRating(73, 1800);
+        expect(Number.isInteger(rating)).toBe(true);
+    });
+
+    it('clamps accuracy above 100 to a maximum score of 1500', () => {
+        // accuracy > 100 is clamped to accuracyScore=1
+        expect(computeSquareColorRating(150, fastMs)).toBe(maxRating);
+    });
+
+    it('clamps negative accuracy to a minimum contribution of 0', () => {
+        // accuracy < 0 is clamped to accuracyScore=0
+        // time=fastMs => timeScore=1 => rating = round(1500 * 0.35) = 525
+        expect(computeSquareColorRating(-10, fastMs)).toBe(Math.round(maxRating * 0.35));
+    });
+
+    it('returns only the accuracy component when time equals slowMs', () => {
+        // timeScore=0 => rating = round(1500 * 0.65 * (accuracy/100))
+        expect(computeSquareColorRating(100, slowMs)).toBe(Math.round(maxRating * 0.65));
+    });
+
+    it('returns only the time component when accuracy is zero and time equals fastMs', () => {
+        // accuracyScore=0, timeScore=1 => rating = round(1500 * 0.35) = 525
+        expect(computeSquareColorRating(0, fastMs)).toBe(Math.round(maxRating * 0.35));
+    });
+});

--- a/common/src/squareColors/rating.test.ts
+++ b/common/src/squareColors/rating.test.ts
@@ -13,7 +13,7 @@ describe('SQUARE_COLOR_RATING_CONFIG', () => {
         expect(SQUARE_COLOR_RATING_CONFIG.timeWeight).toBe(0.35);
         expect(SQUARE_COLOR_RATING_CONFIG.maxRating).toBe(1500);
         expect(SQUARE_COLOR_RATING_CONFIG.fastMs).toBe(500);
-        expect(SQUARE_COLOR_RATING_CONFIG.slowMs).toBe(5000);
+        expect(SQUARE_COLOR_RATING_CONFIG.slowMs).toBe(10000);
     });
 });
 

--- a/common/src/squareColors/rating.ts
+++ b/common/src/squareColors/rating.ts
@@ -9,7 +9,7 @@ export const SQUARE_COLOR_RATING_CONFIG = {
     /** Response time in milliseconds considered "fast" (full time score). */
     fastMs: 500,
     /** Response time in milliseconds considered "slow" (zero time score). */
-    slowMs: 5000,
+    slowMs: 10000,
 } as const;
 
 /**

--- a/common/src/squareColors/rating.ts
+++ b/common/src/squareColors/rating.ts
@@ -1,0 +1,53 @@
+/** Configuration constants for the square color drill rating computation. */
+export const SQUARE_COLOR_RATING_CONFIG = {
+    /** Weight applied to the accuracy score when computing the rating. */
+    accuracyWeight: 0.65,
+    /** Weight applied to the time score when computing the rating. */
+    timeWeight: 0.35,
+    /** The maximum possible rating. */
+    maxRating: 1500,
+    /** Response time in milliseconds considered "fast" (full time score). */
+    fastMs: 500,
+    /** Response time in milliseconds considered "slow" (zero time score). */
+    slowMs: 5000,
+} as const;
+
+/**
+ * The minimum number of questions required before a rating is computed
+ * and displayed to the user.
+ */
+export const MIN_QUESTIONS_FOR_RATING = 20;
+
+/**
+ * Clamps a value between a minimum and maximum.
+ * @param value - The value to clamp.
+ * @param min - The minimum allowed value.
+ * @param max - The maximum allowed value.
+ * @returns The clamped value.
+ */
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Computes a square color drill rating from accuracy and average response time.
+ *
+ * The rating combines an accuracy score (proportion of correct answers) and a
+ * time score (how quickly the user responded on average) using a weighted sum:
+ *
+ *   accuracyScore = clamp(accuracy / 100, 0, 1)
+ *   timeScore     = clamp(1 - (avgResponseTimeMs - fastMs) / (slowMs - fastMs), 0, 1)
+ *   rating        = round(maxRating * (accuracyWeight * accuracyScore + timeWeight * timeScore))
+ *
+ * @param accuracy - Percentage of correct answers (0–100).
+ * @param avgResponseTimeMs - Average response time in milliseconds.
+ * @returns An integer rating in the range [0, 1500].
+ */
+export function computeSquareColorRating(accuracy: number, avgResponseTimeMs: number): number {
+    const { accuracyWeight, timeWeight, maxRating, fastMs, slowMs } = SQUARE_COLOR_RATING_CONFIG;
+
+    const accuracyScore = clamp(accuracy / 100, 0, 1);
+    const timeScore = clamp(1 - (avgResponseTimeMs - fastMs) / (slowMs - fastMs), 0, 1);
+
+    return Math.round(maxRating * (accuracyWeight * accuracyScore + timeWeight * timeScore));
+}

--- a/frontend/src/api/puzzleApi.ts
+++ b/frontend/src/api/puzzleApi.ts
@@ -4,7 +4,10 @@ import {
     NextPuzzleRequest,
     NextPuzzleResponse,
 } from '@jackstenglein/chess-dojo-common/src/puzzles/api';
-import { SubmitSquareColorSessionRequest } from '@jackstenglein/chess-dojo-common/src/squareColors/api';
+import {
+    SubmitSquareColorSessionRequest,
+    SubmitSquareColorSessionResponse,
+} from '@jackstenglein/chess-dojo-common/src/squareColors/api';
 import { AxiosResponse } from 'axios';
 import { axiosService } from './axiosService';
 
@@ -38,7 +41,7 @@ export function getPuzzleHistory(idToken: string, request: GetPuzzleHistoryReque
  * @returns A promise that resolves to the response from the API.
  */
 export function submitSquareColorSession(request: SubmitSquareColorSessionRequest) {
-    return axiosService.post<{ message: string }>(`/puzzle/square-color`, request, {
+    return axiosService.post<SubmitSquareColorSessionResponse>(`/puzzle/square-color`, request, {
         functionName: 'submitSquareColorSession',
     });
 }

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -41,6 +41,17 @@ export function computeSessionStats(
     allQuestions: SquareColorQuestion[],
     sessionStartTime: number,
 ): SessionSummary {
+    if (allQuestions.length === 0) {
+        return {
+            totalQuestions: 0,
+            correctCount: 0,
+            avgResponseTimeMs: 0,
+            bestStreak: 0,
+            totalTimeSeconds: 0,
+            questions: [],
+        };
+    }
+
     const totalTimeSeconds = Math.round((Date.now() - sessionStartTime) / 1000);
     const correctCount = allQuestions.filter((q) => q.userAnswer === q.correctAnswer).length;
     const avgResponseTimeMs = Math.round(
@@ -328,12 +339,12 @@ function ReadyScreen({ onStart }: { onStart: () => void }) {
             </Typography>
             <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
                 {armed
-                    ? 'Timer starts now!'
+                    ? 'Ready? Hit GO! to start the timer.'
                     : "Answer as quickly and accurately as possible. Stop whenever you're ready!"}
             </Typography>
             <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
                 {armed ? (
-                    <>Press GO! to begin — your score will be timed from this moment.</>
+                    <>Press GO! to begin, your score will be timed from this moment.</>
                 ) : (
                     <>
                         Keyboard shortcuts: <strong>W</strong> for White, <strong>B</strong> for

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -7,6 +7,10 @@ import LoadingPage from '@/loading/LoadingPage';
 import NotFoundPage from '@/NotFoundPage';
 import { SquareColorQuestion } from '@jackstenglein/chess-dojo-common/src/squareColors/api';
 import {
+    computeSquareColorRating,
+    MIN_QUESTIONS_FOR_RATING,
+} from '@jackstenglein/chess-dojo-common/src/squareColors/rating';
+import {
     getRandomSquare,
     getSquareColor,
 } from '@jackstenglein/chess-dojo-common/src/squareColors/squareColor';
@@ -22,13 +26,16 @@ interface SessionSummary {
     bestStreak: number;
     totalTimeSeconds: number;
     questions: SquareColorQuestion[];
+    rating?: number;
 }
 
 /**
  * Computes aggregate stats for a square color drill session.
+ * A rating is included when the user has answered at least {@link MIN_QUESTIONS_FOR_RATING} questions.
+ *
  * @param allQuestions - The list of answered questions.
  * @param sessionStartTime - The epoch timestamp (ms) when the session started.
- * @returns The computed session summary stats.
+ * @returns The computed session summary, including an optional rating.
  */
 export function computeSessionStats(
     allQuestions: SquareColorQuestion[],
@@ -51,6 +58,12 @@ export function computeSessionStats(
         }
     }
 
+    let rating: number | undefined;
+    if (allQuestions.length >= MIN_QUESTIONS_FOR_RATING) {
+        const accuracy = (correctCount / allQuestions.length) * 100;
+        rating = computeSquareColorRating(accuracy, avgResponseTimeMs);
+    }
+
     return {
         totalQuestions: allQuestions.length,
         correctCount,
@@ -58,6 +71,7 @@ export function computeSessionStats(
         bestStreak,
         totalTimeSeconds,
         questions: allQuestions,
+        rating,
     };
 }
 
@@ -194,11 +208,20 @@ function SquareColorDrill() {
         );
     }
 
+    const questionsRemaining = Math.max(0, MIN_QUESTIONS_FOR_RATING - questions.length);
+
     return (
         <Container maxWidth='sm' sx={{ py: 6, textAlign: 'center' }}>
             <Typography variant='subtitle1' color='text.secondary' sx={{ mb: 1 }}>
                 Question {questions.length + 1}
             </Typography>
+
+            {questionsRemaining > 0 && (
+                <Typography variant='body2' color='text.secondary' sx={{ mb: 1 }}>
+                    Answer {questionsRemaining} more{' '}
+                    {questionsRemaining === 1 ? 'question' : 'questions'} to receive a rating
+                </Typography>
+            )}
 
             <Box
                 sx={{
@@ -285,7 +308,15 @@ function SquareColorDrill() {
     );
 }
 
+/**
+ * Landing screen shown before the drill begins. Implements a two-step "Ready / GO!"
+ * flow: the first click arms the timer prompt, the second click starts the drill.
+ *
+ * @param onStart - Callback invoked when the user confirms they are ready to start.
+ */
 function ReadyScreen({ onStart }: { onStart: () => void }) {
+    const [armed, setArmed] = useState(false);
+
     return (
         <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
             <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 2 }}>
@@ -296,18 +327,38 @@ function ReadyScreen({ onStart }: { onStart: () => void }) {
                 square.
             </Typography>
             <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
-                Answer as quickly and accurately as possible. Stop whenever you're ready!
+                {armed
+                    ? 'Timer starts now!'
+                    : "Answer as quickly and accurately as possible. Stop whenever you're ready!"}
             </Typography>
             <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
-                Keyboard shortcuts: <strong>W</strong> for White, <strong>B</strong> for Black
+                {armed ? (
+                    <>Press GO! to begin — your score will be timed from this moment.</>
+                ) : (
+                    <>
+                        Keyboard shortcuts: <strong>W</strong> for White, <strong>B</strong> for
+                        Black
+                    </>
+                )}
             </Typography>
-            <Button variant='contained' size='large' onClick={onStart} sx={{ px: 6, py: 1.5 }}>
-                Start
+            <Button
+                variant='contained'
+                size='large'
+                onClick={armed ? onStart : () => setArmed(true)}
+                sx={{ px: 6, py: 1.5 }}
+            >
+                {armed ? 'GO!' : 'Start'}
             </Button>
         </Container>
     );
 }
 
+/**
+ * Summary screen shown after the drill completes.
+ *
+ * @param summary - The computed session statistics.
+ * @param onPlayAgain - Callback invoked when the user wants to start a new session.
+ */
 function CompleteScreen({
     summary,
     onPlayAgain,
@@ -325,6 +376,28 @@ function CompleteScreen({
             </Typography>
 
             <Stack spacing={2} sx={{ mb: 4 }}>
+                {summary.rating !== undefined ? (
+                    <Box
+                        sx={{
+                            py: 2,
+                            mb: 1,
+                            borderRadius: 2,
+                            backgroundColor: 'primary.main',
+                            color: 'primary.contrastText',
+                        }}
+                    >
+                        <Typography variant='overline' sx={{ opacity: 0.85 }}>
+                            Your Rating
+                        </Typography>
+                        <Typography variant='h3' sx={{ fontWeight: 'bold' }}>
+                            {summary.rating}
+                        </Typography>
+                    </Box>
+                ) : (
+                    <Typography variant='body2' color='text.secondary' sx={{ mb: 1 }}>
+                        Answer at least {MIN_QUESTIONS_FOR_RATING} questions to receive a rating
+                    </Typography>
+                )}
                 <StatRow
                     label='Accuracy'
                     value={`${accuracy}% (${summary.correctCount}/${summary.totalQuestions})`}
@@ -373,6 +446,12 @@ function CompleteScreen({
     );
 }
 
+/**
+ * A single labeled stat row for the summary table.
+ *
+ * @param label - The human-readable label for the stat.
+ * @param value - The formatted value to display.
+ */
 function StatRow({ label, value }: { label: string; value: string }) {
     return (
         <Stack

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -14,6 +14,8 @@ import {
     getRandomSquare,
     getSquareColor,
 } from '@jackstenglein/chess-dojo-common/src/squareColors/squareColor';
+import ArrowDownward from '@mui/icons-material/ArrowDownward';
+import ArrowUpward from '@mui/icons-material/ArrowUpward';
 import { Box, Button, Container, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -428,6 +430,32 @@ function CompleteScreen({
                         Answer at least {MIN_QUESTIONS_FOR_RATING} questions to receive a rating
                     </Typography>
                 )}
+                {summary.rating !== undefined &&
+                    personalBest !== undefined &&
+                    summary.rating !== personalBest && (
+                        <Stack
+                            direction='row'
+                            alignItems='center'
+                            justifyContent='center'
+                            spacing={0.5}
+                        >
+                            {summary.rating > personalBest ? (
+                                <ArrowUpward color='success' sx={{ fontSize: '1.5rem' }} />
+                            ) : (
+                                <ArrowDownward color='error' sx={{ fontSize: '1.5rem' }} />
+                            )}
+                            <Typography
+                                variant='h6'
+                                sx={{ fontWeight: 'bold' }}
+                                color={
+                                    summary.rating > personalBest ? 'success.main' : 'error.main'
+                                }
+                            >
+                                {summary.rating > personalBest ? '+' : ''}
+                                {summary.rating - personalBest}
+                            </Typography>
+                        </Stack>
+                    )}
                 {summary.rating !== undefined &&
                     (personalBest === undefined || summary.rating > personalBest) && (
                         <Typography variant='h6' sx={{ fontWeight: 'bold', color: 'warning.main' }}>

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -14,8 +14,12 @@ import {
     getRandomSquare,
     getSquareColor,
 } from '@jackstenglein/chess-dojo-common/src/squareColors/squareColor';
+import AccessTime from '@mui/icons-material/AccessTime';
 import ArrowDownward from '@mui/icons-material/ArrowDownward';
 import ArrowUpward from '@mui/icons-material/ArrowUpward';
+import Target from '@mui/icons-material/GpsFixed';
+import LocalFireDepartment from '@mui/icons-material/LocalFireDepartment';
+import Timer from '@mui/icons-material/Timer';
 import { Box, Button, Container, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -468,12 +472,25 @@ function CompleteScreen({
                     </Typography>
                 )}
                 <StatRow
+                    icon={<Target fontSize='small' />}
                     label='Accuracy'
                     value={`${accuracy}% (${summary.correctCount}/${summary.totalQuestions})`}
                 />
-                <StatRow label='Avg Response Time' value={`${avgTime}s`} />
-                <StatRow label='Best Streak' value={`${summary.bestStreak}`} />
-                <StatRow label='Total Time' value={`${summary.totalTimeSeconds}s`} />
+                <StatRow
+                    icon={<Timer fontSize='small' />}
+                    label='Avg Response Time'
+                    value={`${avgTime}s`}
+                />
+                <StatRow
+                    icon={<LocalFireDepartment fontSize='small' />}
+                    label='Best Streak'
+                    value={`${summary.bestStreak}`}
+                />
+                <StatRow
+                    icon={<AccessTime fontSize='small' />}
+                    label='Total Time'
+                    value={`${summary.totalTimeSeconds}s`}
+                />
             </Stack>
 
             <Stack spacing={1} sx={{ mb: 4, maxHeight: 300, overflow: 'auto' }}>
@@ -518,14 +535,16 @@ function CompleteScreen({
 /**
  * A single labeled stat row for the summary table.
  *
+ * @param icon - An icon element displayed before the label.
  * @param label - The human-readable label for the stat.
  * @param value - The formatted value to display.
  */
-function StatRow({ label, value }: { label: string; value: string }) {
+function StatRow({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
     return (
         <Stack
             direction='row'
             justifyContent='space-between'
+            alignItems='center'
             sx={{
                 px: 2,
                 py: 1,
@@ -533,7 +552,10 @@ function StatRow({ label, value }: { label: string; value: string }) {
                 borderColor: 'divider',
             }}
         >
-            <Typography color='text.secondary'>{label}</Typography>
+            <Stack direction='row' alignItems='center' spacing={1}>
+                <Box sx={{ color: 'text.secondary', display: 'flex' }}>{icon}</Box>
+                <Typography color='text.secondary'>{label}</Typography>
+            </Stack>
             <Typography fontWeight='bold'>{value}</Typography>
         </Stack>
     );

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -100,6 +100,7 @@ export function SquareColorDrillPage() {
 }
 
 function SquareColorDrill() {
+    const { user, updateUser } = useAuth();
     const submitRequest = useRequest();
     const [drillState, setDrillState] = useState<DrillState>('ready');
     const [currentSquare, setCurrentSquare] = useState('');
@@ -109,6 +110,7 @@ function SquareColorDrill() {
     const sessionStartRef = useRef<number>(0);
     const questionsRef = useRef<SquareColorQuestion[]>([]);
     const sessionCreatedAtRef = useRef<string>('');
+    const previousBestRef = useRef<number | undefined>(user?.squareColorRating);
     const [summary, setSummary] = useState<SessionSummary | null>(null);
 
     const nextSquare = useCallback(() => {
@@ -125,10 +127,11 @@ function SquareColorDrill() {
         setFeedback(null);
         setSummary(null);
         setDrillState('in_progress');
+        previousBestRef.current = user?.squareColorRating;
         sessionStartRef.current = Date.now();
         sessionCreatedAtRef.current = new Date().toISOString();
         nextSquare();
-    }, [nextSquare]);
+    }, [nextSquare, user?.squareColorRating]);
 
     const finishDrill = useCallback(
         (allQuestions: SquareColorQuestion[]) => {
@@ -146,12 +149,22 @@ function SquareColorDrill() {
             submitSquareColorSession({
                 ...result,
                 createdAt: sessionCreatedAtRef.current,
+                isFinal: true,
             }).then(
-                () => submitRequest.onSuccess(),
+                (response) => {
+                    submitRequest.onSuccess();
+                    const rating = response.data.rating;
+                    if (
+                        rating !== undefined &&
+                        (user?.squareColorRating === undefined || rating > user.squareColorRating)
+                    ) {
+                        updateUser({ squareColorRating: rating });
+                    }
+                },
                 (err: unknown) => submitRequest.onFailure(err),
             );
         },
-        [submitRequest],
+        [submitRequest, user, updateUser],
     );
 
     const handleAnswer = useCallback(
@@ -207,13 +220,17 @@ function SquareColorDrill() {
     }, [drillState, handleAnswer]);
 
     if (drillState === 'ready') {
-        return <ReadyScreen onStart={startDrill} />;
+        return <ReadyScreen onStart={startDrill} personalBest={user?.squareColorRating} />;
     }
 
     if (drillState === 'complete' && summary) {
         return (
             <>
-                <CompleteScreen summary={summary} onPlayAgain={startDrill} />
+                <CompleteScreen
+                    summary={summary}
+                    onPlayAgain={startDrill}
+                    personalBest={previousBestRef.current}
+                />
                 <RequestSnackbar request={submitRequest} />
             </>
         );
@@ -324,8 +341,9 @@ function SquareColorDrill() {
  * flow: the first click arms the timer prompt, the second click starts the drill.
  *
  * @param onStart - Callback invoked when the user confirms they are ready to start.
+ * @param personalBest - The user's best-ever square color drill rating, if any.
  */
-function ReadyScreen({ onStart }: { onStart: () => void }) {
+function ReadyScreen({ onStart, personalBest }: { onStart: () => void; personalBest?: number }) {
     const [armed, setArmed] = useState(false);
 
     return (
@@ -352,6 +370,11 @@ function ReadyScreen({ onStart }: { onStart: () => void }) {
                     </>
                 )}
             </Typography>
+            {personalBest !== undefined && (
+                <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>
+                    Your best rating: {personalBest}
+                </Typography>
+            )}
             <Button
                 variant='contained'
                 size='large'
@@ -369,13 +392,16 @@ function ReadyScreen({ onStart }: { onStart: () => void }) {
  *
  * @param summary - The computed session statistics.
  * @param onPlayAgain - Callback invoked when the user wants to start a new session.
+ * @param personalBest - The user's best-ever square color drill rating, if any.
  */
 function CompleteScreen({
     summary,
     onPlayAgain,
+    personalBest,
 }: {
     summary: SessionSummary;
     onPlayAgain: () => void;
+    personalBest?: number;
 }) {
     const accuracy = Math.round((summary.correctCount / summary.totalQuestions) * 100);
     const avgTime = (summary.avgResponseTimeMs / 1000).toFixed(1);
@@ -407,6 +433,17 @@ function CompleteScreen({
                 ) : (
                     <Typography variant='body2' color='text.secondary' sx={{ mb: 1 }}>
                         Answer at least {MIN_QUESTIONS_FOR_RATING} questions to receive a rating
+                    </Typography>
+                )}
+                {summary.rating !== undefined &&
+                    (personalBest === undefined || summary.rating > personalBest) && (
+                        <Typography variant='h6' sx={{ fontWeight: 'bold', color: 'warning.main' }}>
+                            New Personal Best!
+                        </Typography>
+                    )}
+                {personalBest !== undefined && (
+                    <Typography variant='body1' color='text.secondary'>
+                        Personal Best: {personalBest}
                     </Typography>
                 )}
                 <StatRow

--- a/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
+++ b/frontend/src/components/puzzles/squareColors/SquareColorDrillPage.tsx
@@ -361,14 +361,7 @@ function ReadyScreen({ onStart, personalBest }: { onStart: () => void; personalB
                     : "Answer as quickly and accurately as possible. Stop whenever you're ready!"}
             </Typography>
             <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
-                {armed ? (
-                    <>Press GO! to begin, your score will be timed from this moment.</>
-                ) : (
-                    <>
-                        Keyboard shortcuts: <strong>W</strong> for White, <strong>B</strong> for
-                        Black
-                    </>
-                )}
+                Keyboard shortcuts: <strong>W</strong> for White, <strong>B</strong> for Black
             </Typography>
             {personalBest !== undefined && (
                 <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary

Adds a rating system (0-1500) to the square color drill. Rating is computed from accuracy (65%) and response speed (35%), with a minimum of 20 questions required. The server recomputes the rating from session stats and persists the user's best-ever rating via a conditional DynamoDB update.

Frontend changes include a two-step Ready/GO start flow, a countdown showing questions remaining for a rating, and personal best display on both the Ready and Complete screens.

## Related Issues

Fixes #2149

## Type of change

* [x] New feature (non-breaking change which adds functionality)

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

## Demo

**Two-step Ready/GO flow (second click starts the timer):**

<img width="576" height="381" alt="Go btn" src="https://github.com/user-attachments/assets/89021378-cb78-4e73-abca-41a93697fa2e" />

**Session complete with rating display:**

<img width="565" height="667" alt="Rating" src="https://github.com/user-attachments/assets/00dba2ba-e641-4e30-9db8-ee3c329a2214" />
