### PR TITLE
feat(#2055): Allow user to hide / archive tasks

### DIFF
--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -330,6 +330,9 @@ type User struct {
 	// The IDs of the user's pinned tasks.
 	PinnedTasks []string `dynamodbav:"pinnedTasks,omitempty" json:"pinnedTasks"`
 
+	// The IDs of the user's archived tasks
+	ArchivedTasks []string `dynamodbav:"archivedTasks,omitempty" json:"archivedTasks"`
+
 	// The day the user's week starts on. Sunday is 0; Saturday is 6.
 	WeekStart int `dynamodbav:"weekStart,omitempty" json:"weekStart"`
 
@@ -439,6 +442,9 @@ type WeeklyPlan struct {
 
 	// The ids of the user's pinned tasks (in order) when the weekly plan was last generated.
 	PinnedTasks []string `dynamodbav:"pinnedTasks,omitempty" json:"pinnedTasks,omitempty"`
+
+	// The IDs of the user's archived tasks when the weekly plan was last generated.
+	ArchivedTasks []string `dynamodbav:"archivedTasks,omitempty" json:"archivedTasks,omitempty"`
 
 	// The date (in ISO 8601) of the user's next scheduled game when the weekly plan was last generated.
 	NextGame string `dynamodbav:"nextGame,omitempty" json:"nextGame"`
@@ -803,6 +809,9 @@ type UserUpdate struct {
 
 	// The IDs of the user's pinned tasks.
 	PinnedTasks *[]string `dynamodbav:"pinnedTasks,omitempty" json:"pinnedTasks,omitempty"`
+
+	// The IDs of the user's archived tasks
+	ArchivedTasks *[]string `dynamodbav:"archivedTasks,omitempty" json:"archivedTasks,omitempty"`
 
 	// The day the user's week starts on. Sunday is 0; Saturday is 6.
 	WeekStart *int `dynamodbav:"weekStart,omitempty" json:"weekStart,omitempty"`

--- a/common/src/database/user.ts
+++ b/common/src/database/user.ts
@@ -100,6 +100,9 @@ export interface User {
     /** The IDs of the user's pinned tasks. */
     pinnedTasks?: string[];
 
+    /** The IDs of the user's archived tasks. */
+    archivedTasks?: string[];
+
     /** The day the user's week starts on. Sunday is 0; Saturday is 6. */
     weekStart: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -195,6 +198,8 @@ export interface WeeklyPlan {
     progressUpdatedAt: string;
     /** The ids of the user's pinned tasks (in order) when the weekly plan was last generated. */
     pinnedTasks?: string[];
+    /** The ids of the user's archived tasks when the weekly plan was last generated. */
+    archivedTasks?: string[];
     /** The date (in ISO 8601) of the user's next scheduled game when the weekly plan was last generated. */
     nextGame: string;
     /** The ids of the user's skipped tasks (in order) when the weekly plan was last generated. */

--- a/frontend/playwright/tests/e2e/profile/trainingPlan/CustomTaskEditor.spec.ts
+++ b/frontend/playwright/tests/e2e/profile/trainingPlan/CustomTaskEditor.spec.ts
@@ -48,6 +48,7 @@ test.describe('Custom Task Editor', () => {
                             referralSource: 'Reddit',
                             totalDojoScore: 2,
                             pinnedTasks: [],
+                            archivedTasks: [],
                             weekStart: 0,
                         }),
                     });

--- a/frontend/src/components/profile/trainingPlan/DeleteCustomTaskModal.tsx
+++ b/frontend/src/components/profile/trainingPlan/DeleteCustomTaskModal.tsx
@@ -64,7 +64,7 @@ const DeleteCustomTaskModal: React.FC<DeleteCustomTaskModalProps> = ({
             <DialogContent>
                 <DialogContentText>
                     This custom task will be removed from your profile, and all time logged will be
-                    lost. This action is irreverisble.
+                    lost. This action is irreversible.
                 </DialogContentText>
             </DialogContent>
             <DialogActions>

--- a/frontend/src/components/profile/trainingPlan/TaskDialog.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/TaskDialog.test.tsx
@@ -1,0 +1,258 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { User } from '@/database/user';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { createContext } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TaskDialog, TaskDialogView } from './TaskDialog';
+import { TrainingPlanContext } from './TrainingPlanTab';
+
+vi.mock('@/api/cache/requirements', () => ({
+    useRequirements: () => ({ requirements: [] }),
+}));
+
+vi.mock('@/auth/Auth', () => ({
+    useAuth: () => ({ user: makeUser([]) }),
+    useFreeTier: () => false,
+}));
+
+vi.mock('@/components/profile/activity/useTimeline', () => ({
+    useTimelineContext: () => ({ entries: [] }),
+}));
+
+vi.mock('@/board/pgn/boardTools/underboard/clock/ClockUsage', () => ({
+    formatTime: (seconds: number) => `${seconds}s`,
+}));
+
+vi.mock('@/components/profile/trainingPlan/DeleteCustomTaskModal', () => ({
+    default: () => null,
+}));
+
+vi.mock('@/components/profile/trainingPlan/Position', () => ({
+    default: () => null,
+}));
+
+vi.mock('@/components/profile/trainingPlan/ProgressHistory', () => ({
+    default: () => null,
+}));
+
+vi.mock('@/components/profile/trainingPlan/ProgressUpdater', () => ({
+    ProgressUpdater: () => null,
+}));
+
+vi.mock('@/components/ui/ModalTitle', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('./CustomTaskEditor', () => ({
+    default: () => null,
+}));
+
+vi.mock('./TaskDescription', () => ({
+    TaskDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('./TrainingPlanTab', () => ({
+    TrainingPlanContext: createContext(null),
+}));
+
+vi.mock('@/components/timer/TimerContext', () => ({
+    TimerContext: createContext({
+        timerSeconds: 0,
+        isRunning: false,
+        isPaused: false,
+        task: undefined,
+        showTask: false,
+        setShowTask: () => undefined,
+        onStart: () => undefined,
+        onPause: () => undefined,
+        onToggle: () => undefined,
+        onClear: () => undefined,
+        getLabel: () => 'Start Timer',
+    }),
+}));
+
+const mockFreeUser: User = {
+    username: 'test-user',
+    displayName: 'Test User',
+    discordUsername: '',
+    dojoCohort: '1400-1500',
+    bio: '',
+    ratingSystem: 'CHESSCOM' as User['ratingSystem'],
+    ratings: {},
+    progress: {},
+    disableBookingNotifications: false,
+    disableCancellationNotifications: false,
+    isAdmin: false,
+    isCalendarAdmin: false,
+    isTournamentAdmin: false,
+    isBetaTester: false,
+    isCoach: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    numberOfGraduations: 0,
+    previousCohort: '',
+    lastGraduatedAt: '',
+    enableLightMode: false,
+    enableZenMode: false,
+    timezoneOverride: 'DEFAULT',
+    timeFormat: '24' as User['timeFormat'],
+    hasCreatedProfile: true,
+    followerCount: 0,
+    followingCount: 0,
+    referralSource: '',
+    totalDojoScore: 0,
+    subscriptionStatus: 'NOT_SUBSCRIBED' as User['subscriptionStatus'],
+    subscriptionTier: 'FREE' as User['subscriptionTier'],
+    exams: {},
+    weekStart: 0,
+    gameSchedule: [],
+    archivedTasks: [],
+};
+
+function makeRequirement(id: string): Requirement {
+    return {
+        id,
+        status: RequirementStatus.Active,
+        category: RequirementCategory.Games,
+        name: `Task ${id}`,
+        description: 'Task description',
+        freeDescription: '',
+        counts: { '1400-1500': 1 },
+        startCount: 0,
+        numberOfCohorts: 1,
+        unitScore: 0,
+        totalScore: 0,
+        scoreboardDisplay: ScoreboardDisplay.ProgressBar,
+        progressBarSuffix: '',
+        updatedAt: '2026-01-01T00:00:00Z',
+        sortPriority: id,
+        expirationDays: -1,
+        isFree: true,
+        atomic: false,
+        expectedMinutes: 0,
+    };
+}
+
+function makeUser(archivedTasks: string[]): User {
+    return {
+        ...mockFreeUser,
+        archivedTasks,
+    };
+}
+
+function renderTaskDialog({
+    archivedTasks = [],
+    isCurrentUser = true,
+    isArchivableTaskId = () => true,
+    toggleArchived = vi.fn(),
+}: {
+    archivedTasks?: string[];
+    isCurrentUser?: boolean;
+    isArchivableTaskId?: (taskId: string) => boolean;
+    toggleArchived?: ReturnType<typeof vi.fn>;
+}) {
+    const task = makeRequirement('task-1');
+    const user = makeUser(archivedTasks);
+
+    render(
+        <TrainingPlanContext
+            value={
+                {
+                    user,
+                    isCurrentUser,
+                    toggleArchived,
+                    isArchivableTaskId,
+                } as never
+            }
+        >
+            <TaskDialog
+                open
+                onClose={() => undefined}
+                task={task}
+                initialView={TaskDialogView.Details}
+                progress={undefined}
+                cohort='1400-1500'
+            />
+        </TrainingPlanContext>,
+    );
+
+    return { task, toggleArchived };
+}
+
+function renderTaskDialogWithoutTrainingPlanContext() {
+    const task = makeRequirement('task-1');
+
+    render(
+        <TaskDialog
+            open
+            onClose={() => undefined}
+            task={task}
+            initialView={TaskDialogView.Details}
+            progress={undefined}
+            cohort='1400-1500'
+        />,
+    );
+}
+
+describe('TaskDialog', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe('Archive Task Button', () => {
+        it('shows Archive Task for current users when task is not archived', () => {
+            renderTaskDialog({ archivedTasks: [] });
+
+            expect(screen.getByRole('button', { name: 'Archive Task' })).toBeInTheDocument();
+        });
+
+        it('shows Unarchive Task for current users when task is archived', () => {
+            renderTaskDialog({ archivedTasks: ['task-1'] });
+
+            expect(screen.getByRole('button', { name: 'Unarchive Task' })).toBeInTheDocument();
+        });
+
+        it('disables the archive button when the task cannot be archived', () => {
+            renderTaskDialog({ isArchivableTaskId: () => false });
+
+            expect(screen.getByRole('button', { name: 'Archive Task' })).toBeDisabled();
+        });
+
+        it('does not show archive controls for non-current users', () => {
+            renderTaskDialog({ isCurrentUser: false });
+
+            expect(screen.queryByRole('button', { name: 'Archive Task' })).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Unarchive Task' }),
+            ).not.toBeInTheDocument();
+        });
+
+        it('calls toggleArchived when archive button is clicked', () => {
+            const toggleArchived = vi.fn();
+            const { task } = renderTaskDialog({ toggleArchived });
+
+            const archiveButton = screen.getByRole('button', {
+                name: 'Archive Task',
+            });
+
+            act(() => archiveButton.click());
+
+            expect(toggleArchived).toHaveBeenCalledWith(task);
+        });
+
+        it('does not show archive controls without valid TrainingPlanContext', () => {
+            renderTaskDialogWithoutTrainingPlanContext();
+
+            expect(screen.queryByRole('button', { name: 'Archive Task' })).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Unarchive Task' }),
+            ).not.toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/TaskDialog.tsx
+++ b/frontend/src/components/profile/trainingPlan/TaskDialog.tsx
@@ -19,7 +19,17 @@ import {
     ScoreboardDisplay,
 } from '@/database/requirement';
 import { ALL_COHORTS, compareCohorts, dojoCohorts } from '@/database/user';
-import { AccessAlarm, Check, Lock, Loop, Pause, PlayArrow, Scoreboard } from '@mui/icons-material';
+import {
+    AccessAlarm,
+    Archive,
+    Check,
+    Lock,
+    Loop,
+    Pause,
+    PlayArrow,
+    Scoreboard,
+    Unarchive,
+} from '@mui/icons-material';
 import {
     Box,
     Button,
@@ -36,6 +46,7 @@ import {
 import { use, useMemo, useState } from 'react';
 import CustomTaskEditor from './CustomTaskEditor';
 import { TaskDescription } from './TaskDescription';
+import { TrainingPlanContext } from './TrainingPlanTab';
 
 export enum TaskDialogView {
     Details = 'DETAILS',
@@ -130,7 +141,21 @@ type DetailsDialogProps = Pick<TaskDialogProps, 'task' | 'onClose' | 'cohort'> &
 };
 
 function DetailsDialog({ task, onClose, cohort, setView }: DetailsDialogProps) {
-    const { user } = useAuth();
+    const auth = useAuth();
+    const trainingPlan = use(TrainingPlanContext);
+
+    // If the training plan exists, use that. Otherwise fall back to hardcoded values.
+    // NOTE: The fallback case represents cases where archival functionality shouldn't be
+    //       displayed at all, so we can leave toggleArchived and isArchivableTaskId undefined
+    const { user, isCurrentUser, toggleArchived, isArchivableTaskId } = trainingPlan
+        ? trainingPlan
+        : {
+              user: auth.user,
+              isCurrentUser: false,
+              toggleArchived: undefined,
+              isArchivableTaskId: undefined,
+          };
+
     const { entries: timeline } = useTimelineContext();
     const [showEditor, setShowEditor] = useState(false);
     const [showDeleter, setShowDeleter] = useState(false);
@@ -202,6 +227,7 @@ function DetailsDialog({ task, onClose, cohort, setView }: DetailsDialogProps) {
     const totalCount = task.counts[selectedCohort] || task.counts[ALL_COHORTS];
     const currentCount = progress?.counts?.[selectedCohort] || progress?.counts?.[ALL_COHORTS] || 0;
     const isCompleted = currentCount >= totalCount;
+    const isArchived = user?.archivedTasks?.includes(task.id) ?? false;
 
     let requirementName = task.name.replaceAll('{{count}}', `${totalCount}`);
     if (task.scoreboardDisplay === ScoreboardDisplay.Checkbox && totalCount > 1) {
@@ -307,28 +333,49 @@ function DetailsDialog({ task, onClose, cohort, setView }: DetailsDialogProps) {
                 </Stack>
             </DialogContent>
             <DialogActions sx={{ flexWrap: 'wrap' }}>
-                <Box sx={{ flexGrow: 1 }}>
-                    {timerRunning ? (
-                        <Button
-                            color='warning'
-                            startIcon={<Pause />}
-                            onClick={() => {
-                                onPauseTimer();
-                                setView(TaskDialogView.Progress);
-                            }}
+                {isCurrentUser && (
+                    <Box sx={{ flexGrow: 1 }}>
+                        {timerRunning ? (
+                            <Button
+                                color='warning'
+                                startIcon={<Pause />}
+                                onClick={() => {
+                                    onPauseTimer();
+                                    setView(TaskDialogView.Progress);
+                                }}
+                            >
+                                Pause Timer ({formatTime(timerSeconds)})
+                            </Button>
+                        ) : (
+                            <Button
+                                color={timerIsOtherTask ? 'error' : 'warning'}
+                                startIcon={<PlayArrow />}
+                                onClick={() => onStartTimer(task.id)}
+                            >
+                                {getTimerLabel(task.id)}
+                            </Button>
+                        )}
+                        <Tooltip
+                            title={
+                                isArchivableTaskId?.(task.id)
+                                    ? isArchived
+                                        ? `Unarchive and restore to your active training plan`
+                                        : `Archive and remove from your active training plan`
+                                    : 'This task cannot be archived.'
+                            }
                         >
-                            Pause Timer ({formatTime(timerSeconds)})
-                        </Button>
-                    ) : (
-                        <Button
-                            color={timerIsOtherTask ? 'error' : 'warning'}
-                            startIcon={<PlayArrow />}
-                            onClick={() => onStartTimer(task.id)}
-                        >
-                            {getTimerLabel(task.id)}
-                        </Button>
-                    )}
-                </Box>
+                            <span>
+                                <Button
+                                    onClick={() => toggleArchived?.(task)}
+                                    startIcon={isArchived ? <Unarchive /> : <Archive />}
+                                    disabled={!isArchivableTaskId?.(task.id)}
+                                >
+                                    {isArchived ? `Unarchive Task` : `Archive Task`}
+                                </Button>
+                            </span>
+                        </Tooltip>
+                    </Box>
+                )}
 
                 <Button onClick={onClose}>Cancel</Button>
                 <Button onClick={() => setView(TaskDialogView.Progress)}>Update Progress</Button>

--- a/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.test.tsx
@@ -1,0 +1,138 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TrainingPlanContext } from '../TrainingPlanTab';
+import { DailyTrainingPlan } from './DailyTrainingPlan';
+
+vi.mock('usehooks-ts', () => ({
+    useLocalStorage: () => [true, vi.fn()],
+}));
+
+vi.mock('@/style/ThemeProvider', () => ({
+    themeRequirementCategory: () => 'primary',
+}));
+
+vi.mock('../full/FullTrainingPlanItem', () => ({
+    displayProgress: () => false,
+}));
+
+vi.mock('../useTrainingPlan', () => ({
+    useTrainingPlanProgress: () => [30, 0, 0, new Set<string>()],
+}));
+
+vi.mock('../WorkGoalSettingsEditor', () => ({
+    WorkGoalSettingsEditor: () => null,
+}));
+
+vi.mock('../ScheduleClassicalGame', () => ({
+    ScheduleClassicalGameDaily: () => null,
+}));
+
+vi.mock('./GraduationTask', () => ({
+    GraduationTask: () => null,
+}));
+
+vi.mock('./TaskTimerIconButton', () => ({
+    TaskTimerIconButton: () => null,
+}));
+
+vi.mock('../TaskDialog', () => ({
+    TaskDialog: () => null,
+    TaskDialogView: {
+        Details: 'DETAILS',
+        Progress: 'PROGRESS',
+    },
+}));
+
+vi.mock('../TaskDescription', () => ({
+    TaskDescription: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function makeRequirement(id: string): Requirement {
+    return {
+        id,
+        status: RequirementStatus.Active,
+        category: RequirementCategory.Games,
+        name: `Task ${id}`,
+        description: '',
+        freeDescription: '',
+        counts: { '1400-1500': 1 },
+        startCount: 0,
+        numberOfCohorts: 1,
+        unitScore: 0,
+        totalScore: 0,
+        scoreboardDisplay: ScoreboardDisplay.ProgressBar,
+        progressBarSuffix: '',
+        updatedAt: '2026-01-01T00:00:00Z',
+        sortPriority: id,
+        expirationDays: -1,
+        isFree: true,
+        atomic: false,
+        expectedMinutes: 0,
+    };
+}
+
+function makeSuggestions(task: Requirement) {
+    const suggestionsByDay = Array.from(
+        { length: 7 },
+        () => [] as { task: Requirement; goalMinutes: number }[],
+    );
+    suggestionsByDay[new Date().getDay()] = [{ task, goalMinutes: 30 }];
+    return suggestionsByDay;
+}
+
+function renderDailyTrainingPlan(archivedTasks: string[]) {
+    const task = makeRequirement('task-1');
+    const contextValue = {
+        suggestionsByDay: makeSuggestions(task),
+        isCurrentUser: true,
+        timeline: [],
+        isLoading: false,
+        user: {
+            dojoCohort: '1400-1500',
+            progress: {},
+            archivedTasks,
+            weekStart: 0,
+            workGoal: undefined,
+            workGoalHistory: [],
+            customTasks: [],
+        },
+        skippedTaskIds: [],
+        allRequirements: [task],
+        pinnedTasks: [],
+        togglePin: () => undefined,
+        toggleSkip: () => undefined,
+    };
+
+    render(
+        <TrainingPlanContext value={contextValue as never}>
+            <DailyTrainingPlan />
+        </TrainingPlanContext>,
+    );
+}
+
+describe('DailyTrainingPlan', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe('Archived task display', () => {
+        it('shows an Archived chip when the task is archived', () => {
+            renderDailyTrainingPlan(['task-1']);
+
+            expect(screen.getByText('Archived')).toBeInTheDocument();
+        });
+
+        it('does not show an Archived chip when the task is not archived', () => {
+            renderDailyTrainingPlan([]);
+
+            expect(screen.queryByText('Archived')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
@@ -246,12 +246,22 @@ function DailyTrainingPlanItem({
                     <CardContent sx={{ height: 1 }}>
                         <Stack sx={{ height: 1 }}>
                             <Stack spacing={1} alignItems='start'>
-                                <Chip
-                                    variant='outlined'
-                                    label={displayRequirementCategory(task.category)}
-                                    color={themeRequirementCategory(task.category)}
-                                    size='small'
-                                />
+                                <Stack direction='row' spacing={1} alignItems='start'>
+                                    <Chip
+                                        variant='outlined'
+                                        label={displayRequirementCategory(task.category)}
+                                        color={themeRequirementCategory(task.category)}
+                                        size='small'
+                                    />
+                                    {user.archivedTasks?.includes(task.id) && (
+                                        <Chip
+                                            variant='outlined'
+                                            label='Archived'
+                                            color='default'
+                                            size='small'
+                                        />
+                                    )}
+                                </Stack>
 
                                 <Typography variant='h6' fontWeight='bold'>
                                     {taskTitle({ task, cohort: user.dojoCohort, goalMinutes })}

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.test.tsx
@@ -1,0 +1,454 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { User } from '@/database/user';
+import { useMediaQuery } from '@mui/material';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { TrainingPlanContext } from '../TrainingPlanTab';
+import { FullTrainingPlan } from './FullTrainingPlan';
+import { GRADUATION_TASK_ID } from './FullTrainingPlanSection';
+
+interface MockSectionProps {
+    section: {
+        category: RequirementCategory;
+        archivedTaskIds: Set<string>;
+    };
+    showArchived: boolean;
+}
+
+const USER_COHORT = '1400-1500';
+const OTHER_COHORT = '1800-1900';
+
+const spies = vi.hoisted(() => ({
+    sectionProps: vi.fn(),
+    localStorageData: {
+        setShowArchived: vi.fn(),
+    },
+}));
+
+vi.mock('../TrainingPlanTab', async () => {
+    const React = await vi.importActual<typeof import('react')>('react');
+    return {
+        TrainingPlanContext: React.createContext(null as never),
+    };
+});
+
+vi.mock('@mui/material', async () => {
+    const actual = await vi.importActual<typeof import('@mui/material')>('@mui/material');
+    return {
+        ...actual,
+        useMediaQuery: vi.fn(() => false),
+    };
+});
+
+vi.mock('usehooks-ts', async () => {
+    const React = await vi.importActual<typeof import('react')>('react');
+    return {
+        useLocalStorage: (_key: string, initialValue: boolean) => {
+            const [showArchived, setShowArchived] = React.useState(initialValue);
+            return [
+                showArchived,
+                (value: boolean) => {
+                    spies.localStorageData.setShowArchived(value);
+                    setShowArchived(value);
+                },
+            ] as const;
+        },
+    };
+});
+
+vi.mock('./FullTrainingPlanSection', () => {
+    return {
+        GRADUATION_TASK_ID: 'GRADUATION_TASK',
+        FullTrainingPlanSection: spies.sectionProps,
+    };
+});
+
+function makeRequirement(id: string, isFree = true): Requirement {
+    return {
+        id,
+        status: RequirementStatus.Active,
+        category: RequirementCategory.Games,
+        name: `Task ${id}`,
+        description: '',
+        freeDescription: '',
+        counts: { [USER_COHORT]: 1 },
+        startCount: 0,
+        numberOfCohorts: 1,
+        unitScore: 0,
+        totalScore: 1,
+        scoreboardDisplay: ScoreboardDisplay.ProgressBar,
+        progressBarSuffix: '',
+        updatedAt: '2026-01-01T00:00:00Z',
+        sortPriority: id,
+        expirationDays: -1,
+        isFree: isFree,
+        atomic: false,
+        expectedMinutes: 0,
+        subscriptionTiers: isFree
+            ? (['FREE', 'BASIC', 'LECTURE', 'GAME_REVIEW'] as Requirement['subscriptionTiers'])
+            : (['BASIC', 'LECTURE', 'GAME_REVIEW'] as Requirement['subscriptionTiers']),
+    };
+}
+
+const mockFreeUser: User = {
+    username: '',
+    displayName: '',
+    discordUsername: '',
+    dojoCohort: USER_COHORT,
+    bio: '',
+    ratingSystem: 'CHESSCOM' as User['ratingSystem'],
+    ratings: {},
+    progress: {},
+    disableBookingNotifications: false,
+    disableCancellationNotifications: false,
+    isAdmin: false,
+    isCalendarAdmin: false,
+    isTournamentAdmin: false,
+    isBetaTester: false,
+    isCoach: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    numberOfGraduations: 0,
+    previousCohort: '',
+    lastGraduatedAt: '',
+    enableLightMode: false,
+    enableZenMode: false,
+    timezoneOverride: 'DEFAULT',
+    timeFormat: '24' as User['timeFormat'],
+    hasCreatedProfile: true,
+    followerCount: 0,
+    followingCount: 0,
+    referralSource: '',
+    totalDojoScore: 0,
+    subscriptionStatus: 'NOT_SUBSCRIBED' as User['subscriptionStatus'],
+    subscriptionTier: 'FREE' as User['subscriptionTier'],
+    exams: {},
+    weekStart: 0,
+    gameSchedule: [],
+};
+
+function renderTrainingPlan(
+    archivedTaskIds: string[],
+    userCohort: string,
+    userIsFree = true,
+    currentUser = true,
+) {
+    const user = userIsFree
+        ? { ...mockFreeUser, dojoCohort: userCohort, archivedTaskIds: archivedTaskIds }
+        : {
+              ...mockFreeUser,
+              dojoCohort: userCohort,
+              archivedTaskIds: archivedTaskIds,
+              subscriptionTier: 'BASIC' as User['subscriptionTier'],
+              subscriptionStatus: 'SUBSCRIBED' as User['subscriptionStatus'],
+          };
+
+    const allRequirements = [
+        makeRequirement('free-task', true),
+        { ...makeRequirement('free-task-2', true), category: RequirementCategory.Opening },
+        makeRequirement('paid-task', false),
+    ];
+
+    const contextValue = {
+        user: user,
+        timeline: [],
+        request: {
+            isLoading: () => false,
+        },
+        requirements: allRequirements,
+        allRequirements,
+        pinnedTasks: [],
+        archivedTaskIds,
+        togglePin: () => undefined,
+        toggleArchived: () => undefined,
+        isCurrentUser: currentUser,
+        skippedTaskIds: [],
+        toggleSkip: () => undefined,
+        isArchivableTaskId: () => true,
+        suggestionsByDay: [],
+        weekSuggestions: [],
+        startDate: '',
+        endDate: '',
+        isLoading: false,
+    };
+
+    render(
+        <TrainingPlanContext value={contextValue as never}>
+            <FullTrainingPlan cohort={userCohort} setCohort={() => 0} />
+        </TrainingPlanContext>,
+    );
+}
+
+describe(`FullTrainingPlan`, () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe(`"Show Archived Tasks" checkbox`, () => {
+        describe('Visibility conditions', () => {
+            it('displays the correct button for large screens', () => {
+                // Defensively make sure the media query is mocked to false
+                (useMediaQuery as MockedFunction<typeof useMediaQuery>).mockReturnValue(false);
+
+                renderTrainingPlan(['free-task'], USER_COHORT);
+
+                const button = screen.getByRole('button', { name: 'Show Archived Tasks' });
+
+                // It should be a text button
+                expect(button.textContent).toBe('Show Archived Tasks');
+            });
+
+            it('hides the Show Archived Tasks checkbox when there are no archived tasks', () => {
+                renderTrainingPlan([], USER_COHORT);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('shows the Show Archived Tasks checkbox when free users have archived free tasks in the visible cohort', () => {
+                renderTrainingPlan(['free-task', 'free-task-2', 'paid-task'], USER_COHORT);
+
+                expect(
+                    screen.getByRole('button', { name: 'Show Archived Tasks' }),
+                ).toBeInTheDocument();
+            });
+
+            it('shows the Show Archived Tasks checkbox when paid users have paid archived tasks in the visible cohort', () => {
+                renderTrainingPlan(['paid-task'], USER_COHORT, false);
+
+                expect(
+                    screen.getByRole('button', { name: 'Show Archived Tasks' }),
+                ).toBeInTheDocument();
+            });
+
+            it('shows the Show Archived Tasks checkbox when paid users have free archived tasks in the visible cohort', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT, false);
+
+                expect(
+                    screen.getByRole('button', { name: 'Show Archived Tasks' }),
+                ).toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox when archived tasks are not in the visible cohort', () => {
+                renderTrainingPlan(['free-task'], OTHER_COHORT);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox when free users have only paid archived tasks', () => {
+                renderTrainingPlan(['paid-task'], USER_COHORT, true);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox when archived task ids are not in the training plan', () => {
+                renderTrainingPlan(['task-not-in-plan'], USER_COHORT);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox for non-current users', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT, true, false);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        describe('Functionality', () => {
+            it('shows archived tasks when Show Archived Tasks is checked', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT);
+
+                const showArchivedButton = screen.getByRole('button', {
+                    name: 'Show Archived Tasks',
+                });
+
+                // Toggle to checked
+                act(() => showArchivedButton.click());
+
+                expect(spies.sectionProps.mock.calls.at(-1)?.[0]).toHaveProperty(
+                    'showArchived',
+                    true,
+                );
+            });
+
+            it('hides archived tasks when Show Archived Tasks is unchecked', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT);
+
+                const showArchivedButton = screen.getByRole('button', {
+                    name: 'Show Archived Tasks',
+                });
+
+                // Toggle to unchecked
+                act(() => showArchivedButton.click());
+                act(() => showArchivedButton.click());
+
+                expect(spies.sectionProps.mock.calls.at(-1)?.[0]).toHaveProperty(
+                    'showArchived',
+                    false,
+                );
+            });
+
+            it('persists Show Archived Tasks state in localStorage', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT);
+
+                const showArchivedButton = screen.getByRole('button', {
+                    name: 'Show Archived Tasks',
+                });
+
+                // Toggle to checked
+                act(() => showArchivedButton.click());
+
+                expect(spies.localStorageData.setShowArchived).toHaveBeenLastCalledWith(true);
+
+                // Toggle to unchecked
+                act(() => showArchivedButton.click());
+
+                expect(spies.localStorageData.setShowArchived).toHaveBeenLastCalledWith(false);
+            });
+        });
+
+        describe('Small screen visibility conditions', () => {
+            beforeEach(() => {
+                (useMediaQuery as MockedFunction<typeof useMediaQuery>).mockReturnValue(true);
+            });
+
+            it('displays the correct button for small screens', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT);
+
+                const button = screen.getByRole('button', { name: 'Show Archived Tasks' });
+
+                // It should be an icon button with no text
+                expect(button.textContent).toBe('');
+            });
+
+            it('hides the Show Archived Tasks checkbox when there are no archived tasks', () => {
+                renderTrainingPlan([], USER_COHORT);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('shows the Show Archived Tasks checkbox when free users have archived free tasks in the visible cohort', () => {
+                renderTrainingPlan(['free-task', 'free-task-2', 'paid-task'], USER_COHORT);
+
+                expect(
+                    screen.getByRole('button', { name: 'Show Archived Tasks' }),
+                ).toBeInTheDocument();
+            });
+
+            it('shows the Show Archived Tasks checkbox when paid users have paid archived tasks in the visible cohort', () => {
+                renderTrainingPlan(['paid-task'], USER_COHORT, false);
+
+                expect(
+                    screen.getByRole('button', { name: 'Show Archived Tasks' }),
+                ).toBeInTheDocument();
+            });
+
+            it('shows the Show Archived Tasks checkbox when paid users have free archived tasks in the visible cohort', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT, false);
+
+                expect(
+                    screen.getByRole('button', { name: 'Show Archived Tasks' }),
+                ).toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox when archived tasks are not in the visible cohort', () => {
+                renderTrainingPlan(['free-task'], OTHER_COHORT);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox when free users have only paid archived tasks', () => {
+                renderTrainingPlan(['paid-task'], USER_COHORT, true);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox when archived task ids are not in the training plan', () => {
+                renderTrainingPlan(['task-not-in-plan'], USER_COHORT);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+
+            it('hides the Show Archived Tasks checkbox for non-current users', () => {
+                renderTrainingPlan(['free-task'], USER_COHORT, true, false);
+
+                expect(
+                    screen.queryByRole('button', { name: 'Show Archived Tasks' }),
+                ).not.toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Archived Tasks in Sections', () => {
+        it("passes IDs of archived tasks to the task's section", () => {
+            renderTrainingPlan(['free-task'], USER_COHORT);
+
+            const sectionCalls = spies.sectionProps.mock.calls as unknown as MockSectionProps[][];
+
+            const freeTaskSectionProps = sectionCalls.find(
+                (call) => call[0]?.section.category === RequirementCategory.Games,
+            )?.[0];
+
+            expect(freeTaskSectionProps?.section?.archivedTaskIds).toEqual(new Set(['free-task']));
+        });
+
+        it('does not pass IDs of archived tasks to different sections', () => {
+            renderTrainingPlan(['free-task'], USER_COHORT);
+
+            const sectionCalls = spies.sectionProps.mock.calls as unknown as MockSectionProps[][];
+
+            const freeTaskSectionProps = sectionCalls.find(
+                (call) => call[0]?.section.category === RequirementCategory.Opening,
+            )?.[0];
+
+            expect(freeTaskSectionProps?.section?.archivedTaskIds).toEqual(new Set<string>());
+        });
+
+        it("does not pass IDs of archived tasks to sections when on another user's profile", () => {
+            renderTrainingPlan(['free-task'], USER_COHORT, true, false);
+
+            const sectionCalls = spies.sectionProps.mock.calls as unknown as MockSectionProps[][];
+
+            const freeTaskSectionProps = sectionCalls.find(
+                (call) => call[0]?.section.category === RequirementCategory.Games,
+            )?.[0];
+
+            expect(freeTaskSectionProps?.section?.archivedTaskIds).toEqual(new Set<string>());
+        });
+
+        it('does not archive graduation tasks', () => {
+            renderTrainingPlan([GRADUATION_TASK_ID], USER_COHORT);
+
+            const sectionCalls = spies.sectionProps.mock.calls as unknown as MockSectionProps[][];
+
+            const graduationSectionProps = sectionCalls.find(
+                (call) => call[0]?.section.category === RequirementCategory.Graduation,
+            )?.[0];
+
+            expect(graduationSectionProps?.section?.archivedTaskIds).toEqual(new Set<string>());
+        });
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
@@ -19,6 +19,7 @@ import CohortIcon from '@/scoreboard/CohortIcon';
 import { CategoryColors } from '@/style/ThemeProvider';
 import { getSubscriptionTier } from '@jackstenglein/chess-dojo-common/src/database/user';
 import {
+    Archive,
     CheckBox,
     CheckBoxOutlineBlank,
     KeyboardDoubleArrowDown,
@@ -85,11 +86,13 @@ export function FullTrainingPlan({
         request: requirementRequest,
         allRequirements,
         pinnedTasks,
+        archivedTaskIds,
         togglePin,
         isCurrentUser,
     } = use(TrainingPlanContext);
 
     const [showCompleted, setShowCompleted] = useShowCompleted(isCurrentUser);
+    const [showArchived, setShowArchived] = useShowArchived(isCurrentUser);
     const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
 
     const [expanded, setExpanded] = useState<Partial<Record<RequirementCategory, boolean>>>({
@@ -111,19 +114,25 @@ export function FullTrainingPlan({
         const requirements = allRequirements.filter(
             (r) => r.counts[cohort] && (r.subscriptionTiers?.includes(subscriptionTier) ?? true),
         );
-        const tasks = (requirements as (Requirement | CustomTask)[]).concat(user.customTasks ?? []);
+        const tasks = [...requirements, ...(user.customTasks ?? [])] as (
+            | Requirement
+            | CustomTask
+        )[];
+
+        // When looking at someone else's profile, we don't care if they have archived tasks. We just want to show everything normally.
+        const userScopedArchivedTaskIds = isCurrentUser
+            ? new Set(archivedTaskIds)
+            : new Set<string>();
+
+        // Partition tasks into sections by category
         for (const task of tasks) {
             if (task.counts[cohort] === undefined) {
                 continue;
             }
 
-            const s = sections.find((s) => s.category === task.category);
-            const complete = MINIMUM_TASKS.has(task.id)
-                ? false
-                : task.id !== SCHEDULE_CLASSICAL_GAME_TASK_ID
-                  ? isComplete(cohort, task, user.progress[task.id], timeline, false)
-                  : getUpcomingGameSchedule(user.gameSchedule).length > 0;
+            let s = sections.find((s) => s.category === task.category);
 
+            // Create a new section for this category if one doesn't already exist
             if (s === undefined) {
                 const value = getCategoryScore(user, cohort, task.category, requirements, timeline);
                 const total = getTotalCategoryScore(cohort, task.category, requirements);
@@ -131,15 +140,32 @@ export function FullTrainingPlan({
 
                 sections.push({
                     category: task.category,
-                    uncompletedTasks: complete ? [] : [task],
-                    completedTasks: complete ? [task] : [],
+                    uncompletedTasks: [],
+                    completedTasks: [],
+                    archivedTaskIds: new Set<string>(),
                     progressBar: percent,
                     color: CategoryColors[task.category],
                 });
-            } else if (complete) {
+                s = sections[sections.length - 1];
+            }
+
+            // Check if the task is complete
+            const complete = MINIMUM_TASKS.has(task.id)
+                ? false
+                : task.id !== SCHEDULE_CLASSICAL_GAME_TASK_ID
+                  ? isComplete(cohort, task, user.progress[task.id], timeline, false)
+                  : getUpcomingGameSchedule(user.gameSchedule).length > 0;
+
+            // Partition the task into completed vs uncompleted
+            if (complete) {
                 s.completedTasks.push(task);
             } else {
                 s.uncompletedTasks.push(task);
+            }
+
+            // Mark the task as archived if necessary
+            if (userScopedArchivedTaskIds.has(task.id)) {
+                s.archivedTaskIds.add(task.id);
             }
         }
 
@@ -173,6 +199,7 @@ export function FullTrainingPlan({
                     category: RequirementCategory.Graduation,
                     uncompletedTasks: gradComplete ? [] : [graduationTask],
                     completedTasks: gradComplete ? [graduationTask] : [],
+                    archivedTaskIds: new Set<string>(), // Graduation tasks are never archived
                     progressBar: graduationPercent,
                     color: CategoryColors[RequirementCategory.Graduation],
                 });
@@ -180,7 +207,12 @@ export function FullTrainingPlan({
         }
 
         return sections;
-    }, [allRequirements, user, cohort, timeline]);
+    }, [allRequirements, user, cohort, timeline, archivedTaskIds, isCurrentUser]);
+
+    const hasArchivedTasks = useMemo(
+        () => sections.some((s) => s.archivedTaskIds.size > 0),
+        [sections],
+    );
 
     if (requirementRequest.isLoading() || sections.length === 0) {
         return <LoadingPage />;
@@ -256,6 +288,22 @@ export function FullTrainingPlan({
                     <Stack direction='row' spacing={1} justifyContent='end' alignItems='center'>
                         {isSmall ? (
                             <>
+                                {isCurrentUser && hasArchivedTasks && (
+                                    <Tooltip
+                                        title={
+                                            showArchived
+                                                ? 'Hide Archived Tasks'
+                                                : 'Show Archived Tasks'
+                                        }
+                                    >
+                                        <IconButton
+                                            onClick={() => setShowArchived(!showArchived)}
+                                            color='primary'
+                                        >
+                                            <Archive sx={{ opacity: showArchived ? 1 : 0.5 }} />
+                                        </IconButton>
+                                    </Tooltip>
+                                )}
                                 <Tooltip
                                     title={
                                         showCompleted
@@ -283,6 +331,16 @@ export function FullTrainingPlan({
                             </>
                         ) : (
                             <>
+                                {isCurrentUser && hasArchivedTasks && (
+                                    <Button
+                                        onClick={() => setShowArchived(!showArchived)}
+                                        startIcon={
+                                            showArchived ? <CheckBox /> : <CheckBoxOutlineBlank />
+                                        }
+                                    >
+                                        Show Archived Tasks
+                                    </Button>
+                                )}
                                 <Button
                                     onClick={() => setShowCompleted(!showCompleted)}
                                     startIcon={
@@ -321,6 +379,7 @@ export function FullTrainingPlan({
                         pinnedTasks={pinnedTasks}
                         showCompleted={showCompleted}
                         setShowCompleted={setShowCompleted}
+                        showArchived={showArchived}
                     />
                 ))}
             </Stack>
@@ -330,6 +389,16 @@ export function FullTrainingPlan({
 
 export function useShowCompleted(isCurrentUser: boolean) {
     const myProfile = useLocalStorage('showCompletedTasks', false);
+    const otherProfile = useState(false);
+
+    if (isCurrentUser) {
+        return myProfile;
+    }
+    return otherProfile;
+}
+
+export function useShowArchived(isCurrentUser: boolean) {
+    const myProfile = useLocalStorage('showArchivedTasks', false);
     const otherProfile = useState(false);
 
     if (isCurrentUser) {

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanItem.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanItem.test.tsx
@@ -1,0 +1,156 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { User } from '@/database/user';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FullTrainingPlanItem } from './FullTrainingPlanItem';
+
+vi.mock('@/api/cache/requirements', () => ({
+    useRequirements: () => ({ requirements: [] }),
+}));
+
+vi.mock('../../activity/useTimeline', () => ({
+    useTimelineContext: () => ({ entries: [] }),
+}));
+
+vi.mock('@/scoreboard/ScoreboardProgress', () => ({
+    __esModule: true,
+    default: () => null,
+    ProgressText: () => null,
+}));
+
+vi.mock('../daily/TaskTimerIconButton', () => ({
+    TaskTimerIconButton: () => null,
+}));
+
+vi.mock('../suggestedTasks', () => ({
+    MINIMUM_TASKS: new Set(),
+}));
+
+vi.mock('../TaskDialog', () => ({
+    TaskDialog: () => null,
+    TaskDialogView: {
+        Details: 'DETAILS',
+        Progress: 'PROGRESS',
+    },
+}));
+
+function makeRequirement(id: string): Requirement {
+    return {
+        id,
+        status: RequirementStatus.Active,
+        category: RequirementCategory.Games,
+        name: `Task ${id}`,
+        description: '',
+        freeDescription: '',
+        counts: { '1400-1500': 1 },
+        startCount: 0,
+        numberOfCohorts: 1,
+        unitScore: 0,
+        totalScore: 0,
+        scoreboardDisplay: ScoreboardDisplay.ProgressBar,
+        progressBarSuffix: '',
+        updatedAt: '2026-01-01T00:00:00Z',
+        sortPriority: id,
+        expirationDays: -1,
+        isFree: true,
+        atomic: false,
+        expectedMinutes: 0,
+    };
+}
+
+const mockUser: User = {
+    username: 'test-user',
+    displayName: 'Test User',
+    discordUsername: '',
+    dojoCohort: '1400-1500',
+    bio: '',
+    ratingSystem: 'CHESSCOM' as User['ratingSystem'],
+    ratings: {},
+    progress: {},
+    disableBookingNotifications: false,
+    disableCancellationNotifications: false,
+    isAdmin: false,
+    isCalendarAdmin: false,
+    isTournamentAdmin: false,
+    isBetaTester: false,
+    isCoach: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    numberOfGraduations: 0,
+    previousCohort: '',
+    lastGraduatedAt: '',
+    enableLightMode: false,
+    enableZenMode: false,
+    timezoneOverride: 'DEFAULT',
+    timeFormat: '24' as User['timeFormat'],
+    hasCreatedProfile: true,
+    followerCount: 0,
+    followingCount: 0,
+    referralSource: '',
+    totalDojoScore: 0,
+    subscriptionStatus: 'NOT_SUBSCRIBED' as User['subscriptionStatus'],
+    subscriptionTier: 'FREE' as User['subscriptionTier'],
+    exams: {},
+    weekStart: 0,
+    gameSchedule: [],
+};
+
+function renderItem(isArchived: boolean) {
+    render(
+        <FullTrainingPlanItem
+            user={mockUser}
+            requirement={makeRequirement('task-1')}
+            cohort='1400-1500'
+            isCurrentUser
+            togglePin={() => undefined}
+            isPinned={false}
+            isArchived={isArchived}
+        />,
+    );
+}
+
+describe('FullTrainingPlanItem', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe('Archived Training Plan Item', () => {
+        it('grays out archived items', () => {
+            renderItem(true);
+
+            expect(screen.getByTestId('Task-task-1-training-plan-entry')).toHaveStyle({
+                opacity: '0.5',
+            });
+        });
+
+        it('does not gray out unarchived items', () => {
+            renderItem(false);
+
+            expect(screen.getByTestId('Task-task-1-training-plan-entry')).toHaveStyle({
+                opacity: '1',
+            });
+        });
+
+        it('shows Archived chip when item is archived', () => {
+            renderItem(true);
+
+            expect(screen.getByTestId('Task-task-1-training-plan-entry')).toHaveTextContent(
+                'Archived',
+            );
+        });
+
+        it('does not show Archived chip when item is not archived', () => {
+            renderItem(false);
+
+            expect(screen.getByTestId('Task-task-1-training-plan-entry')).not.toHaveTextContent(
+                'Archived',
+            );
+        });
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanItem.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanItem.tsx
@@ -40,6 +40,7 @@ interface FullTrainingPlanItemProps {
     isCurrentUser: boolean;
     togglePin: (req: Requirement | CustomTask) => void;
     isPinned: boolean;
+    isArchived: boolean;
 }
 
 export const FullTrainingPlanItem = ({
@@ -50,6 +51,7 @@ export const FullTrainingPlanItem = ({
     isCurrentUser,
     togglePin,
     isPinned,
+    isArchived,
 }: FullTrainingPlanItemProps) => {
     const [taskDialogView, setTaskDialogView] = useState<TaskDialogView>();
     const { requirements } = useRequirements(ALL_COHORTS, false);
@@ -135,6 +137,7 @@ export const FullTrainingPlanItem = ({
     return (
         <Tooltip title={blocker.reason} followCursor>
             <Stack
+                sx={{ opacity: isArchived ? 0.5 : 1 }}
                 spacing={2}
                 mt={2}
                 data-testid={`${requirement.name.replaceAll(' ', '-')}-training-plan-entry`}
@@ -223,6 +226,7 @@ export const FullTrainingPlanItem = ({
                             />
                         )}
                     </Grid>
+                    {isArchived && <Chip label='Archived' size='small' color='default' />}
                     <Grid size='auto' id='task-status'>
                         <Stack direction='row' alignItems='center' justifyContent='end'>
                             {!blocker.isBlocked && (

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.test.tsx
@@ -1,0 +1,208 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { User } from '@/database/user';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FullTrainingPlanSection, Section } from './FullTrainingPlanSection';
+
+vi.mock('./FullTrainingPlanItem', () => ({
+    FullTrainingPlanItem: ({
+        requirement,
+        isArchived,
+    }: {
+        requirement: Requirement;
+        isArchived: boolean;
+    }) => <div data-testid={`item-${requirement.id}`}>{isArchived ? 'archived' : ''}</div>,
+}));
+
+vi.mock('@/scoreboard/ScoreboardProgress', () => ({
+    __esModule: true,
+    default: () => <div data-testid='scoreboard-progress' />,
+    ProgressText: ({ value, max, min }: { value: number; max: number; min: number }) => (
+        <span data-testid='progress-text'>{`${value}/${max}/${min}`}</span>
+    ),
+}));
+
+vi.mock('../ScheduleClassicalGame', () => ({
+    ScheduleClassicalGame: () => null,
+}));
+
+vi.mock('./FullTrainingPlanGraduationItem', () => ({
+    FullTrainingPlanGraduationItem: () => null,
+}));
+
+vi.mock('../CustomTaskEditor', () => ({
+    default: () => null,
+}));
+
+function makeRequirement(id: string): Requirement {
+    return {
+        id,
+        status: RequirementStatus.Active,
+        category: RequirementCategory.Games,
+        name: `Task ${id}`,
+        description: '',
+        freeDescription: '',
+        counts: { '1400-1500': 1000 },
+        startCount: 0,
+        numberOfCohorts: 1,
+        unitScore: 0,
+        totalScore: 0,
+        scoreboardDisplay: ScoreboardDisplay.ProgressBar,
+        progressBarSuffix: '',
+        updatedAt: '2026-01-01T00:00:00Z',
+        sortPriority: id,
+        expirationDays: -1,
+        isFree: true,
+        atomic: false,
+        expectedMinutes: 0,
+    };
+}
+
+const mockFreeUser: User = {
+    username: '',
+    displayName: '',
+    discordUsername: '',
+    dojoCohort: '1400-1500',
+    bio: '',
+    ratingSystem: 'CHESSCOM' as User['ratingSystem'],
+    ratings: {},
+    progress: {},
+    disableBookingNotifications: false,
+    disableCancellationNotifications: false,
+    isAdmin: false,
+    isCalendarAdmin: false,
+    isTournamentAdmin: false,
+    isBetaTester: false,
+    isCoach: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    numberOfGraduations: 0,
+    previousCohort: '',
+    lastGraduatedAt: '',
+    enableLightMode: false,
+    enableZenMode: false,
+    timezoneOverride: 'DEFAULT',
+    timeFormat: '24' as User['timeFormat'],
+    hasCreatedProfile: true,
+    followerCount: 0,
+    followingCount: 0,
+    referralSource: '',
+    totalDojoScore: 0,
+    subscriptionStatus: 'NOT_SUBSCRIBED' as User['subscriptionStatus'],
+    subscriptionTier: 'FREE' as User['subscriptionTier'],
+    exams: {},
+    weekStart: 0,
+    gameSchedule: [],
+};
+
+function renderSection(showArchived: boolean) {
+    const uncompletedTask1 = makeRequirement('task-1');
+    const uncompletedTask2 = makeRequirement('task-2');
+    const uncompletedTask3 = makeRequirement('task-3');
+    const completedTask1 = makeRequirement('ctask-1');
+    const completedTask2 = makeRequirement('ctask-2');
+    const completedTask3 = makeRequirement('ctask-3');
+    const completedTask4 = makeRequirement('ctask-4');
+
+    const section: Section = {
+        category: RequirementCategory.Games,
+        uncompletedTasks: [uncompletedTask1, uncompletedTask2, uncompletedTask3],
+        completedTasks: [completedTask1, completedTask2, completedTask3, completedTask4],
+        archivedTaskIds: new Set(['task-2', 'ctask-1', 'ctask-4']),
+        color: '#000',
+        progressBar: 0,
+    };
+
+    render(
+        <FullTrainingPlanSection
+            section={section}
+            expanded
+            toggleExpand={() => undefined}
+            user={mockFreeUser}
+            isCurrentUser
+            cohort='1400-1500'
+            togglePin={() => undefined}
+            pinnedTasks={[]}
+            showCompleted={true}
+            setShowCompleted={() => undefined}
+            showArchived={showArchived}
+        />,
+    );
+}
+
+describe('FullTrainingPlanSection', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe('Archived Tasks Handling', () => {
+        it('passes archived status to items correctly', () => {
+            renderSection(true);
+
+            const archivedItem = screen.getByTestId('item-task-2');
+            const unarchivedItem = screen.getByTestId('item-task-1');
+
+            expect(archivedItem).toHaveTextContent('archived');
+            expect(unarchivedItem).not.toHaveTextContent('archived');
+        });
+
+        describe('Uncompleted Task Section', () => {
+            it('hides archived tasks when showArchived is false', () => {
+                renderSection(false);
+
+                expect(screen.queryByTestId('item-task-2')).not.toBeInTheDocument();
+            });
+
+            it('shows archived tasks when showArchived is true', () => {
+                renderSection(true);
+
+                expect(screen.queryByTestId('item-task-2')).toBeInTheDocument();
+            });
+
+            it('renders archived tasks after unarchived tasks when showArchived is true', () => {
+                renderSection(true);
+
+                const renderedItems = screen.getAllByTestId(/item-task-/);
+                expect(renderedItems.map((el) => el.getAttribute('data-testid'))).toEqual([
+                    'item-task-1',
+                    'item-task-3',
+                    'item-task-2',
+                ]);
+            });
+        });
+
+        describe('Completed Task Section', () => {
+            it('hides archived tasks when showArchived is false', () => {
+                renderSection(false);
+
+                expect(screen.queryByTestId('item-ctask-1')).not.toBeInTheDocument();
+                expect(screen.queryByTestId('item-ctask-4')).not.toBeInTheDocument();
+            });
+
+            it('shows archived tasks when showArchived is true', () => {
+                renderSection(true);
+
+                expect(screen.queryByTestId('item-ctask-1')).toBeInTheDocument();
+                expect(screen.queryByTestId('item-ctask-4')).toBeInTheDocument();
+            });
+
+            it('renders archived tasks after unarchived tasks when showArchived is true', () => {
+                renderSection(true);
+
+                const renderedItems = screen.getAllByTestId(/item-ctask-/);
+                expect(renderedItems.map((el) => el.getAttribute('data-testid'))).toEqual([
+                    'item-ctask-2',
+                    'item-ctask-3',
+                    'item-ctask-1',
+                    'item-ctask-4',
+                ]);
+            });
+        });
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
@@ -41,6 +41,8 @@ export interface Section {
     uncompletedTasks: (Requirement | CustomTask)[];
     /** The completed tasks in the section. */
     completedTasks: (Requirement | CustomTask)[];
+    /** The IDs of the user's archived tasks in the section. */
+    archivedTaskIds: Set<string>;
     /** The color of the icon in the section header and the progress bar. */
     color?: string;
     /** The value of the progress bar for the section. */
@@ -68,6 +70,8 @@ interface TrainingPlanSectionProps {
     showCompleted: boolean;
     /** Callback to set whether to show completed tasks. */
     setShowCompleted: (v: boolean) => void;
+    /** Whether to show archived tasks */
+    showArchived: boolean;
 }
 
 export function FullTrainingPlanSection({
@@ -81,6 +85,7 @@ export function FullTrainingPlanSection({
     pinnedTasks,
     showCompleted,
     setShowCompleted,
+    showArchived,
 }: TrainingPlanSectionProps) {
     const isFreeTier = useFreeTier();
     const [showCustomTaskEditor, setShowCustomTaskEditor] = useState(false);
@@ -166,6 +171,8 @@ export function FullTrainingPlanSection({
                     isCurrentUser={isCurrentUser}
                     togglePin={togglePin}
                     pinnedTasks={pinnedTasks}
+                    archivedTaskIds={section.archivedTaskIds}
+                    showArchived={showArchived}
                 />
 
                 {section.completedTasks.length > 0 &&
@@ -192,6 +199,8 @@ export function FullTrainingPlanSection({
                                 isCurrentUser={isCurrentUser}
                                 togglePin={togglePin}
                                 pinnedTasks={pinnedTasks}
+                                archivedTaskIds={section.archivedTaskIds}
+                                showArchived={showArchived}
                             />
                         </>
                     ) : (
@@ -246,6 +255,8 @@ function TaskList({
     isCurrentUser,
     togglePin,
     pinnedTasks,
+    showArchived,
+    archivedTaskIds,
 }: {
     tasks: (Requirement | CustomTask)[];
     isFreeTier: boolean;
@@ -256,10 +267,26 @@ function TaskList({
     togglePin: (req: Requirement | CustomTask) => void;
     /** The set of pinned tasks. */
     pinnedTasks: (Requirement | CustomTask)[];
+    showArchived: boolean;
+    archivedTaskIds: Set<string>;
 }) {
+    // Partition tasks into an array of archived tasks and an array of unarchived tasks
+    const [unarchivedTasks, archivedTasks] = tasks.reduce<
+        [(Requirement | CustomTask)[], (Requirement | CustomTask)[]]
+    >(
+        ([unarchived, archived], task) => {
+            (archivedTaskIds.has(task.id) ? archived : unarchived).push(task);
+            return [unarchived, archived];
+        },
+        [[], []],
+    );
+
+    // Reconstitute the list of tasks with archived tasks at the end if they should be shown, and removed otherwise
+    const displayedTasks = showArchived ? [...unarchivedTasks, ...archivedTasks] : unarchivedTasks;
+
     return (
         <>
-            {tasks.map((r) => {
+            {displayedTasks.map((r) => {
                 if (r.id === SCHEDULE_CLASSICAL_GAME_TASK_ID) {
                     return <ScheduleClassicalGame key={r.id} hideChip />;
                 }
@@ -287,6 +314,7 @@ function TaskList({
                         user={user}
                         togglePin={togglePin}
                         isPinned={pinnedTasks.some((t) => t.id === r.id)}
+                        isArchived={archivedTaskIds.has(r.id)}
                     />
                 );
             })}

--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.test.tsx
@@ -1,0 +1,793 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { User, WeeklyPlan } from '@/database/user';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskSuggestionAlgorithm } from './suggestedTasks';
+
+const USER_COHORT = '1400-1500';
+
+const MOCK_TODAY = new Date(Date.UTC(2026, 3, 1)); // April 1, 2026
+
+const mockFreeUser: User = {
+    username: 'test-user',
+    displayName: 'Test User',
+    discordUsername: '',
+    dojoCohort: USER_COHORT,
+    bio: '',
+    ratingSystem: 'CHESSCOM' as User['ratingSystem'],
+    ratings: {},
+    progress: {},
+    disableBookingNotifications: false,
+    disableCancellationNotifications: false,
+    isAdmin: false,
+    isCalendarAdmin: false,
+    isTournamentAdmin: false,
+    isBetaTester: false,
+    isCoach: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    numberOfGraduations: 0,
+    previousCohort: '',
+    lastGraduatedAt: '',
+    enableLightMode: false,
+    enableZenMode: false,
+    timezoneOverride: 'DEFAULT',
+    timeFormat: '24' as User['timeFormat'],
+    hasCreatedProfile: true,
+    followerCount: 0,
+    followingCount: 0,
+    referralSource: '',
+    totalDojoScore: 0,
+    subscriptionStatus: 'NOT_SUBSCRIBED' as User['subscriptionStatus'],
+    subscriptionTier: 'FREE' as User['subscriptionTier'],
+    exams: {},
+    weekStart: 0,
+    gameSchedule: [],
+    pinnedTasks: [],
+    archivedTasks: [],
+};
+
+function makeRequirement(id: string, category = RequirementCategory.Games): Requirement {
+    return {
+        id,
+        status: RequirementStatus.Active,
+        category,
+        name: `Task ${id}`,
+        description: '',
+        freeDescription: '',
+        counts: { [USER_COHORT]: 1000 },
+        startCount: 0,
+        numberOfCohorts: 1,
+        unitScore: 1,
+        totalScore: 0,
+        scoreboardDisplay: ScoreboardDisplay.ProgressBar,
+        progressBarSuffix: '',
+        updatedAt: '2026-01-01T00:00:00Z',
+        sortPriority: id,
+        expirationDays: -1,
+        isFree: true,
+        atomic: false,
+        expectedMinutes: 0,
+    };
+}
+
+function makeWeeklyPlan(overrides: Partial<WeeklyPlan> = {}): WeeklyPlan {
+    return {
+        endDate: '2099-01-01T00:00:00.000Z',
+        progressUpdatedAt: '',
+        pinnedTasks: [],
+        archivedTasks: [],
+        nextGame: '',
+        tasks: Array.from({ length: 7 }, () => []),
+        ...overrides,
+    };
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+    return {
+        ...mockFreeUser,
+        ...overrides,
+    };
+}
+
+describe('suggestedTasks', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(MOCK_TODAY);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('Archived Tasks Handling', () => {
+        describe('Should Regenerate Detection', () => {
+            describe('ShouldRegenerateToday', () => {
+                it('is false when both plans have undefined archived task arrays', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: undefined });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: undefined }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when new plan has an undefined archived task array and existing plan has an empty archived task array', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: undefined });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when both plans have empty archived task arrays', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: [] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is true when new plan has archived tasks but existing plan has an undefined archived task array', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: undefined }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are added where none existed', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are added when some already exist', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const user = makeUser({ archivedTasks: ['task', 'task-2'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req, req2], [req, req2], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task'] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are changed but are still the same number of archived tasks', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const req3 = makeRequirement('task-3');
+                    const user = makeUser({ archivedTasks: ['task', 'task-2'] });
+                    const algo = new TaskSuggestionAlgorithm(
+                        user,
+                        [req, req2, req3],
+                        [req, req2, req3],
+                        [],
+                    );
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task', 'task-3'] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are removed', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req, req2], [req, req2], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task', 'task-2'] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is false when archived tasks reordered but not changed', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const user = makeUser({ archivedTasks: ['task', 'task-2'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req, req2], [req, req2], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task-2', 'task'] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when archived tasks are present but have not changed', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task'] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when there are no archived tasks and none were added', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: [] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                // Will fail if the if statements in getGenerationReason are misordered
+                it('is true when archived tasks and progressUpdatedAt are both changed', () => {
+                    const req = makeRequirement('task');
+                    const oldUpdateTime = '2026-04-01T00:00:00Z';
+                    const newUpdateTime = '2026-04-02T01:00:00Z';
+                    const user = makeUser({
+                        archivedTasks: ['task'],
+                        progress: {
+                            [req.id]: {
+                                requirementId: req.id,
+                                minutesSpent: {},
+                                updatedAt: newUpdateTime,
+                            },
+                        },
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({
+                                    archivedTasks: [],
+                                    progressUpdatedAt: oldUpdateTime,
+                                }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                // Will fail if the if statements in getGenerationReason are misordered
+                it('is true when archived tasks and work goals are both changed', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: ['task'],
+                        workGoal: {
+                            minutesPerDay: [60, 60, 60, 60, 60, 60, 60],
+                        },
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({
+                                    archivedTasks: [],
+                                    tasks: [[{ id: req.id, minutes: 10 }], [], [], [], [], [], []],
+                                }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                // Will fail if the if statements in getGenerationReason are misordered
+                it('is true when archived tasks have changed and future upcoming games have changed', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: ['task'],
+                        gameSchedule: [
+                            {
+                                date: '2026-04-08T01:00:00Z',
+                                count: 1,
+                            },
+                        ],
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateToday(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({
+                                    archivedTasks: [],
+                                    nextGame: '2026-04-05T01:00:00Z',
+                                }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+            });
+
+            describe('ShouldRegenerateFuture', () => {
+                it('is false when both plans have undefined archived task arrays', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: undefined });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: undefined }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when new plan has an undefined archived task array and existing plan has an empty archived task array', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: undefined });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when both plans have empty archived task arrays', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: [] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is true when new plan has archived tasks but existing plan has an undefined archived task array', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: undefined }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are added where none existed', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are added when some already exist', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const user = makeUser({ archivedTasks: ['task', 'task-2'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req, req2], [req, req2], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task'] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are changed but are still the same number of archived tasks', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const req3 = makeRequirement('task-3');
+                    const user = makeUser({ archivedTasks: ['task', 'task-2'] });
+                    const algo = new TaskSuggestionAlgorithm(
+                        user,
+                        [req, req2, req3],
+                        [req, req2, req3],
+                        [],
+                    );
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task', 'task-3'] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is true when archived tasks are removed', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req, req2], [req, req2], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task', 'task-2'] }),
+                            ),
+                        ),
+                    ).toBe(true);
+                });
+
+                it('is false when archived tasks are present but have not changed', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task'] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when there are no archived tasks and none were added', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: [] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: [] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when archived tasks reordered but not changed', () => {
+                    const req = makeRequirement('task');
+                    const req2 = makeRequirement('task-2');
+                    const user = makeUser({ archivedTasks: ['task', 'task-2'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req, req2], [req, req2], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task-2', 'task'] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when archived tasks have duplicates in new plan but not in existing plan', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task', 'task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task'] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+
+                it('is false when archived tasks have duplicates in existing plan but not in new plan', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({ archivedTasks: ['task'] });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    expect(
+                        algo.shouldRegenerateFuture(
+                            algo.getGenerationReason(
+                                new Date(),
+                                makeWeeklyPlan({ archivedTasks: ['task', 'task'] }),
+                            ),
+                        ),
+                    ).toBe(false);
+                });
+            });
+        });
+        describe('Exclusion from suggestions', () => {
+            describe('getSuggestedTasks', () => {
+                it('does not suggest pinned archived tasks', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        pinnedTasks: ['task'],
+                        archivedTasks: ['task'],
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    const suggested = algo.getSuggestedTasks(new Date());
+
+                    expect(suggested.map((t) => t.id)).not.toContain('task');
+                });
+
+                it('does not suggest otherwise-eligible archived tasks', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: ['task'],
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    const suggested = algo.getSuggestedTasks(new Date());
+
+                    expect(suggested.map((t) => t.id)).not.toContain('task');
+                });
+
+                it('still suggests eligible non-archived tasks', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: [],
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    const suggested = algo.getSuggestedTasks(new Date());
+
+                    expect(suggested.map((t) => t.id)).toContain('task');
+                });
+            });
+            describe('getWelcomeTasks', () => {
+                it('does not suggest pinned archived welcome tasks', () => {
+                    const welcomeTask = makeRequirement('welcome', RequirementCategory.Welcome);
+                    const user = makeUser({
+                        pinnedTasks: ['welcome'],
+                        archivedTasks: ['welcome'],
+                    });
+                    const algo = new TaskSuggestionAlgorithm(
+                        user,
+                        [welcomeTask],
+                        [welcomeTask],
+                        [],
+                    );
+
+                    const suggested = algo.getWelcomeTasks();
+
+                    expect(suggested.map((s) => s.task.id)).not.toContain('welcome');
+                });
+
+                it('does not suggest otherwise-eligible archived welcome tasks', () => {
+                    const welcomeTask = makeRequirement('welcome', RequirementCategory.Welcome);
+                    const user = makeUser({
+                        archivedTasks: ['welcome'],
+                    });
+                    const algo = new TaskSuggestionAlgorithm(
+                        user,
+                        [welcomeTask],
+                        [welcomeTask],
+                        [],
+                    );
+
+                    const suggested = algo.getWelcomeTasks();
+
+                    expect(suggested.map((s) => s.task.id)).not.toContain('welcome');
+                });
+
+                it('still suggests eligible non-archived welcome tasks', () => {
+                    const welcomeTask = makeRequirement('welcome', RequirementCategory.Welcome);
+                    const user = makeUser({
+                        archivedTasks: [],
+                    });
+                    const algo = new TaskSuggestionAlgorithm(
+                        user,
+                        [welcomeTask],
+                        [welcomeTask],
+                        [],
+                    );
+
+                    const suggested = algo.getWelcomeTasks();
+
+                    expect(suggested.map((s) => s.task.id)).toContain('welcome');
+                });
+            });
+            describe('getWeeklySuggestions', () => {
+                it('still shows archived tasks from past days', () => {
+                    // Make sure we're not on a Sunday, since there are no days
+                    // of the week before that
+                    const today = new Date();
+                    if (today.getDay() === 0) {
+                        today.setDate(today.getDate() + 2);
+                    }
+                    vi.setSystemTime(today);
+
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: ['task'],
+                        weeklyPlan: makeWeeklyPlan({
+                            tasks: [
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                            ],
+                        }),
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    const suggestions = algo.getWeeklySuggestions();
+                    expect(
+                        suggestions.suggestionsByDay[new Date().getDay() - 1].map((s) => s.task.id),
+                    ).toContain('task');
+                });
+
+                it('does not show archived tasks for the current day', () => {
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: ['task'],
+                        weeklyPlan: makeWeeklyPlan({
+                            tasks: [
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                            ],
+                        }),
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    const suggestions = algo.getWeeklySuggestions();
+                    expect(
+                        suggestions.suggestionsByDay[new Date().getDay()].map((s) => s.task.id),
+                    ).not.toContain('task');
+                });
+
+                it('does not show archived tasks for future days', () => {
+                    // Make sure we're not on a Saturday, since there are no days
+                    // of the week after that
+                    const today = new Date();
+                    if (today.getDay() === 6) {
+                        today.setDate(today.getDate() - 2);
+                    }
+                    vi.setSystemTime(today);
+
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: ['task'],
+                        weeklyPlan: makeWeeklyPlan({
+                            tasks: [
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                            ],
+                        }),
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    const suggestions = algo.getWeeklySuggestions();
+                    expect(
+                        suggestions.suggestionsByDay[new Date().getDay() + 1].map((s) => s.task.id),
+                    ).not.toContain('task');
+                });
+
+                // Just to verify that our tests are well-constructed, and the task is being excluded
+                // for the right reasons. In particular, too low a cohort count can cause a task to
+                // be considered completed after a certain number of days and removed from latter days'
+                // suggestions
+                it('still shows eligible non-archived tasks for future days', () => {
+                    // Make sure we're not on a Saturday, since there are no days
+                    // of the week after that
+                    const today = new Date();
+                    if (today.getDay() === 6) {
+                        today.setDate(today.getDate() - 2);
+                    }
+                    vi.setSystemTime(today);
+
+                    const req = makeRequirement('task');
+                    const user = makeUser({
+                        archivedTasks: [],
+                        weeklyPlan: makeWeeklyPlan({
+                            tasks: [
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                                [{ id: 'task', minutes: 10 }],
+                            ],
+                        }),
+                    });
+                    const algo = new TaskSuggestionAlgorithm(user, [req], [req], []);
+
+                    const suggestions = algo.getWeeklySuggestions();
+                    expect(
+                        suggestions.suggestionsByDay[new Date().getDay() + 1].map((s) => s.task.id),
+                    ).toContain('task');
+                });
+            });
+        });
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
@@ -129,6 +129,7 @@ enum SuggestedTaskGenerationReason {
     ScheduledGamesUpdateToday,
     ScheduledGamesUpdateFuture,
     SkippedTaskUpdate,
+    ArchivedTaskUpdate,
 }
 
 export class TaskSuggestionAlgorithm {
@@ -137,6 +138,7 @@ export class TaskSuggestionAlgorithm {
     private readonly pinnedTasks: Task[];
     private readonly timeline: TimelineEntry[];
     private readonly skippedTaskIds: string[];
+    private readonly archivedTaskIds: string[];
 
     private user: User;
     private timePerTask: Record<string, number> = {};
@@ -161,6 +163,7 @@ export class TaskSuggestionAlgorithm {
                 )
                 .filter((t) => !!t) ?? [];
         this.skippedTaskIds = this.user.weeklyPlan?.skippedTasks ?? [];
+        this.archivedTaskIds = this.user.archivedTasks ?? [];
     }
 
     /**
@@ -219,6 +222,16 @@ export class TaskSuggestionAlgorithm {
             return SuggestedTaskGenerationReason.PinnedTaskUpdate;
         }
 
+        if (!weeklyPlanMatchesArchivedTasks(existingPlan, this.user.archivedTasks ?? [])) {
+            return SuggestedTaskGenerationReason.ArchivedTaskUpdate;
+        }
+
+        // IMPORTANT: if statements above this comment need to stay above this comment,
+        // and if statements below this comment need to stay below this comment.
+        // Otherwise, e.g. a progressUpdate reason might clobber an archivedTaskUpdate reason,
+        // causing later calls to shouldRegenerateToday() to erroneously ignore
+        // archived task updates
+
         if (existingPlan.progressUpdatedAt !== lastProgressUpdate(this.user)) {
             return SuggestedTaskGenerationReason.ProgressUpdate;
         }
@@ -245,7 +258,8 @@ export class TaskSuggestionAlgorithm {
         return (
             reason === SuggestedTaskGenerationReason.PinnedTaskUpdate ||
             reason === SuggestedTaskGenerationReason.ScheduledGamesUpdateToday ||
-            reason === SuggestedTaskGenerationReason.SkippedTaskUpdate
+            reason === SuggestedTaskGenerationReason.SkippedTaskUpdate ||
+            reason === SuggestedTaskGenerationReason.ArchivedTaskUpdate
         );
     }
 
@@ -476,6 +490,9 @@ export class TaskSuggestionAlgorithm {
      * be suggested unless the user has pinned them. These task IDs are listed in
      * INELIGIBLE_SUGGESTED_TASKS.
      *
+     * NOTE: Tasks in the user's archived tasks list are also ineligible to be suggested,
+     * even if they are pinned.
+     *
      * @param date The date to get suggested tasks for.
      * @returns A list of at most MAX_SUGGESTED_TASKS suggested tasks.
      */
@@ -504,7 +521,9 @@ export class TaskSuggestionAlgorithm {
                     this.user.progress[t.id],
                     this.timeline,
                     true,
-                ) && !this.skippedTaskIds.includes(t.id),
+                ) &&
+                !this.skippedTaskIds.includes(t.id) &&
+                !this.archivedTaskIds.includes(t.id),
         );
         suggestedTasks.push(...pinnedTasks);
 
@@ -518,6 +537,7 @@ export class TaskSuggestionAlgorithm {
             user: this.user,
             timeline: this.timeline,
             skippedTaskIds: this.skippedTaskIds,
+            archivedTaskIds: this.archivedTaskIds,
         });
         if (eligibleRequirements.length === 0) {
             return suggestedTasks;
@@ -615,7 +635,8 @@ export class TaskSuggestionAlgorithm {
             (r) =>
                 r.category === RequirementCategory.Welcome &&
                 !isComplete(this.user.dojoCohort, r, this.user.progress[r.id]) &&
-                !this.skippedTaskIds.includes(r.id),
+                !this.skippedTaskIds.includes(r.id) &&
+                !this.archivedTaskIds.includes(r.id),
         );
         return eligibleRequirements.map((t) => ({ task: t, goalMinutes: 0 }));
     }
@@ -628,6 +649,7 @@ export class TaskSuggestionAlgorithm {
  * @param user The user to suggest tasks for.
  * @param timeline The user's timeline entries.
  * @param skippedTaskIds The ids of tasks the user has skipped.
+ * @param archivedTaskIds The ids of tasks the user has archived.
  * @returns A subset of requirements that are eligible to be suggested to the user.
  */
 function getEligibleTasks({
@@ -636,12 +658,14 @@ function getEligibleTasks({
     user,
     timeline,
     skippedTaskIds,
+    archivedTaskIds,
 }: {
     suggestedTasks: Task[];
     requirements: Requirement[];
     user: User;
     timeline: TimelineEntry[];
     skippedTaskIds: string[];
+    archivedTaskIds: string[];
 }) {
     const isFreeUser = isFree(user);
     let eligibleRequirements = requirements.filter(
@@ -651,7 +675,8 @@ function getEligibleTasks({
             !suggestedTasks.some((t) => r.id === t.id) &&
             SUGGESTED_TASK_CATEGORIES.includes(r.category) &&
             !isComplete(user.dojoCohort, r, user.progress[r.id], timeline, false) &&
-            !skippedTaskIds.includes(r.id),
+            !skippedTaskIds.includes(r.id) &&
+            !archivedTaskIds.includes(r.id),
     );
 
     const classicalGamesTask = requirements.find((r) => r.id === CLASSICAL_GAMES_TASK_ID);
@@ -802,8 +827,32 @@ function weeklyPlanMatchesPinnedTasks(weeklyPlan: WeeklyPlan, pinnedTasks: strin
     if (weeklyPlan.pinnedTasks?.length !== pinnedTasks.length) {
         return false;
     }
+    // For pinned tasks, order matters
     for (let i = 0; i < weeklyPlan.pinnedTasks.length; i++) {
         if (weeklyPlan.pinnedTasks[i] !== pinnedTasks[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Returns a boolean indicating whether the given weekly plan matches the given archived tasks.
+ * A weekly plan matches archived tasks if the plan has the same task ids (in any order) as
+ * the given archived tasks.
+ * @param weeklyPlan The weekly plan to check.
+ * @param archivedTasks The archived tasks to check.
+ * @returns True if the weekly plan matches the archived tasks.
+ */
+function weeklyPlanMatchesArchivedTasks(weeklyPlan: WeeklyPlan, archivedTasks: string[]): boolean {
+    // For archived tasks, order doesn't matter and we don't care about duplicates
+    const oldArchivedTasksSet = new Set(weeklyPlan?.archivedTasks);
+    const newArchivedTasksSet = new Set(archivedTasks);
+    if (oldArchivedTasksSet.size !== newArchivedTasksSet.size) {
+        return false;
+    }
+    for (const newTaskId of newArchivedTasksSet) {
+        if (!oldArchivedTasksSet.has(newTaskId)) {
             return false;
         }
     }

--- a/frontend/src/components/profile/trainingPlan/useTrainingPlan.ts
+++ b/frontend/src/components/profile/trainingPlan/useTrainingPlan.ts
@@ -7,7 +7,8 @@ import { TimelineEntry } from '@/database/timeline';
 import { ALL_COHORTS, User, WeeklyPlan, WorkGoalSettings } from '@/database/user';
 import { useEffect, useMemo } from 'react';
 import { useTimelineContext } from '../activity/useTimeline';
-import { SuggestedTask, TaskSuggestionAlgorithm } from './suggestedTasks';
+import { GRADUATION_TASK_ID } from './full/FullTrainingPlanSection';
+import { CLASSICAL_GAMES_TASK_ID, SuggestedTask, TaskSuggestionAlgorithm } from './suggestedTasks';
 
 export interface UseTrainingPlanResponse {
     /** The request for fetching requirements. */
@@ -20,14 +21,20 @@ export interface UseTrainingPlanResponse {
     pinnedTasks: (Requirement | CustomTask)[];
     /** A callback function to toggle whether a task is pinned. */
     togglePin: (task: Requirement | CustomTask) => void;
+    /** A callback function to toggle whether a task is archived */
+    toggleArchived: (task: Requirement | CustomTask) => void;
     /** The user passed as a parameter, unchanged. */
     user: User;
     /** Whether the provided user is the current logged in user. */
     isCurrentUser: boolean;
+    /** The ids of tasks the user has archived. */
+    archivedTaskIds: string[];
     /** The ids of tasks the user has skipped for the current week. */
     skippedTaskIds?: string[];
     /** A callback function to toggle whether a task is skipped. */
     toggleSkip: (...ids: string[]) => void;
+    /** A function to determine if a task can be archived based on its ID. */
+    isArchivableTaskId: (taskId: string) => boolean;
 }
 
 /**
@@ -51,6 +58,9 @@ export function useTrainingPlan(user: User, cohort?: string): UseTrainingPlanRes
                 .filter((t) => !!t) ?? []
         );
     }, [user, allRequirements]);
+    const archivedTaskIds = useMemo(() => {
+        return user.archivedTasks ?? [];
+    }, [user]);
 
     const togglePin = (task: Requirement | CustomTask) => {
         const isPinned = pinnedTasks.some((t) => t.id === task.id);
@@ -61,6 +71,32 @@ export function useTrainingPlan(user: User, cohort?: string): UseTrainingPlanRes
 
         updateUser({ pinnedTasks: newIds });
         void api.updateUser({ pinnedTasks: newIds });
+    };
+
+    // Determines if a task can be archived based on its ID.
+    const isArchivableTaskId = (taskId: string) => {
+        if (taskId === CLASSICAL_GAMES_TASK_ID) {
+            return false;
+        }
+
+        if (taskId === GRADUATION_TASK_ID) {
+            return false;
+        }
+
+        return true;
+    };
+
+    const toggleArchived = (task: Requirement | CustomTask) => {
+        if (!isArchivableTaskId(task.id)) {
+            return;
+        }
+        const isArchived = archivedTaskIds.some((id) => id === task.id);
+        const newArchivedTasks = isArchived
+            ? archivedTaskIds.filter((id) => id !== task.id)
+            : [...archivedTaskIds, task.id];
+
+        updateUser({ archivedTasks: newArchivedTasks });
+        void api.updateUser({ archivedTasks: newArchivedTasks });
     };
 
     const toggleSkip = (...ids: string[]) => {
@@ -80,9 +116,12 @@ export function useTrainingPlan(user: User, cohort?: string): UseTrainingPlanRes
         allRequirements,
         pinnedTasks,
         togglePin,
+        archivedTaskIds,
+        toggleArchived,
         isCurrentUser: currentUser?.username === user.username,
         skippedTaskIds: user.weeklyPlan?.skippedTasks,
         toggleSkip,
+        isArchivableTaskId,
     };
 }
 
@@ -104,7 +143,8 @@ export interface UseWeeklyTrainingPlanResponse extends UseTrainingPlanResponse {
 export function useWeeklyTrainingPlan(user: User): UseWeeklyTrainingPlanResponse {
     const api = useApi();
     const trainingPlan = useTrainingPlan(user);
-    const { pinnedTasks, requirements, allRequirements, isCurrentUser } = trainingPlan;
+    const { pinnedTasks, archivedTaskIds, requirements, allRequirements, isCurrentUser } =
+        trainingPlan;
     const { entries: timeline } = useTimelineContext();
 
     const { suggestionsByDay, weekSuggestions, endDate, progressUpdatedAt, nextGame } =
@@ -141,6 +181,7 @@ export function useWeeklyTrainingPlan(user: User): UseWeeklyTrainingPlanResponse
                 endDate,
                 progressUpdatedAt,
                 pinnedTasks: pinnedTasks.map((t) => t.id),
+                archivedTasks: archivedTaskIds,
                 nextGame,
             }) ||
             isEmpty(suggestionsByDay) ||
@@ -159,6 +200,7 @@ export function useWeeklyTrainingPlan(user: User): UseWeeklyTrainingPlanResponse
             ),
             progressUpdatedAt,
             pinnedTasks: pinnedTasks.map((t) => t.id),
+            archivedTasks: archivedTaskIds,
             nextGame,
             skippedTasks:
                 (savedPlan?.endDate ?? '') >= endDate ? savedPlan?.skippedTasks : undefined,
@@ -174,6 +216,7 @@ export function useWeeklyTrainingPlan(user: User): UseWeeklyTrainingPlanResponse
         endDate,
         progressUpdatedAt,
         pinnedTasks,
+        archivedTaskIds,
         nextGame,
         api,
         isLoading,
@@ -214,6 +257,7 @@ function equalPlans(
         endDate: string;
         progressUpdatedAt: string;
         pinnedTasks: string[];
+        archivedTasks: string[];
         nextGame: string;
     },
 ) {
@@ -229,11 +273,33 @@ function equalPlans(
     if (savedPlan.nextGame !== newPlan.nextGame) {
         return false;
     }
-    for (let i = 0; i < newPlan.pinnedTasks.length; i++) {
-        if (savedPlan.pinnedTasks?.[i] !== newPlan.pinnedTasks[i]) {
+
+    // We want savedPlan.pinnedTasks = undefined and newPlan.pinnedTasks = [] to be considered equal
+    // to avoid triggering regenerations on rollout.
+    const savedPinnedTasks = savedPlan.pinnedTasks ?? [];
+    const newPinnedTasks = newPlan.pinnedTasks ?? [];
+    if (savedPinnedTasks.length !== newPinnedTasks.length) {
+        return false;
+    }
+    for (let i = 0; i < newPinnedTasks.length; i++) {
+        if (savedPinnedTasks[i] !== newPinnedTasks[i]) {
             return false;
         }
     }
+
+    // We want savedPlan.archivedTasks = undefined and newPlan.archivedTasks = [] to be considered equal
+    // to avoid triggering regenerations on rollout.
+    const savedArchivedTasks = savedPlan.archivedTasks ?? [];
+    const newArchivedTasks = newPlan.archivedTasks ?? [];
+    if (savedArchivedTasks.length !== newArchivedTasks.length) {
+        return false;
+    }
+    for (let i = 0; i < newArchivedTasks.length; i++) {
+        if (savedArchivedTasks[i] !== newArchivedTasks[i]) {
+            return false;
+        }
+    }
+
     for (let i = 0; i < savedPlan.tasks.length; i++) {
         const savedTasks = savedPlan.tasks[i];
         const newTasks = newPlan.suggestionsByDay[i];


### PR DESCRIPTION
## Summary

### Added archival system for tasks. 

Tasks can be archived and unarchived from the task dialog:

![ex3](https://github.com/user-attachments/assets/f80051d6-c3c3-420c-b246-88c0676793d0)

By default, any task a user archives is hidden from their training plan (from their perspective), and will not appear in weekly and daily task suggestions from the archival date onward.

The 'Archive Task' button, along with the timer next to it, are hidden when the TaskDialog was opened from a profile page other than the current user's.

Graduation tasks and play classical games tasks are not archivable. The archive button is grayed out for these tasks and a tooltip explains to the user that they cannot be archived.

When a user is looking at their own  profile, and if they have archived tasks, a checkbox will appear allowing them to toggle archived task visibility:

![ex2](https://github.com/user-attachments/assets/b4872e5a-4e93-4cf6-9efa-85e1d6594724)

This checkbox _will not appear_ if the user does not have any archived tasks in the currently visible cohort and subscription tier (e.g. if the 1400-1500 cohort is selected and the user has an archived task that only appears in the 1500-1600 cohort, or if the user is a free-tier user and only has paid tasks archived, or if the user simply does not have any archived tasks at all).

The checkbox _will not appear_ if the user is looking at a profile that is not their own. In this case, _archived tasks will be ignored entirely and the entire training plan will be shown_, regardless of what the current user or the user of the profile they're viewing have marked archived.

When visible, archived tasks appear below other tasks in their sections, grayed out and with an 'archived' chip:

![ex1](https://github.com/user-attachments/assets/8d83f597-05d6-4d89-84d7-45bb0413dcfc)

Archived tasks may still appear in the Daily section if the user has submitted progress for that task today. In that case, they will appear with an 'archived' chip:

![ex4](https://github.com/user-attachments/assets/220341a8-e10f-43c6-86b8-1145704b4336)

### Miscellaneous

Fixed typo in the descriptive text for DeleteCustomTaskModal.

## Related Issues

Implements #2055 

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}} 