### PR TITLE
feat: add Activity tab to round-robin tournaments

### DIFF
--- a/backend/roundRobinService/submitGame.ts
+++ b/backend/roundRobinService/submitGame.ts
@@ -61,6 +61,7 @@ async function submitGame({
         .set([...path, 'url'], request.url)
         .set([...path, 'white'], white)
         .set([...path, 'black'], black)
+        .set([...path, 'submittedAt'], new Date().toISOString())
         .condition(attributeExists(path))
         .table(tournamentsTable)
         .return('ALL_NEW')

--- a/common/src/roundRobin/api.ts
+++ b/common/src/roundRobin/api.ts
@@ -85,6 +85,8 @@ const RoundRobinPairingSchema = z.object({
     result: z.union([z.literal('1-0'), z.literal('1/2-1/2'), z.literal('0-1')]).optional(),
     /** The URL of the game. */
     url: z.string().optional(),
+    /** The ISO timestamp when the game was submitted. */
+    submittedAt: z.string().optional(),
 });
 
 export type RoundRobinPairing = z.infer<typeof RoundRobinPairingSchema>;

--- a/frontend/src/components/tournaments/round-robin/Activity.test.tsx
+++ b/frontend/src/components/tournaments/round-robin/Activity.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, render, screen } from '@testing-library/react';
 import {
     RoundRobin,
     RoundRobinPlayerStatuses,
 } from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
+import { cleanup, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Activity, getActivitySummary } from './Activity';
@@ -162,7 +162,7 @@ describe('Activity', () => {
         expect(screen.getAllByText('(Withdrawn)')).toHaveLength(1);
         expect(screen.getByText(/15 days ago/)).toBeInTheDocument();
         expect(
-            screen.getByText(/Tournament may have stalled - No games submitted in 15 days/)
+            screen.getByText(/Tournament may have stalled - No games submitted in 15 days/),
         ).toBeInTheDocument();
     });
 
@@ -184,7 +184,7 @@ describe('Activity', () => {
         render(<Activity tournament={tournament} />);
 
         expect(
-            screen.queryByText(/Tournament may have stalled - No games submitted in/)
+            screen.queryByText(/Tournament may have stalled - No games submitted in/),
         ).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/components/tournaments/round-robin/Activity.test.tsx
+++ b/frontend/src/components/tournaments/round-robin/Activity.test.tsx
@@ -1,0 +1,190 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import {
+    RoundRobin,
+    RoundRobinPlayerStatuses,
+} from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Activity, getActivitySummary } from './Activity';
+
+vi.mock('@/components/navigation/Link', async () => {
+    const { forwardRef } = await import('react');
+    return {
+        Link: forwardRef<HTMLAnchorElement, { children: ReactNode; href: string }>(
+            ({ children, href, ...rest }, ref) => (
+                <a ref={ref} href={href} {...rest}>
+                    {children}
+                </a>
+            ),
+        ),
+    };
+});
+
+function createTournament(overrides: Partial<RoundRobin> = {}): RoundRobin {
+    return {
+        type: 'ROUND_ROBIN_TEST',
+        startsAt: 'ACTIVE_2024-06-01T00:00:00.000Z',
+        cohort: '0-1000',
+        name: 'Test Tournament',
+        startDate: '2024-06-01T00:00:00.000Z',
+        endDate: '2024-07-01T00:00:00.000Z',
+        players: {
+            alice: {
+                username: 'alice',
+                displayName: 'Alice',
+                lichessUsername: 'alice_l',
+                chesscomUsername: 'alice_c',
+                discordUsername: 'alice_d',
+                discordId: '1',
+                status: RoundRobinPlayerStatuses.ACTIVE,
+            },
+            bob: {
+                username: 'bob',
+                displayName: 'Bob',
+                lichessUsername: 'bob_l',
+                chesscomUsername: 'bob_c',
+                discordUsername: 'bob_d',
+                discordId: '2',
+                status: RoundRobinPlayerStatuses.ACTIVE,
+            },
+            carol: {
+                username: 'carol',
+                displayName: 'Carol',
+                lichessUsername: 'carol_l',
+                chesscomUsername: 'carol_c',
+                discordUsername: 'carol_d',
+                discordId: '3',
+                status: RoundRobinPlayerStatuses.ACTIVE,
+            },
+        },
+        playerOrder: ['alice', 'bob', 'carol'],
+        pairings: [],
+        updatedAt: '2024-06-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('Activity', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-06-20T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.useRealTimers();
+    });
+
+    it('renders the empty state when no games have been submitted', () => {
+        const tournament = createTournament({
+            pairings: [[{ white: 'alice', black: 'bob' }]],
+        });
+
+        render(<Activity tournament={tournament} />);
+
+        expect(screen.getByText('No games submitted yet')).toBeInTheDocument();
+    });
+
+    it('summarizes activities in reverse submission order and places undated games last', () => {
+        const tournament = createTournament({
+            pairings: [
+                [
+                    {
+                        white: 'alice',
+                        black: 'bob',
+                        result: '1-0',
+                        url: 'https://example.com/game-1',
+                        submittedAt: '2024-06-18T10:00:00Z',
+                    },
+                    {
+                        white: 'carol',
+                        black: 'alice',
+                        result: '0-1',
+                        url: 'https://example.com/game-2',
+                    },
+                ],
+                [
+                    {
+                        white: 'bob',
+                        black: 'carol',
+                        result: '1/2-1/2',
+                        url: 'https://example.com/game-3',
+                        submittedAt: '2024-06-19T09:00:00Z',
+                    },
+                ],
+            ],
+        });
+
+        const summary = getActivitySummary(tournament, new Date('2024-06-20T12:00:00Z'));
+
+        expect(summary.activities.map((activity) => activity.url)).toEqual([
+            'https://example.com/game-3',
+            'https://example.com/game-1',
+            'https://example.com/game-2',
+        ]);
+        expect(summary.completedGames).toBe(3);
+        expect(summary.totalPairings).toBe(3);
+        expect(summary.completionRate).toBe(100);
+        expect(summary.daysSinceLastGame).toBe(1);
+        expect(summary.mostRecentDate?.toISOString()).toBe('2024-06-19T09:00:00.000Z');
+    });
+
+    it('renders withdrawn players and a stall warning for incomplete stale tournaments', () => {
+        const tournament = createTournament({
+            players: {
+                ...createTournament().players,
+                bob: {
+                    ...createTournament().players.bob,
+                    status: RoundRobinPlayerStatuses.WITHDRAWN,
+                },
+            },
+            pairings: [
+                [
+                    {
+                        white: 'alice',
+                        black: 'bob',
+                        result: '1-0',
+                        url: 'https://example.com/game-1',
+                        submittedAt: '2024-06-05T09:00:00Z',
+                    },
+                    {
+                        white: 'alice',
+                        black: 'carol',
+                    },
+                ],
+            ],
+        });
+
+        render(<Activity tournament={tournament} />);
+
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+        expect(screen.getAllByText('(Withdrawn)')).toHaveLength(1);
+        expect(screen.getByText(/15 days ago/)).toBeInTheDocument();
+        expect(
+            screen.getByText(/Tournament may have stalled - No games submitted in 15 days/)
+        ).toBeInTheDocument();
+    });
+
+    it('does not render a stall warning when all pairings are completed', () => {
+        const tournament = createTournament({
+            pairings: [
+                [
+                    {
+                        white: 'alice',
+                        black: 'bob',
+                        result: '1-0',
+                        url: 'https://example.com/game-1',
+                        submittedAt: '2024-06-01T09:00:00Z',
+                    },
+                ],
+            ],
+        });
+
+        render(<Activity tournament={tournament} />);
+
+        expect(
+            screen.queryByText(/Tournament may have stalled - No games submitted in/)
+        ).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/tournaments/round-robin/Activity.tsx
+++ b/frontend/src/components/tournaments/round-robin/Activity.tsx
@@ -1,7 +1,6 @@
 import { Link } from '@/components/navigation/Link';
 import {
     RoundRobin,
-    RoundRobinPairing,
     RoundRobinPlayerStatuses,
 } from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
 import { CalendarMonth } from '@mui/icons-material';
@@ -17,6 +16,7 @@ import {
     TableRow,
     Typography,
 } from '@mui/material';
+import { countTotalGames } from './Stats';
 
 export interface GameActivity {
     white: string;
@@ -26,6 +26,7 @@ export interface GameActivity {
     round: number;
     submittedAt: string;
     date: Date | null;
+    active: boolean;
 }
 
 /**
@@ -47,6 +48,9 @@ export function getActivities(tournament: RoundRobin): GameActivity[] {
                     round: round + 1,
                     submittedAt: p.submittedAt ?? '',
                     date: p.submittedAt ? new Date(p.submittedAt) : null,
+                    active:
+                        tournament.players[p.white].status !== RoundRobinPlayerStatuses.WITHDRAWN &&
+                        tournament.players[p.black].status !== RoundRobinPlayerStatuses.WITHDRAWN,
                 });
             }
         }
@@ -86,11 +90,8 @@ export function getActivitySummary(
         ? Math.floor((now.getTime() - mostRecentDate.getTime()) / (1000 * 60 * 60 * 24))
         : null;
 
-    const totalPairings = tournament.pairings.reduce(
-        (sum: number, round: RoundRobinPairing[]) => sum + round.length,
-        0,
-    );
-    const completedGames = activities.length;
+    const totalPairings = countTotalGames(tournament);
+    const completedGames = activities.filter((a) => a.active).length;
     const completionRate =
         totalPairings > 0 ? Math.round((completedGames / totalPairings) * 100) : 0;
 

--- a/frontend/src/components/tournaments/round-robin/Activity.tsx
+++ b/frontend/src/components/tournaments/round-robin/Activity.tsx
@@ -78,7 +78,7 @@ export interface ActivitySummary {
  */
 export function getActivitySummary(
     tournament: RoundRobin,
-    now: Date = new Date()
+    now: Date = new Date(),
 ): ActivitySummary {
     const activities = getActivities(tournament);
     const mostRecentDate = activities.find((a) => a.date)?.date ?? null;
@@ -88,12 +88,11 @@ export function getActivitySummary(
 
     const totalPairings = tournament.pairings.reduce(
         (sum: number, round: RoundRobinPairing[]) => sum + round.length,
-        0
+        0,
     );
     const completedGames = activities.length;
-    const completionRate = totalPairings > 0
-        ? Math.round((completedGames / totalPairings) * 100)
-        : 0;
+    const completionRate =
+        totalPairings > 0 ? Math.round((completedGames / totalPairings) * 100) : 0;
 
     return {
         activities,
@@ -155,8 +154,8 @@ export function Activity({ tournament }: { tournament: RoundRobin }) {
                             {daysSinceLastGame === 0
                                 ? 'Today'
                                 : daysSinceLastGame === 1
-                                    ? '1 day ago'
-                                    : `${daysSinceLastGame} days ago`}
+                                  ? '1 day ago'
+                                  : `${daysSinceLastGame} days ago`}
                         </Typography>
                         <Typography variant='body2' color='text.secondary'>
                             {mostRecentDate.toLocaleDateString()}
@@ -190,13 +189,12 @@ export function Activity({ tournament }: { tournament: RoundRobin }) {
                         {activities.map((activity, index) => {
                             const prevDateStr = activities[index - 1]?.date?.toDateString() ?? null;
                             const curDateStr = activity.date?.toDateString() ?? null;
-                            const showDateHeader =
-                                index === 0 || prevDateStr !== curDateStr;
+                            const showDateHeader = index === 0 || prevDateStr !== curDateStr;
 
                             const isWithinWeek = activity.date
                                 ? (now.getTime() - activity.date.getTime()) /
-                                (1000 * 60 * 60 * 24) <=
-                                7
+                                      (1000 * 60 * 60 * 24) <=
+                                  7
                                 : false;
 
                             return (
@@ -209,9 +207,7 @@ export function Activity({ tournament }: { tournament: RoundRobin }) {
                                         activity.submittedAt || 'no-date',
                                     ].join('-')}
                                     sx={{
-                                        backgroundColor: isWithinWeek
-                                            ? 'action.hover'
-                                            : 'inherit',
+                                        backgroundColor: isWithinWeek ? 'action.hover' : 'inherit',
                                     }}
                                 >
                                     <TableCell>
@@ -244,14 +240,14 @@ export function Activity({ tournament }: { tournament: RoundRobin }) {
                                         </Link>
                                         {tournament.players[activity.white].status ===
                                             RoundRobinPlayerStatuses.WITHDRAWN && (
-                                                <Typography
-                                                    variant='caption'
-                                                    color='text.secondary'
-                                                    sx={{ ml: 1 }}
-                                                >
-                                                    (Withdrawn)
-                                                </Typography>
-                                            )}
+                                            <Typography
+                                                variant='caption'
+                                                color='text.secondary'
+                                                sx={{ ml: 1 }}
+                                            >
+                                                (Withdrawn)
+                                            </Typography>
+                                        )}
                                     </TableCell>
                                     <TableCell>
                                         <Link href={`/profile/${activity.black}`}>
@@ -259,14 +255,14 @@ export function Activity({ tournament }: { tournament: RoundRobin }) {
                                         </Link>
                                         {tournament.players[activity.black].status ===
                                             RoundRobinPlayerStatuses.WITHDRAWN && (
-                                                <Typography
-                                                    variant='caption'
-                                                    color='text.secondary'
-                                                    sx={{ ml: 1 }}
-                                                >
-                                                    (Withdrawn)
-                                                </Typography>
-                                            )}
+                                            <Typography
+                                                variant='caption'
+                                                color='text.secondary'
+                                                sx={{ ml: 1 }}
+                                            >
+                                                (Withdrawn)
+                                            </Typography>
+                                        )}
                                     </TableCell>
                                     <TableCell align='center'>
                                         <Link href={activity.url}>{activity.result}</Link>
@@ -288,8 +284,8 @@ export function Activity({ tournament }: { tournament: RoundRobin }) {
                     }}
                 >
                     <Typography variant='body2' fontWeight='bold'>
-                        ⚠️ Tournament may have stalled - No games submitted in{' '}
-                        {daysSinceLastGame} days
+                        ⚠️ Tournament may have stalled - No games submitted in {daysSinceLastGame}{' '}
+                        days
                     </Typography>
                 </Box>
             )}

--- a/frontend/src/components/tournaments/round-robin/Activity.tsx
+++ b/frontend/src/components/tournaments/round-robin/Activity.tsx
@@ -1,0 +1,298 @@
+import { Link } from '@/components/navigation/Link';
+import {
+    RoundRobin,
+    RoundRobinPairing,
+    RoundRobinPlayerStatuses,
+} from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
+import { CalendarMonth } from '@mui/icons-material';
+import {
+    Box,
+    Card,
+    Stack,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Typography,
+} from '@mui/material';
+
+export interface GameActivity {
+    white: string;
+    black: string;
+    result: string;
+    url: string;
+    round: number;
+    submittedAt: string;
+    date: Date | null;
+}
+
+/**
+ * Returns the completed games in the tournament ordered by submission date.
+ * Games without submission timestamps are included and sorted after dated games.
+ * @param tournament The tournament to collect activity for.
+ */
+export function getActivities(tournament: RoundRobin): GameActivity[] {
+    const activities: GameActivity[] = [];
+
+    for (let round = 0; round < tournament.pairings.length; round++) {
+        for (const p of tournament.pairings[round]) {
+            if (p.url && p.white && p.black && p.result) {
+                activities.push({
+                    white: p.white,
+                    black: p.black,
+                    result: p.result,
+                    url: p.url,
+                    round: round + 1,
+                    submittedAt: p.submittedAt ?? '',
+                    date: p.submittedAt ? new Date(p.submittedAt) : null,
+                });
+            }
+        }
+    }
+
+    activities.sort((a, b) => {
+        if (!a.date && !b.date) return 0;
+        if (!a.date) return 1;
+        if (!b.date) return -1;
+        return b.date.getTime() - a.date.getTime();
+    });
+
+    return activities;
+}
+
+export interface ActivitySummary {
+    activities: GameActivity[];
+    mostRecentDate: Date | null;
+    daysSinceLastGame: number | null;
+    totalPairings: number;
+    completedGames: number;
+    completionRate: number;
+}
+
+/**
+ * Computes the rendered summary for the activity view.
+ * @param tournament The tournament to summarize.
+ * @param now The current time used for relative date calculations.
+ */
+export function getActivitySummary(
+    tournament: RoundRobin,
+    now: Date = new Date()
+): ActivitySummary {
+    const activities = getActivities(tournament);
+    const mostRecentDate = activities.find((a) => a.date)?.date ?? null;
+    const daysSinceLastGame = mostRecentDate
+        ? Math.floor((now.getTime() - mostRecentDate.getTime()) / (1000 * 60 * 60 * 24))
+        : null;
+
+    const totalPairings = tournament.pairings.reduce(
+        (sum: number, round: RoundRobinPairing[]) => sum + round.length,
+        0
+    );
+    const completedGames = activities.length;
+    const completionRate = totalPairings > 0
+        ? Math.round((completedGames / totalPairings) * 100)
+        : 0;
+
+    return {
+        activities,
+        mostRecentDate,
+        daysSinceLastGame,
+        totalPairings,
+        completedGames,
+        completionRate,
+    };
+}
+
+/**
+ * Renders an activity view of games played in the Round Robin tournament.
+ * @param tournament The tournament to render the activities list for.
+ */
+export function Activity({ tournament }: { tournament: RoundRobin }) {
+    const now = new Date();
+    const {
+        activities,
+        mostRecentDate,
+        daysSinceLastGame,
+        totalPairings,
+        completedGames,
+        completionRate,
+    } = getActivitySummary(tournament, now);
+
+    if (activities.length === 0) {
+        return (
+            <Stack alignItems='center' spacing={2} py={4}>
+                <CalendarMonth sx={{ fontSize: 60, color: 'text.secondary' }} />
+                <Typography textAlign='center' color='text.secondary'>
+                    No games submitted yet
+                </Typography>
+            </Stack>
+        );
+    }
+
+    return (
+        <Stack spacing={3}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                <Card sx={{ flex: 1, p: 2 }}>
+                    <Typography variant='body2' color='text.secondary'>
+                        Games Completed
+                    </Typography>
+                    <Typography variant='h4'>
+                        {completedGames} / {totalPairings}
+                    </Typography>
+                    <Typography variant='body2' color='text.secondary'>
+                        {completionRate}% complete
+                    </Typography>
+                </Card>
+
+                {mostRecentDate && (
+                    <Card sx={{ flex: 1, p: 2 }}>
+                        <Typography variant='body2' color='text.secondary'>
+                            Last Game Submitted
+                        </Typography>
+                        <Typography variant='h4'>
+                            {daysSinceLastGame === 0
+                                ? 'Today'
+                                : daysSinceLastGame === 1
+                                    ? '1 day ago'
+                                    : `${daysSinceLastGame} days ago`}
+                        </Typography>
+                        <Typography variant='body2' color='text.secondary'>
+                            {mostRecentDate.toLocaleDateString()}
+                        </Typography>
+                    </Card>
+                )}
+            </Stack>
+
+            <TableContainer>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>
+                                <Typography fontWeight='bold'>Date</Typography>
+                            </TableCell>
+                            <TableCell align='center'>
+                                <Typography fontWeight='bold'>Round</Typography>
+                            </TableCell>
+                            <TableCell>
+                                <Typography fontWeight='bold'>White</Typography>
+                            </TableCell>
+                            <TableCell>
+                                <Typography fontWeight='bold'>Black</Typography>
+                            </TableCell>
+                            <TableCell align='center'>
+                                <Typography fontWeight='bold'>Result</Typography>
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {activities.map((activity, index) => {
+                            const prevDateStr = activities[index - 1]?.date?.toDateString() ?? null;
+                            const curDateStr = activity.date?.toDateString() ?? null;
+                            const showDateHeader =
+                                index === 0 || prevDateStr !== curDateStr;
+
+                            const isWithinWeek = activity.date
+                                ? (now.getTime() - activity.date.getTime()) /
+                                (1000 * 60 * 60 * 24) <=
+                                7
+                                : false;
+
+                            return (
+                                <TableRow
+                                    key={[
+                                        activity.round,
+                                        activity.white,
+                                        activity.black,
+                                        activity.url,
+                                        activity.submittedAt || 'no-date',
+                                    ].join('-')}
+                                    sx={{
+                                        backgroundColor: isWithinWeek
+                                            ? 'action.hover'
+                                            : 'inherit',
+                                    }}
+                                >
+                                    <TableCell>
+                                        <Stack>
+                                            {showDateHeader && activity.date && (
+                                                <Typography fontWeight='bold'>
+                                                    {activity.date.toLocaleDateString(undefined, {
+                                                        weekday: 'short',
+                                                        month: 'short',
+                                                        day: 'numeric',
+                                                    })}
+                                                </Typography>
+                                            )}
+                                            {activity.date && (
+                                                <Typography variant='body2' color='text.secondary'>
+                                                    {activity.date.toLocaleTimeString(undefined, {
+                                                        hour: 'numeric',
+                                                        minute: '2-digit',
+                                                    })}
+                                                </Typography>
+                                            )}
+                                        </Stack>
+                                    </TableCell>
+                                    <TableCell align='center'>
+                                        <Typography>{activity.round}</Typography>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Link href={`/profile/${activity.white}`}>
+                                            {tournament.players[activity.white].displayName}
+                                        </Link>
+                                        {tournament.players[activity.white].status ===
+                                            RoundRobinPlayerStatuses.WITHDRAWN && (
+                                                <Typography
+                                                    variant='caption'
+                                                    color='text.secondary'
+                                                    sx={{ ml: 1 }}
+                                                >
+                                                    (Withdrawn)
+                                                </Typography>
+                                            )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Link href={`/profile/${activity.black}`}>
+                                            {tournament.players[activity.black].displayName}
+                                        </Link>
+                                        {tournament.players[activity.black].status ===
+                                            RoundRobinPlayerStatuses.WITHDRAWN && (
+                                                <Typography
+                                                    variant='caption'
+                                                    color='text.secondary'
+                                                    sx={{ ml: 1 }}
+                                                >
+                                                    (Withdrawn)
+                                                </Typography>
+                                            )}
+                                    </TableCell>
+                                    <TableCell align='center'>
+                                        <Link href={activity.url}>{activity.result}</Link>
+                                    </TableCell>
+                                </TableRow>
+                            );
+                        })}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+
+            {daysSinceLastGame !== null && daysSinceLastGame > 14 && completionRate < 100 && (
+                <Box
+                    sx={{
+                        p: 2,
+                        backgroundColor: 'warning.light',
+                        borderRadius: 1,
+                        textAlign: 'center',
+                    }}
+                >
+                    <Typography variant='body2' fontWeight='bold'>
+                        ⚠️ Tournament may have stalled - No games submitted in{' '}
+                        {daysSinceLastGame} days
+                    </Typography>
+                </Box>
+            )}
+        </Stack>
+    );
+}

--- a/frontend/src/components/tournaments/round-robin/Tournament.test.tsx
+++ b/frontend/src/components/tournaments/round-robin/Tournament.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+    RoundRobin,
+    RoundRobinPlayerStatuses,
+} from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Tournament } from './Tournament';
+
+vi.mock('@/auth/Auth', () => ({
+    useAuth: () => ({ user: undefined }),
+}));
+
+vi.mock('@/config', () => ({
+    getConfig: () => ({
+        discord: {
+            guildId: 'test-guild',
+        },
+    }),
+}));
+
+vi.mock('@/components/navigation/Link', async () => {
+    const { forwardRef } = await import('react');
+    return {
+        Link: forwardRef<HTMLAnchorElement, { children: ReactNode; href: string }>(
+            ({ children, href, ...rest }, ref) => (
+                <a ref={ref} href={href} {...rest}>
+                    {children}
+                </a>
+            )
+        ),
+    };
+});
+
+vi.mock('./TournamentInfo', () => ({
+    TournamentInfo: () => <div>Tournament Info</div>,
+}));
+
+vi.mock('./Players', () => ({
+    Players: () => <div>Players Panel</div>,
+}));
+
+vi.mock('./Crosstable', () => ({
+    Crosstable: () => <div>Crosstable Panel</div>,
+}));
+
+vi.mock('./Pairings', () => ({
+    Pairings: () => <div>Pairings Panel</div>,
+}));
+
+vi.mock('./Games', () => ({
+    Games: () => <div>Games Panel</div>,
+}));
+
+vi.mock('./Activity', () => ({
+    Activity: () => <div>Activity Panel</div>,
+}));
+
+vi.mock('./Stats', () => ({
+    Stats: () => <div>Stats Panel</div>,
+}));
+
+vi.mock('./SubmitGameModal', () => ({
+    default: () => null,
+}));
+
+vi.mock('./WithdrawModal', () => ({
+    WithdrawModal: () => null,
+}));
+
+function createTournament(overrides: Partial<RoundRobin> = {}): RoundRobin {
+    return {
+        type: 'ROUND_ROBIN_TEST',
+        startsAt: 'ACTIVE_2024-06-01T00:00:00.000Z',
+        cohort: '0-1000',
+        name: 'Test Tournament',
+        startDate: '2024-06-01T00:00:00.000Z',
+        endDate: '2024-07-01T00:00:00.000Z',
+        players: {
+            alice: {
+                username: 'alice',
+                displayName: 'Alice',
+                lichessUsername: 'alice_l',
+                chesscomUsername: 'alice_c',
+                discordUsername: 'alice_d',
+                discordId: '1',
+                status: RoundRobinPlayerStatuses.ACTIVE,
+            },
+            bob: {
+                username: 'bob',
+                displayName: 'Bob',
+                lichessUsername: 'bob_l',
+                chesscomUsername: 'bob_c',
+                discordUsername: 'bob_d',
+                discordId: '2',
+                status: RoundRobinPlayerStatuses.ACTIVE,
+            },
+        },
+        playerOrder: ['alice', 'bob'],
+        pairings: [[]],
+        updatedAt: '2024-06-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('Tournament', () => {
+    afterEach(cleanup);
+
+    it('switches to the Activity tab and renders the Activity panel', () => {
+        render(
+            <Tournament tournament={createTournament()} onUpdateTournaments={vi.fn()} />
+        );
+
+        expect(screen.getByText('Crosstable Panel')).toBeVisible();
+        expect(screen.queryByText('Activity Panel')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Activity' }));
+
+        expect(screen.getByText('Activity Panel')).toBeVisible();
+        expect(screen.queryByText('Crosstable Panel')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/tournaments/round-robin/Tournament.test.tsx
+++ b/frontend/src/components/tournaments/round-robin/Tournament.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import {
     RoundRobin,
     RoundRobinPlayerStatuses,
 } from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Tournament } from './Tournament';
@@ -27,7 +27,7 @@ vi.mock('@/components/navigation/Link', async () => {
                 <a ref={ref} href={href} {...rest}>
                     {children}
                 </a>
-            )
+            ),
         ),
     };
 });
@@ -107,9 +107,7 @@ describe('Tournament', () => {
     afterEach(cleanup);
 
     it('switches to the Activity tab and renders the Activity panel', () => {
-        render(
-            <Tournament tournament={createTournament()} onUpdateTournaments={vi.fn()} />
-        );
+        render(<Tournament tournament={createTournament()} onUpdateTournaments={vi.fn()} />);
 
         expect(screen.getByText('Crosstable Panel')).toBeVisible();
         expect(screen.queryByText('Activity Panel')).not.toBeInTheDocument();

--- a/frontend/src/components/tournaments/round-robin/Tournament.tsx
+++ b/frontend/src/components/tournaments/round-robin/Tournament.tsx
@@ -7,7 +7,12 @@ import {
     RoundRobin,
     RoundRobinPlayerStatuses,
 } from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
-import { CalendarMonth, PeopleAlt, TableChart, Timeline as TimelineIcon } from '@mui/icons-material';
+import {
+    CalendarMonth,
+    PeopleAlt,
+    TableChart,
+    Timeline as TimelineIcon,
+} from '@mui/icons-material';
 import { TabContext, TabPanel } from '@mui/lab';
 import {
     Button,
@@ -21,12 +26,12 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import { GiCrossedSwords } from 'react-icons/gi';
+import { Activity } from './Activity';
 import { Crosstable } from './Crosstable';
 import { Games } from './Games';
 import { Pairings } from './Pairings';
 import { Players } from './Players';
 import { Stats } from './Stats';
-import { Activity } from './Activity';
 import SubmitGameModal from './SubmitGameModal';
 import { WithdrawModal } from './WithdrawModal';
 
@@ -52,7 +57,7 @@ export function Tournament({
             <CardContent>
                 {user &&
                     tournament.players[user.username]?.status ===
-                    RoundRobinPlayerStatuses.ACTIVE && (
+                        RoundRobinPlayerStatuses.ACTIVE && (
                         <Stack sx={{ mt: -2, mb: 3 }} gap={2}>
                             <Stack direction='row' gap={1}>
                                 <Button

--- a/frontend/src/components/tournaments/round-robin/Tournament.tsx
+++ b/frontend/src/components/tournaments/round-robin/Tournament.tsx
@@ -7,7 +7,7 @@ import {
     RoundRobin,
     RoundRobinPlayerStatuses,
 } from '@jackstenglein/chess-dojo-common/src/roundRobin/api';
-import { PeopleAlt, TableChart, Timeline } from '@mui/icons-material';
+import { CalendarMonth, PeopleAlt, TableChart, Timeline as TimelineIcon } from '@mui/icons-material';
 import { TabContext, TabPanel } from '@mui/lab';
 import {
     Button,
@@ -26,6 +26,7 @@ import { Games } from './Games';
 import { Pairings } from './Pairings';
 import { Players } from './Players';
 import { Stats } from './Stats';
+import { Activity } from './Activity';
 import SubmitGameModal from './SubmitGameModal';
 import { WithdrawModal } from './WithdrawModal';
 
@@ -51,7 +52,7 @@ export function Tournament({
             <CardContent>
                 {user &&
                     tournament.players[user.username]?.status ===
-                        RoundRobinPlayerStatuses.ACTIVE && (
+                    RoundRobinPlayerStatuses.ACTIVE && (
                         <Stack sx={{ mt: -2, mb: 3 }} gap={2}>
                             <Stack direction='row' gap={1}>
                                 <Button
@@ -98,7 +99,8 @@ export function Tournament({
                             icon={<GiCrossedSwords size={24} />}
                         />
                         <Tab label='Games' value='games' icon={<PawnIcon />} />
-                        <Tab label='Stats' value='stats' icon={<Timeline />} />
+                        <Tab label='Activity' value='activity' icon={<CalendarMonth />} />
+                        <Tab label='Stats' value='stats' icon={<TimelineIcon />} />
                     </Tabs>
 
                     <TabPanel value='players' sx={{ px: 0 }}>
@@ -115,6 +117,10 @@ export function Tournament({
 
                     <TabPanel value='games' sx={{ px: 0 }}>
                         <Games tournament={tournament} />
+                    </TabPanel>
+
+                    <TabPanel value='activity' sx={{ px: 0 }}>
+                        <Activity tournament={tournament} />
                     </TabPanel>
 
                     <TabPanel value='stats' sx={{ px: 0 }}>


### PR DESCRIPTION
This is my first Pull Request and my first work with TypeScript and web development. I made heavy use of AI for coding, but reviewed every snippet until I understood it. Please keep this in mind during review.

The originating ticket hinted at a calendar-like view, but I couldn't design one that felt clean and simple, so I went with the approach you see here — open to discussion.

I'm not entirely convinced the "stale tournament" warning bar is necessary since the activity data already conveys that information, but I included it as a starting point for discussion.


- Add Activity component showing completed games sorted by submission date
- Display summary cards (games completed, days since last game)
- Show stall warning when no games submitted in 14+ days
- Add submittedAt field to RoundRobinPairingSchema
- Wire Activity tab into Tournament component
- Add unit tests for Activity and Tournament tab switching

## Summary

Added a mechanism to show RR tournament activities, in particular highlighting if the tournament has gone stale. This has been done through a table of dated games and two cards showing the number of played games and last game's date.

## Related Issues

https://github.com/jackstenglein/chess-dojo/issues/1420
Fixes #1420

## Type of change

*   [x] New feature (non-breaking change which adds functionality)

## Testing

* [x] New unit tests (vitest) were added

## Demo

Active tournament:
<img width="1817" height="666" alt="screenshot_active" src="https://github.com/user-attachments/assets/f831ab54-3125-4b73-a455-b648df85ba4d" />

Active tournament where some games have no date (to check back compatibility):
<img width="1767" height="750" alt="screenshot_activeWithDatesMissing" src="https://github.com/user-attachments/assets/d267b8d6-6256-4970-abd8-2deda7a3d9fd" />

Active tournament with withdrawn players:
<img width="1105" height="561" alt="screenshot_activeWithWithdrawns" src="https://github.com/user-attachments/assets/efdc22bc-bca4-45a0-850c-baed501e5bec" />

Tournament with no games:
<img width="1267" height="172" alt="screenshot_noGames" src="https://github.com/user-attachments/assets/55ef5f67-e1e5-4a4d-85fc-93eee0f1980d" />

Stalled tournament:
<img width="1096" height="657" alt="screenshot_stalled" src="https://github.com/user-attachments/assets/cc7f9dca-4f10-48c9-9a7e-e3b039d462d5" />

