### PR TITLE
feat(#2195): Mate in One Visualization Drill

### DIFF
--- a/backend/puzzleService/mateInOne.ts
+++ b/backend/puzzleService/mateInOne.ts
@@ -63,6 +63,9 @@ export const getNextPuzzleHandler: APIGatewayProxyHandlerV2 = async (event) => {
             ]);
 
         const document = await cursor.next();
+        if (!document) {
+            return errToApiGatewayProxyResultV2(new Error('No puzzle found'));
+        }
         const response: GetMateInOnePuzzleResponse = {
             puzzle: {
                 id: String(document?._id ?? ''),

--- a/backend/puzzleService/mateInOne.ts
+++ b/backend/puzzleService/mateInOne.ts
@@ -68,9 +68,9 @@ export const getNextPuzzleHandler: APIGatewayProxyHandlerV2 = async (event) => {
         }
         const response: GetMateInOnePuzzleResponse = {
             puzzle: {
-                id: String(document?._id ?? ''),
-                fen: document?.fen ?? '',
-                moves: document?.moves ?? [],
+                id: String(document._id),
+                fen: document.fen ?? '',
+                moves: document.moves ?? [],
             },
         };
 

--- a/backend/puzzleService/mateInOne.ts
+++ b/backend/puzzleService/mateInOne.ts
@@ -1,0 +1,111 @@
+import { PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+import {
+    GetMateInOnePuzzleResponse,
+    MateInOneSessionResult,
+    SubmitMateInOneSessionResponse,
+    submitMateInOneSessionSchema,
+} from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { MongoClient, ServerApiVersion } from 'mongodb';
+import {
+    errToApiGatewayProxyResultV2,
+    parseBody,
+    requireUserInfo,
+    success,
+} from '../directoryService/api';
+import { dynamo } from '../directoryService/database';
+
+const mateInOneResultsTable = `${process.env.stage}-mate-in-one-results`;
+
+const mongoClient = new MongoClient(process.env.MONGODB_URI ?? '', {
+    auth: {
+        username: process.env.AWS_ACCESS_KEY_ID,
+        password: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+    authSource: '$external',
+    authMechanism: 'MONGODB-AWS',
+    authMechanismProperties: {
+        AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN,
+    },
+    maxIdleTimeMS: 60000,
+    serverApi: {
+        version: ServerApiVersion.v1,
+        strict: true,
+        deprecationErrors: true,
+    },
+});
+
+/**
+ * Handles GET /puzzle/mate-in-one/next.
+ * Fetches a random mate-in-one puzzle in the 800-1200 rating band from MongoDB.
+ * Requires a valid JWT but does not read or write any DynamoDB user data.
+ *
+ * @param event - The API Gateway proxy event.
+ * @returns A response containing the next puzzle.
+ */
+export const getNextPuzzleHandler: APIGatewayProxyHandlerV2 = async (event) => {
+    try {
+        console.log('Event: %j', event);
+        requireUserInfo(event);
+
+        const cursor = mongoClient
+            .db('puzzles')
+            .collection('puzzles')
+            .aggregate([
+                {
+                    $match: {
+                        themes: { $in: ['mateIn1'] },
+                        rating: { $gte: 800, $lte: 1200 },
+                    },
+                },
+                { $sample: { size: 1 } },
+            ]);
+
+        const document = await cursor.next();
+        const response: GetMateInOnePuzzleResponse = {
+            puzzle: {
+                id: document?._id as string,
+                fen: document?.fen ?? '',
+                moves: document?.moves ?? [],
+            },
+        };
+
+        return success(response);
+    } catch (err) {
+        return errToApiGatewayProxyResultV2(err);
+    }
+};
+
+/**
+ * Handles POST /puzzle/mate-in-one/session.
+ * Validates and persists a mate-in-one drill session result to DynamoDB.
+ *
+ * @param event - The API Gateway proxy event.
+ * @returns An empty response on success.
+ */
+export const submitSessionHandler: APIGatewayProxyHandlerV2 = async (event) => {
+    try {
+        console.log('Event: %j', event);
+        const userInfo = requireUserInfo(event);
+        const request = parseBody(event, submitMateInOneSessionSchema);
+
+        const result: MateInOneSessionResult = {
+            ...request,
+            username: userInfo.username,
+            createdAt: request.createdAt ?? new Date().toISOString(),
+        };
+
+        await dynamo.send(
+            new PutItemCommand({
+                TableName: mateInOneResultsTable,
+                Item: marshall(result, { removeUndefinedValues: true }),
+            }),
+        );
+
+        const response: SubmitMateInOneSessionResponse = {};
+        return success(response);
+    } catch (err) {
+        return errToApiGatewayProxyResultV2(err);
+    }
+};

--- a/backend/puzzleService/mateInOne.ts
+++ b/backend/puzzleService/mateInOne.ts
@@ -65,7 +65,7 @@ export const getNextPuzzleHandler: APIGatewayProxyHandlerV2 = async (event) => {
         const document = await cursor.next();
         const response: GetMateInOnePuzzleResponse = {
             puzzle: {
-                id: document?._id as string,
+                id: String(document?._id ?? ''),
                 fen: document?.fen ?? '',
                 moves: document?.moves ?? [],
             },

--- a/backend/puzzleService/mateInOne/get.ts
+++ b/backend/puzzleService/mateInOne/get.ts
@@ -1,22 +1,7 @@
-import { PutItemCommand } from '@aws-sdk/client-dynamodb';
-import { marshall } from '@aws-sdk/util-dynamodb';
-import {
-    GetMateInOnePuzzleResponse,
-    MateInOneSessionResult,
-    SubmitMateInOneSessionResponse,
-    submitMateInOneSessionSchema,
-} from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import { GetMateInOnePuzzleResponse } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
 import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { MongoClient, ServerApiVersion } from 'mongodb';
-import {
-    errToApiGatewayProxyResultV2,
-    parseBody,
-    requireUserInfo,
-    success,
-} from '../directoryService/api';
-import { dynamo } from '../directoryService/database';
-
-const mateInOneResultsTable = `${process.env.stage}-mate-in-one-results`;
+import { errToApiGatewayProxyResultV2, requireUserInfo, success } from '../../directoryService/api';
 
 const mongoClient = new MongoClient(process.env.MONGODB_URI ?? '', {
     auth: {
@@ -74,39 +59,6 @@ export const getNextPuzzleHandler: APIGatewayProxyHandlerV2 = async (event) => {
             },
         };
 
-        return success(response);
-    } catch (err) {
-        return errToApiGatewayProxyResultV2(err);
-    }
-};
-
-/**
- * Handles POST /puzzle/mate-in-one/session.
- * Validates and persists a mate-in-one drill session result to DynamoDB.
- *
- * @param event - The API Gateway proxy event.
- * @returns An empty response on success.
- */
-export const submitSessionHandler: APIGatewayProxyHandlerV2 = async (event) => {
-    try {
-        console.log('Event: %j', event);
-        const userInfo = requireUserInfo(event);
-        const request = parseBody(event, submitMateInOneSessionSchema);
-
-        const result: MateInOneSessionResult = {
-            ...request,
-            username: userInfo.username,
-            createdAt: request.createdAt ?? new Date().toISOString(),
-        };
-
-        await dynamo.send(
-            new PutItemCommand({
-                TableName: mateInOneResultsTable,
-                Item: marshall(result, { removeUndefinedValues: true }),
-            }),
-        );
-
-        const response: SubmitMateInOneSessionResponse = {};
         return success(response);
     } catch (err) {
         return errToApiGatewayProxyResultV2(err);

--- a/backend/puzzleService/mateInOne/submit.ts
+++ b/backend/puzzleService/mateInOne/submit.ts
@@ -1,0 +1,50 @@
+import { PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+import {
+    MateInOneSessionResult,
+    SubmitMateInOneSessionResponse,
+    submitMateInOneSessionSchema,
+} from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import {
+    errToApiGatewayProxyResultV2,
+    parseBody,
+    requireUserInfo,
+    success,
+} from '../../directoryService/api';
+import { dynamo } from '../../directoryService/database';
+
+const mateInOneResultsTable = `${process.env.stage}-mate-in-one-results`;
+
+/**
+ * Handles POST /puzzle/mate-in-one/session.
+ * Validates and persists a mate-in-one drill session result to DynamoDB.
+ *
+ * @param event - The API Gateway proxy event.
+ * @returns An empty response on success.
+ */
+export const submitSessionHandler: APIGatewayProxyHandlerV2 = async (event) => {
+    try {
+        console.log('Event: %j', event);
+        const userInfo = requireUserInfo(event);
+        const request = parseBody(event, submitMateInOneSessionSchema);
+
+        const result: MateInOneSessionResult = {
+            ...request,
+            username: userInfo.username,
+            createdAt: request.createdAt ?? new Date().toISOString(),
+        };
+
+        await dynamo.send(
+            new PutItemCommand({
+                TableName: mateInOneResultsTable,
+                Item: marshall(result, { removeUndefinedValues: true }),
+            }),
+        );
+
+        const response: SubmitMateInOneSessionResponse = {};
+        return success(response);
+    } catch (err) {
+        return errToApiGatewayProxyResultV2(err);
+    }
+};

--- a/backend/puzzleService/serverless.yml
+++ b/backend/puzzleService/serverless.yml
@@ -85,7 +85,7 @@ functions:
         Resource: ${param:UsersTableArn}
 
   getMateInOnePuzzle:
-    handler: mateInOne.getNextPuzzleHandler
+    handler: mateInOne/get.getNextPuzzleHandler
     timeout: 15
     events:
       - httpApi:
@@ -100,7 +100,7 @@ functions:
     # by adding the function's role ARN as a database user in Mongo Cloud Atlas.
 
   submitMateInOneSession:
-    handler: mateInOne.submitSessionHandler
+    handler: mateInOne/submit.submitSessionHandler
     events:
       - httpApi:
           path: /puzzle/mate-in-one/session

--- a/backend/puzzleService/serverless.yml
+++ b/backend/puzzleService/serverless.yml
@@ -84,6 +84,36 @@ functions:
           - dynamodb:UpdateItem
         Resource: ${param:UsersTableArn}
 
+  getMateInOnePuzzle:
+    handler: mateInOne.getNextPuzzleHandler
+    timeout: 15
+    events:
+      - httpApi:
+          path: /puzzle/mate-in-one/next
+          method: get
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
+    environment:
+      MONGODB_URI: ${file(../config-${sls:stage}.yml):mongoUri}
+    # This function has read access to the MongoDB puzzle database, configured
+    # by adding the function's role ARN as a database user in Mongo Cloud Atlas.
+
+  submitMateInOneSession:
+    handler: mateInOne.submitSessionHandler
+    events:
+      - httpApi:
+          path: /puzzle/mate-in-one/session
+          method: post
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:PutItem
+        Resource: !GetAtt MateInOneResultsTable.Arn
+
 resources:
   Conditions:
     IsProd: !Equals ['${sls:stage}', 'prod']
@@ -116,6 +146,28 @@ resources:
       DeletionPolicy: Retain
       Properties:
         TableName: ${sls:stage}-square-color-results
+        BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: !If
+            - IsProd
+            - true
+            - false
+        AttributeDefinitions:
+          - AttributeName: username
+            AttributeType: S
+          - AttributeName: createdAt
+            AttributeType: S
+        KeySchema:
+          - AttributeName: username
+            KeyType: HASH
+          - AttributeName: createdAt
+            KeyType: RANGE
+
+    MateInOneResultsTable:
+      Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
+      Properties:
+        TableName: ${sls:stage}-mate-in-one-results
         BillingMode: PAY_PER_REQUEST
         PointInTimeRecoverySpecification:
           PointInTimeRecoveryEnabled: !If

--- a/common/src/mateInOne/api.ts
+++ b/common/src/mateInOne/api.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+/** A single puzzle attempt within a mate-in-one drill session. */
+const mateInOneAttemptSchema = z.object({
+    /** The Lichess puzzle ID. */
+    puzzleId: z.string(),
+    /** The FEN after the setup move (the position the user must solve). */
+    fen: z.string(),
+    /** The correct mating move in SAN notation. */
+    correctMove: z.string(),
+    /** The move the user entered. */
+    userMove: z.string(),
+    /** Whether the user's answer was correct. */
+    isCorrect: z.boolean(),
+    /** Time in milliseconds the user took to answer. */
+    responseTimeMs: z.number(),
+});
+
+/** Verifies the type of a request to submit a mate-in-one session. */
+export const submitMateInOneSessionSchema = z.object({
+    /** The total number of puzzles in the session. */
+    totalPuzzles: z.number(),
+    /** The number of correct answers. */
+    correctCount: z.number(),
+    /** The average response time in milliseconds. */
+    avgResponseTimeMs: z.number(),
+    /** The total time for the session in seconds. */
+    totalTimeSeconds: z.number(),
+    /** The individual puzzle attempts. */
+    attempts: z.array(mateInOneAttemptSchema),
+    /** Optional client-generated timestamp to allow updating the same session record. */
+    createdAt: z.string().datetime().optional(),
+});
+
+/** A request to submit a mate-in-one drill session. */
+export type SubmitMateInOneSessionRequest = z.infer<typeof submitMateInOneSessionSchema>;
+
+/** A single puzzle attempt within a mate-in-one session. */
+export type MateInOneAttempt = z.infer<typeof mateInOneAttemptSchema>;
+
+/** The result of a mate-in-one drill session, as stored in DynamoDB. */
+export interface MateInOneSessionResult extends SubmitMateInOneSessionRequest {
+    /** The username of the user who completed the session. */
+    username: string;
+    /** The ISO 8601 timestamp when the session was created. */
+    createdAt: string;
+}
+
+/** A mate-in-one puzzle from the Lichess database. */
+export interface MateInOnePuzzle {
+    /** The Lichess puzzle ID. */
+    id: string;
+    /** The FEN before the setup move. */
+    fen: string;
+    /** The move sequence: moves[0] is the setup move, moves[1] is the mating move. */
+    moves: string[];
+}
+
+/** Response from fetching a mate-in-one puzzle. */
+export interface GetMateInOnePuzzleResponse {
+    /** The puzzle to solve. */
+    puzzle: MateInOnePuzzle;
+}
+
+/** Response from submitting a mate-in-one session (empty for PR 1). */
+export type SubmitMateInOneSessionResponse = Record<string, never>;

--- a/common/src/mateInOne/fen.test.ts
+++ b/common/src/mateInOne/fen.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { fenToPieceList } from './fen';
+
+describe('fenToPieceList', () => {
+    it('starting position - all pieces and pawns', () => {
+        const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+        expect(fenToPieceList(fen)).toBe(
+            'White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1, pawns a2 b2 c2 d2 e2 f2 g2 h2 / Black: Qd8, Ra8, Rh8, Bc8, Bf8, Nb8, Ng8, Ke8, pawns a7 b7 c7 d7 e7 f7 g7 h7',
+        );
+    });
+
+    it('no pawns - Q and K vs K', () => {
+        // White Qd1 Ke1, Black Kh1
+        const fen = '8/8/8/8/8/8/8/3QK2k w - - 0 1';
+        expect(fenToPieceList(fen)).toBe('White: Qd1, Ke1 / Black: Kh1');
+    });
+
+    it('promotion - two queens on the board', () => {
+        // White has a promoted queen on a8 and original queen on d1, king on e1; Black king on h1
+        const fen = 'Q7/8/8/8/8/8/8/3QK2k w - - 0 1';
+        expect(fenToPieceList(fen)).toBe('White: Qa8, Qd1, Ke1 / Black: Kh1');
+    });
+
+    it('single piece each side - K vs K', () => {
+        // White Ke1, Black Ke8
+        const fen = '4k3/8/8/8/8/8/8/4K3 w - - 0 1';
+        expect(fenToPieceList(fen)).toBe('White: Ke1 / Black: Ke8');
+    });
+
+    it('only pawns remaining for one side', () => {
+        // White has only pawns a2 b2, Black has king and queen
+        const fen = '4k3/8/8/8/8/8/PP6/3QK3 w - - 0 1';
+        expect(fenToPieceList(fen)).toBe(
+            'White: Qd1, Ke1, pawns a2 b2 / Black: Ke8',
+        );
+    });
+
+    it('piece ordering - Q before R before B before N before K', () => {
+        // White has K, N, B, R, Q in various positions - should output Q, R, B, N, K order
+        const fen = '4k3/8/8/8/8/8/8/RNBQKBNR w - - 0 1';
+        expect(fenToPieceList(fen)).toBe(
+            'White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1 / Black: Ke8',
+        );
+    });
+
+    it('uses board field only - ignores side to move and other FEN fields', () => {
+        const fenW = '4k3/8/8/8/8/8/8/4K3 w - - 0 1';
+        const fenB = '4k3/8/8/8/8/8/8/4K3 b - - 0 1';
+        expect(fenToPieceList(fenW)).toBe(fenToPieceList(fenB));
+    });
+
+    it('mate-in-one position - Rxh7#', () => {
+        // Typical rook-delivers-mate position: White Re7 Ke1, Black Ke8 - placeholder
+        const fen = '4k3/4R3/8/8/8/8/8/4K3 w - - 0 1';
+        expect(fenToPieceList(fen)).toBe('White: Re7, Ke1 / Black: Ke8');
+    });
+});

--- a/common/src/mateInOne/fen.test.ts
+++ b/common/src/mateInOne/fen.test.ts
@@ -5,33 +5,33 @@ describe('fenToPieceList', () => {
     it('starting position - all pieces and pawns', () => {
         const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
         expect(fenToPieceList(fen)).toBe(
-            'White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1, pawns a2 b2 c2 d2 e2 f2 g2 h2 / Black: Qd8, Ra8, Rh8, Bc8, Bf8, Nb8, Ng8, Ke8, pawns a7 b7 c7 d7 e7 f7 g7 h7',
+            'White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1, pawns a2 b2 c2 d2 e2 f2 g2 h2\nBlack: Qd8, Ra8, Rh8, Bc8, Bf8, Nb8, Ng8, Ke8, pawns a7 b7 c7 d7 e7 f7 g7 h7',
         );
     });
 
     it('no pawns - Q and K vs K', () => {
         // White Qd1 Ke1, Black Kh1
         const fen = '8/8/8/8/8/8/8/3QK2k w - - 0 1';
-        expect(fenToPieceList(fen)).toBe('White: Qd1, Ke1 / Black: Kh1');
+        expect(fenToPieceList(fen)).toBe('White: Qd1, Ke1\nBlack: Kh1');
     });
 
     it('promotion - two queens on the board', () => {
         // White has a promoted queen on a8 and original queen on d1, king on e1; Black king on h1
         const fen = 'Q7/8/8/8/8/8/8/3QK2k w - - 0 1';
-        expect(fenToPieceList(fen)).toBe('White: Qa8, Qd1, Ke1 / Black: Kh1');
+        expect(fenToPieceList(fen)).toBe('White: Qa8, Qd1, Ke1\nBlack: Kh1');
     });
 
     it('single piece each side - K vs K', () => {
         // White Ke1, Black Ke8
         const fen = '4k3/8/8/8/8/8/8/4K3 w - - 0 1';
-        expect(fenToPieceList(fen)).toBe('White: Ke1 / Black: Ke8');
+        expect(fenToPieceList(fen)).toBe('White: Ke1\nBlack: Ke8');
     });
 
     it('only pawns remaining for one side', () => {
         // White has only pawns a2 b2, Black has king and queen
         const fen = '4k3/8/8/8/8/8/PP6/3QK3 w - - 0 1';
         expect(fenToPieceList(fen)).toBe(
-            'White: Qd1, Ke1, pawns a2 b2 / Black: Ke8',
+            'White: Qd1, Ke1, pawns a2 b2\nBlack: Ke8',
         );
     });
 
@@ -39,7 +39,7 @@ describe('fenToPieceList', () => {
         // White has K, N, B, R, Q in various positions - should output Q, R, B, N, K order
         const fen = '4k3/8/8/8/8/8/8/RNBQKBNR w - - 0 1';
         expect(fenToPieceList(fen)).toBe(
-            'White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1 / Black: Ke8',
+            'White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1\nBlack: Ke8',
         );
     });
 
@@ -52,6 +52,6 @@ describe('fenToPieceList', () => {
     it('mate-in-one position - Rxh7#', () => {
         // Typical rook-delivers-mate position: White Re7 Ke1, Black Ke8 - placeholder
         const fen = '4k3/4R3/8/8/8/8/8/4K3 w - - 0 1';
-        expect(fenToPieceList(fen)).toBe('White: Re7, Ke1 / Black: Ke8');
+        expect(fenToPieceList(fen)).toBe('White: Re7, Ke1\nBlack: Ke8');
     });
 });

--- a/common/src/mateInOne/fen.ts
+++ b/common/src/mateInOne/fen.ts
@@ -1,0 +1,87 @@
+const FILES = 'abcdefgh';
+
+/** Display order for non-pawn pieces: Q, R, B, N, K. */
+const PIECE_ORDER: Record<string, number> = {
+    Q: 0,
+    R: 1,
+    B: 2,
+    N: 3,
+    K: 4,
+};
+
+interface PieceEntry {
+    type: string;
+    square: string;
+}
+
+/**
+ * Formats one side's pieces into a human-readable string.
+ * Non-pawn pieces are listed first in Q > R > B > N > K order (comma-separated),
+ * followed by "pawns {sq1} {sq2} ..." if any pawns are present.
+ *
+ * @param pieces - All pieces for this side, in board-scan order.
+ * @returns A formatted string such as "Qd1, Ra1, Rh1, Ke1, pawns a2 b2".
+ */
+function formatSide(pieces: PieceEntry[]): string {
+    const nonPawns = pieces
+        .filter((p) => p.type !== 'P')
+        .sort((a, b) => (PIECE_ORDER[a.type] ?? 5) - (PIECE_ORDER[b.type] ?? 5));
+    const pawns = pieces.filter((p) => p.type === 'P');
+
+    const parts: string[] = [];
+    if (nonPawns.length > 0) {
+        parts.push(nonPawns.map((p) => `${p.type}${p.square}`).join(', '));
+    }
+    if (pawns.length > 0) {
+        parts.push(`pawns ${pawns.map((p) => p.square).join(' ')}`);
+    }
+    return parts.join(', ');
+}
+
+/**
+ * Converts a FEN string to a human-readable piece list suitable for a blindfold drill.
+ * Only the board field of the FEN is used; side-to-move, castling, and other fields
+ * are ignored.
+ *
+ * Output format: "White: {pieces} / Black: {pieces}"
+ * Non-pawn pieces appear in Q > R > B > N > K order, then "pawns {sq1} {sq2} ...".
+ *
+ * @example
+ * fenToPieceList('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1')
+ * // => "White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1, pawns a2 b2 c2 d2 e2 f2 g2 h2 / Black: Qd8, Ra8, Rh8, Bc8, Bf8, Nb8, Ng8, Ke8, pawns a7 b7 c7 d7 e7 f7 g7 h7"
+ *
+ * @param fen - A valid FEN string.
+ * @returns A human-readable description of all pieces on the board.
+ */
+export function fenToPieceList(fen: string): string {
+    const boardField = fen.split(' ')[0];
+    const ranks = boardField.split('/');
+
+    const whitePieces: PieceEntry[] = [];
+    const blackPieces: PieceEntry[] = [];
+
+    for (let rankIdx = 0; rankIdx < 8; rankIdx++) {
+        const rankNum = 8 - rankIdx; // index 0 = rank 8, index 7 = rank 1
+        const rankStr = ranks[rankIdx];
+        let fileIdx = 0;
+
+        for (const char of rankStr) {
+            if (char >= '1' && char <= '8') {
+                fileIdx += parseInt(char, 10);
+            } else {
+                const square = FILES[fileIdx] + rankNum;
+                const pieceType = char.toUpperCase();
+                const isWhite = char === char.toUpperCase();
+
+                if (isWhite) {
+                    whitePieces.push({ type: pieceType, square });
+                } else {
+                    blackPieces.push({ type: pieceType, square });
+                }
+                fileIdx++;
+            }
+        }
+    }
+
+    return `White: ${formatSide(whitePieces)} / Black: ${formatSide(blackPieces)}`;
+}

--- a/common/src/mateInOne/fen.ts
+++ b/common/src/mateInOne/fen.ts
@@ -33,7 +33,12 @@ function formatSide(pieces: PieceEntry[]): string {
         parts.push(nonPawns.map((p) => `${p.type}${p.square}`).join(', '));
     }
     if (pawns.length > 0) {
-        parts.push(`pawns ${pawns.map((p) => p.square).join(' ')}`);
+        parts.push(
+            `pawns ${pawns
+                .map((p) => p.square)
+                .sort((a, b) => a.localeCompare(b))
+                .join(' ')}`,
+        );
     }
     return parts.join(', ');
 }
@@ -45,6 +50,7 @@ function formatSide(pieces: PieceEntry[]): string {
  *
  * Output format: "White: {pieces} / Black: {pieces}"
  * Non-pawn pieces appear in Q > R > B > N > K order, then "pawns {sq1} {sq2} ...".
+ * Pawns are sorted by file: a -> h.
  *
  * @example
  * fenToPieceList('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1')
@@ -69,7 +75,7 @@ export function fenToPieceList(fen: string): string {
             if (char >= '1' && char <= '8') {
                 fileIdx += parseInt(char, 10);
             } else {
-                const square = FILES[fileIdx] + rankNum;
+                const square = FILES[fileIdx] + `${rankNum}`;
                 const pieceType = char.toUpperCase();
                 const isWhite = char === char.toUpperCase();
 

--- a/common/src/mateInOne/fen.ts
+++ b/common/src/mateInOne/fen.ts
@@ -48,7 +48,7 @@ function formatSide(pieces: PieceEntry[]): string {
  *
  * @example
  * fenToPieceList('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1')
- * // => "White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1, pawns a2 b2 c2 d2 e2 f2 g2 h2 / Black: Qd8, Ra8, Rh8, Bc8, Bf8, Nb8, Ng8, Ke8, pawns a7 b7 c7 d7 e7 f7 g7 h7"
+ * // => "White: Qd1, Ra1, Rh1, Bc1, Bf1, Nb1, Ng1, Ke1, pawns a2 b2 c2 d2 e2 f2 g2 h2\nBlack: Qd8, Ra8, Rh8, Bc8, Bf8, Nb8, Ng8, Ke8, pawns a7 b7 c7 d7 e7 f7 g7 h7"
  *
  * @param fen - A valid FEN string.
  * @returns A human-readable description of all pieces on the board.
@@ -83,5 +83,5 @@ export function fenToPieceList(fen: string): string {
         }
     }
 
-    return `White: ${formatSide(whitePieces)} / Black: ${formatSide(blackPieces)}`;
+    return `White: ${formatSide(whitePieces)}\nBlack: ${formatSide(blackPieces)}`;
 }

--- a/frontend/src/api/puzzleApi.ts
+++ b/frontend/src/api/puzzleApi.ts
@@ -1,4 +1,9 @@
 import {
+    GetMateInOnePuzzleResponse,
+    SubmitMateInOneSessionRequest,
+    SubmitMateInOneSessionResponse,
+} from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import {
     GetPuzzleHistoryRequest,
     GetPuzzleHistoryResponse,
     NextPuzzleRequest,
@@ -44,4 +49,29 @@ export function submitSquareColorSession(request: SubmitSquareColorSessionReques
     return axiosService.post<SubmitSquareColorSessionResponse>(`/puzzle/square-color`, request, {
         functionName: 'submitSquareColorSession',
     });
+}
+
+/**
+ * Fetches a random mate-in-one puzzle in the 800-1200 rating band.
+ * @returns A promise that resolves to a puzzle the user must solve.
+ */
+export function getMateInOnePuzzle(): Promise<AxiosResponse<GetMateInOnePuzzleResponse>> {
+    return axiosService.get<GetMateInOnePuzzleResponse>(`/puzzle/mate-in-one/next`, {
+        functionName: 'getMateInOnePuzzle',
+    });
+}
+
+/**
+ * Submits the results of a mate-in-one drill session.
+ * @param request The request containing the session results.
+ * @returns A promise that resolves to the response from the API.
+ */
+export function submitMateInOneSession(
+    request: SubmitMateInOneSessionRequest,
+): Promise<AxiosResponse<SubmitMateInOneSessionResponse>> {
+    return axiosService.post<SubmitMateInOneSessionResponse>(
+        `/puzzle/mate-in-one/session`,
+        request,
+        { functionName: 'submitMateInOneSession' },
+    );
 }

--- a/frontend/src/app/(scoreboard)/puzzles/mate-in-one/page.tsx
+++ b/frontend/src/app/(scoreboard)/puzzles/mate-in-one/page.tsx
@@ -1,0 +1,5 @@
+import { MateInOneDrillPage } from '@/components/puzzles/mateInOne/MateInOneDrillPage';
+
+export default function MateInOnePage() {
+    return <MateInOneDrillPage />;
+}

--- a/frontend/src/app/(scoreboard)/tests/page.tsx
+++ b/frontend/src/app/(scoreboard)/tests/page.tsx
@@ -40,8 +40,8 @@ export default function ExamLandingPage() {
                 />
 
                 <ExamCard
-                    name='Mate in One Drill'
-                    description='All Ratings'
+                    name='Blindfold Mate in One'
+                    description='Visualization Drill'
                     href='/puzzles/mate-in-one'
                     icon={EmojiEvents}
                 />

--- a/frontend/src/app/(scoreboard)/tests/page.tsx
+++ b/frontend/src/app/(scoreboard)/tests/page.tsx
@@ -40,7 +40,7 @@ export default function ExamLandingPage() {
                 />
 
                 <ExamCard
-                    name='Blindfold Mate in One'
+                    name='Mate in One Visualization Drill'
                     description='Visualization Drill'
                     href='/puzzles/mate-in-one'
                     icon={EmojiEvents}

--- a/frontend/src/app/(scoreboard)/tests/page.tsx
+++ b/frontend/src/app/(scoreboard)/tests/page.tsx
@@ -1,6 +1,6 @@
 import { ExamCard } from '@/components/exams/ExamCard';
 import { KingIcon, QueenIcon, RookIcon } from '@/style/ChessIcons';
-import { Visibility } from '@mui/icons-material';
+import { EmojiEvents, Visibility } from '@mui/icons-material';
 import { Container, Grid } from '@mui/material';
 
 /**
@@ -37,6 +37,13 @@ export default function ExamLandingPage() {
                     description='All Ratings'
                     href='/puzzles/square-colors'
                     icon={Visibility}
+                />
+
+                <ExamCard
+                    name='Mate in One Drill'
+                    description='All Ratings'
+                    href='/puzzles/mate-in-one'
+                    icon={EmojiEvents}
                 />
             </Grid>
         </Container>

--- a/frontend/src/app/(scoreboard)/tests/page.tsx
+++ b/frontend/src/app/(scoreboard)/tests/page.tsx
@@ -41,7 +41,7 @@ export default function ExamLandingPage() {
 
                 <ExamCard
                     name='Mate in One Visualization Drill'
-                    description='Visualization Drill'
+                    description='All Ratings'
                     href='/puzzles/mate-in-one'
                     icon={EmojiEvents}
                 />

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -84,7 +84,11 @@ function computeSolutionFromPuzzle(puzzle: MateInOnePuzzle): PuzzleWithSolution 
  * @returns The normalised lowercase move.
  */
 export function normalizeSan(san: string): string {
-    return san.replace(/[+#=]/g, '').toLowerCase().trim();
+    return san
+        .replace(/[x+#=-]/g, '')
+        .replace(/[0]/g, 'O')
+        .toLowerCase()
+        .trim();
 }
 
 /**

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -3,6 +3,7 @@
 import { getMateInOnePuzzle, submitMateInOneSession } from '@/api/puzzleApi';
 import { RequestSnackbar, useRequest } from '@/api/Request';
 import { AuthStatus, useAuth } from '@/auth/Auth';
+import Board from '@/board/Board';
 import LoadingPage from '@/loading/LoadingPage';
 import NotFoundPage from '@/NotFoundPage';
 import { Chess } from '@jackstenglein/chess';
@@ -23,7 +24,9 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
+import { Key } from 'chessground/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { computeSessionStats, isCorrectAnswer } from './mateInOneDrillUtils';
 
 const MIN_PUZZLES_FOR_RATING = 10;
 
@@ -34,6 +37,10 @@ interface PuzzleWithSolution {
     puzzle: MateInOnePuzzle;
     /** The correct mating move in SAN notation. */
     correctSan: string;
+    /** The correct move's from square. */
+    correctFrom: Key;
+    /** The correct move's to square. */
+    correctTo: Key;
     /** The FEN after the setup move (the position the user must solve). */
     fenAfterSetup: string;
     /** 'White' or 'Black', the side that delivers mate. */
@@ -61,8 +68,7 @@ function computeSolutionFromPuzzle(puzzle: MateInOnePuzzle): PuzzleWithSolution 
     chess.move(puzzle.moves[0]);
     const fenAfterSetup = chess.fen();
     const sideToMove = chess.turn() === 'w' ? 'White' : 'Black';
-    const sol = new Chess({ fen: fenAfterSetup });
-    const moveResult = sol.move(puzzle.moves[1]);
+    const moveResult = chess.move(puzzle.moves[1]);
     if (!moveResult) {
         throw new Error(`Invalid mating move for puzzle ${puzzle.id}: ${puzzle.moves[1]}`);
     }
@@ -70,59 +76,12 @@ function computeSolutionFromPuzzle(puzzle: MateInOnePuzzle): PuzzleWithSolution 
     return {
         puzzle,
         correctSan,
+        correctFrom: moveResult.from,
+        correctTo: moveResult.to,
         fenAfterSetup,
         sideToMove,
         pieceList: fenToPieceList(fenAfterSetup),
     };
-}
-
-/**
- * Strips check, checkmate, and promotion characters so answers like
- * "Qh7" match "Qh7#" and "a8Q" matches "a8=Q".
- *
- * @param san - A SAN move string.
- * @returns The normalised lowercase move.
- */
-export function normalizeSan(san: string): string {
-    return san
-        .replace(/[x+#=-]/g, '')
-        .replace(/[0]/g, 'O')
-        .toLowerCase()
-        .trim();
-}
-
-/**
- * Returns true when the user's input matches the correct mating move,
- * ignoring check/checkmate annotations and promotion `=` characters.
- *
- * @param userInput - The raw text the user typed.
- * @param correctSan - The correct SAN move from the puzzle.
- * @returns Whether the answer is considered correct.
- */
-export function isCorrectAnswer(userInput: string, correctSan: string): boolean {
-    return normalizeSan(userInput) === normalizeSan(correctSan);
-}
-
-/**
- * Computes summary statistics from a list of attempts.
- *
- * @param allAttempts - All attempts in the session.
- * @param sessionStartMs - The session start timestamp in milliseconds.
- * @returns The computed stats.
- */
-export function computeSessionStats(
-    allAttempts: MateInOneAttempt[],
-    sessionStartMs: number,
-): Pick<SessionSummary, 'totalTimeSeconds' | 'correctCount' | 'avgResponseTimeMs'> {
-    const totalTimeSeconds = Math.round((Date.now() - sessionStartMs) / 1000);
-    const correctCount = allAttempts.filter((a) => a.isCorrect).length;
-    const avgResponseTimeMs =
-        allAttempts.length > 0
-            ? Math.round(
-                  allAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / allAttempts.length,
-              )
-            : 0;
-    return { totalTimeSeconds, correctCount, avgResponseTimeMs };
 }
 
 /** Root component: requires authentication. */
@@ -323,11 +282,7 @@ function MateInOneDrill() {
         }).catch(() => undefined);
 
         setFeedback(correct ? 'correct' : 'incorrect');
-
-        setTimeout(() => {
-            advanceToNextPuzzle();
-        }, 600);
-    }, [currentPuzzle, feedback, userInput, advanceToNextPuzzle]);
+    }, [currentPuzzle, feedback, userInput]);
 
     if (drillState === 'loading') {
         return (
@@ -357,6 +312,7 @@ function MateInOneDrill() {
             userInput={userInput}
             onInputChange={setUserInput}
             onSubmit={handleSubmit}
+            onContinue={advanceToNextPuzzle}
             onStop={handleStop}
             feedback={feedback}
             prefetchLoading={prefetchLoading}
@@ -410,6 +366,7 @@ interface InProgressScreenProps {
     userInput: string;
     onInputChange: (value: string) => void;
     onSubmit: () => void;
+    onContinue: () => void;
     onStop: () => void;
     feedback: 'correct' | 'incorrect' | null;
     prefetchLoading: boolean;
@@ -424,6 +381,7 @@ interface InProgressScreenProps {
  * @param userInput - Current text in the move input field.
  * @param onInputChange - Callback to update the input value.
  * @param onSubmit - Callback invoked when the user submits their answer.
+ * @param onContinue - Callback invoked when the user continues to the next puzzle.
  * @param onStop - Callback invoked when the user ends the session early.
  * @param feedback - Current feedback state ('correct', 'incorrect', or null).
  * @param prefetchLoading - Whether the next puzzle is still being fetched.
@@ -436,6 +394,7 @@ function InProgressScreen({
     onInputChange,
     onSubmit,
     onStop,
+    onContinue,
     feedback,
     prefetchLoading,
     inputRef,
@@ -449,7 +408,7 @@ function InProgressScreen({
     }
 
     return (
-        <Container maxWidth='sm' sx={{ py: 6, textAlign: 'center' }}>
+        <Container maxWidth='sm' sx={{ py: 4, textAlign: 'center' }}>
             <Typography variant='subtitle1' color='text.secondary' sx={{ mb: 0.5 }}>
                 Puzzle {puzzleNumber}
             </Typography>
@@ -500,10 +459,17 @@ function InProgressScreen({
                     value={userInput}
                     onChange={(e) => onInputChange(e.target.value)}
                     onKeyDown={(e) => {
-                        if (e.key === 'Enter') onSubmit();
+                        if (e.key === 'Enter') {
+                            if (feedback) {
+                                onContinue();
+                            } else {
+                                onSubmit();
+                            }
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }
                     }}
                     placeholder='e.g. Qh7'
-                    disabled={feedback !== null}
                     size='small'
                     sx={{ width: 150 }}
                     autoComplete='off'
@@ -513,22 +479,42 @@ function InProgressScreen({
                 />
                 <Button
                     variant='contained'
-                    onClick={onSubmit}
-                    disabled={feedback !== null || userInput.trim() === ''}
+                    onClick={feedback ? onContinue : onSubmit}
+                    disabled={feedback === null && userInput.trim() === ''}
                 >
-                    Submit
+                    {feedback ? 'Continue' : 'Submit'}
+                </Button>
+
+                <Button variant='outlined' color='error' onClick={onStop}>
+                    Stop
                 </Button>
             </Stack>
 
-            <Button
-                variant='outlined'
-                size='small'
-                onClick={onStop}
-                disabled={feedback !== null}
-                sx={{ mt: 3 }}
-            >
-                Stop
-            </Button>
+            {feedback && (
+                <Stack direction='row' justifyContent='center'>
+                    <Box
+                        width={{ xs: 1, sm: 0.8, md: 0.75, lg: 0.75 }}
+                        sx={{ aspectRatio: 1, mt: 3 }}
+                    >
+                        <Board
+                            config={{
+                                fen: puzzle.fenAfterSetup,
+                                viewOnly: true,
+                                drawable: {
+                                    shapes: [
+                                        {
+                                            orig: puzzle.correctFrom,
+                                            dest: puzzle.correctTo,
+                                            brush: 'green',
+                                        },
+                                    ],
+                                    eraseOnClick: false,
+                                },
+                            }}
+                        />
+                    </Box>
+                </Stack>
+            )}
         </Container>
     );
 }

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -79,7 +79,7 @@ function computeSolutionFromPuzzle(puzzle: MateInOnePuzzle): PuzzleWithSolution 
  * @param san - A SAN move string.
  * @returns The normalised lowercase move.
  */
-function normalizeSan(san: string): string {
+export function normalizeSan(san: string): string {
     return san.replace(/[+#=]/g, '').toLowerCase().trim();
 }
 
@@ -91,8 +91,30 @@ function normalizeSan(san: string): string {
  * @param correctSan - The correct SAN move from the puzzle.
  * @returns Whether the answer is considered correct.
  */
-function isCorrectAnswer(userInput: string, correctSan: string): boolean {
+export function isCorrectAnswer(userInput: string, correctSan: string): boolean {
     return normalizeSan(userInput) === normalizeSan(correctSan);
+}
+
+/**
+ * Computes summary statistics from a list of attempts.
+ *
+ * @param allAttempts - All attempts in the session.
+ * @param sessionStartMs - The session start timestamp in milliseconds.
+ * @returns The computed stats.
+ */
+export function computeSessionStats(
+    allAttempts: MateInOneAttempt[],
+    sessionStartMs: number,
+): Pick<SessionSummary, 'totalTimeSeconds' | 'correctCount' | 'avgResponseTimeMs'> {
+    const totalTimeSeconds = Math.round((Date.now() - sessionStartMs) / 1000);
+    const correctCount = allAttempts.filter((a) => a.isCorrect).length;
+    const avgResponseTimeMs =
+        allAttempts.length > 0
+            ? Math.round(
+                  allAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / allAttempts.length,
+              )
+            : 0;
+    return { totalTimeSeconds, correctCount, avgResponseTimeMs };
 }
 
 /** Root component: requires authentication. */
@@ -119,6 +141,7 @@ function MateInOneDrill() {
     const [attempts, setAttempts] = useState<MateInOneAttempt[]>([]);
     const [summary, setSummary] = useState<SessionSummary | null>(null);
     const [prefetchLoading, setPrefetchLoading] = useState(false);
+    const [fetchError, setFetchError] = useState(false);
 
     const attemptsRef = useRef<MateInOneAttempt[]>([]);
     const sessionStartRef = useRef<number>(0);
@@ -126,6 +149,11 @@ function MateInOneDrill() {
     const sessionCreatedAtRef = useRef<string>('');
     const prefetchRef = useRef<Promise<PuzzleWithSolution> | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
+
+    const FOCUS_DELAY_MS = 50;
+    const focusInput = useCallback(() => {
+        setTimeout(() => inputRef.current?.focus(), FOCUS_DELAY_MS);
+    }, []);
 
     /** Fetches and computes a single puzzle. */
     const fetchPuzzle = useCallback(async (): Promise<PuzzleWithSolution> => {
@@ -143,9 +171,11 @@ function MateInOneDrill() {
         fetchPuzzle()
             .then((p) => {
                 setCurrentPuzzle(p);
+                setFetchError(false);
                 setDrillState('ready');
             })
             .catch(() => {
+                setFetchError(true);
                 setDrillState('ready');
             });
     }, [fetchPuzzle]);
@@ -156,13 +186,20 @@ function MateInOneDrill() {
         setFeedback(null);
         setSummary(null);
         setUserInput('');
+        setCurrentPuzzle(null);
+        prefetchRef.current = null;
         sessionStartRef.current = Date.now();
         sessionCreatedAtRef.current = new Date().toISOString();
-        questionStartRef.current = Date.now();
         setDrillState('in_progress');
-        prefetchNext();
-        setTimeout(() => inputRef.current?.focus(), 50);
-    }, [prefetchNext]);
+        fetchPuzzle()
+            .then((p) => {
+                setCurrentPuzzle(p);
+                questionStartRef.current = Date.now();
+                prefetchNext();
+                focusInput();
+            })
+            .catch(() => setDrillState('ready'));
+    }, [fetchPuzzle, prefetchNext, focusInput]);
 
     const finishDrill = useCallback(
         (allAttempts: MateInOneAttempt[]) => {
@@ -171,10 +208,9 @@ function MateInOneDrill() {
                 return;
             }
 
-            const totalTimeSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
-            const correctCount = allAttempts.filter((a) => a.isCorrect).length;
-            const avgResponseTimeMs = Math.round(
-                allAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / allAttempts.length,
+            const { totalTimeSeconds, correctCount, avgResponseTimeMs } = computeSessionStats(
+                allAttempts,
+                sessionStartRef.current,
             );
 
             const result: SessionSummary = {
@@ -216,7 +252,7 @@ function MateInOneDrill() {
                     setPrefetchLoading(false);
                     questionStartRef.current = Date.now();
                     prefetchNext();
-                    setTimeout(() => inputRef.current?.focus(), 50);
+                    focusInput();
                 })
                 .catch(() => setPrefetchLoading(false));
             return;
@@ -228,14 +264,14 @@ function MateInOneDrill() {
                 setPrefetchLoading(false);
                 questionStartRef.current = Date.now();
                 prefetchNext();
-                setTimeout(() => inputRef.current?.focus(), 50);
+                focusInput();
             })
             .catch(() => {
                 setPrefetchLoading(false);
             });
 
         prefetchRef.current = null;
-    }, [fetchPuzzle, prefetchNext]);
+    }, [fetchPuzzle, prefetchNext, focusInput]);
 
     const handleSubmit = useCallback(() => {
         if (!currentPuzzle || feedback !== null || userInput.trim() === '') return;
@@ -256,10 +292,9 @@ function MateInOneDrill() {
         attemptsRef.current = updatedAttempts;
         setAttempts(updatedAttempts);
 
-        const totalTimeSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
-        const correctCount = updatedAttempts.filter((a) => a.isCorrect).length;
-        const avgResponseTimeMs = Math.round(
-            updatedAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / updatedAttempts.length,
+        const { totalTimeSeconds, correctCount, avgResponseTimeMs } = computeSessionStats(
+            updatedAttempts,
+            sessionStartRef.current,
         );
 
         submitMateInOneSession({
@@ -287,7 +322,7 @@ function MateInOneDrill() {
     }
 
     if (drillState === 'ready') {
-        return <ReadyScreen onStart={startDrill} />;
+        return <ReadyScreen onStart={startDrill} fetchError={fetchError} />;
     }
 
     if (drillState === 'complete' && summary) {
@@ -319,7 +354,7 @@ function MateInOneDrill() {
  *
  * @param onStart - Callback invoked when the user confirms they want to start.
  */
-function ReadyScreen({ onStart }: { onStart: () => void }) {
+function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError: boolean }) {
     const [armed, setArmed] = useState(false);
 
     return (
@@ -336,6 +371,11 @@ function ReadyScreen({ onStart }: { onStart: () => void }) {
                     ? 'Ready? Hit GO! to start the timer.'
                     : 'No board is shown. Visualize the position and find the mate from memory!'}
             </Typography>
+            {fetchError && (
+                <Typography variant='body2' color='error' sx={{ mb: 2 }}>
+                    Could not load puzzles. Check your connection and try again.
+                </Typography>
+            )}
             <Button
                 variant='contained'
                 size='large'

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -577,7 +577,7 @@ function CompleteScreen({ summary, onPlayAgain }: CompleteScreenProps) {
             <Stack spacing={1} sx={{ mb: 4, maxHeight: 300, overflow: 'auto' }}>
                 {summary.attempts.map((a, i) => (
                     <Stack
-                        key={i}
+                        key={`${a.puzzleId}-${i}`}
                         direction='row'
                         justifyContent='space-between'
                         sx={{

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -62,7 +62,11 @@ function computeSolutionFromPuzzle(puzzle: MateInOnePuzzle): PuzzleWithSolution 
     const fenAfterSetup = chess.fen();
     const sideToMove = chess.turn() === 'w' ? 'White' : 'Black';
     const sol = new Chess({ fen: fenAfterSetup });
-    const correctSan = sol.move(puzzle.moves[1])?.san ?? puzzle.moves[1];
+    const moveResult = sol.move(puzzle.moves[1]);
+    if (!moveResult) {
+        throw new Error(`Invalid mating move for puzzle ${puzzle.id}: ${puzzle.moves[1]}`);
+    }
+    const correctSan = moveResult.san;
     return {
         puzzle,
         correctSan,
@@ -194,11 +198,15 @@ function MateInOneDrill() {
         fetchPuzzle()
             .then((p) => {
                 setCurrentPuzzle(p);
+                setFetchError(false);
                 questionStartRef.current = Date.now();
                 prefetchNext();
                 focusInput();
             })
-            .catch(() => setDrillState('ready'));
+            .catch(() => {
+                setFetchError(true);
+                setDrillState('ready');
+            });
     }, [fetchPuzzle, prefetchNext, focusInput]);
 
     const finishDrill = useCallback(

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -1,0 +1,595 @@
+'use client';
+
+import { getMateInOnePuzzle, submitMateInOneSession } from '@/api/puzzleApi';
+import { RequestSnackbar, useRequest } from '@/api/Request';
+import { AuthStatus, useAuth } from '@/auth/Auth';
+import LoadingPage from '@/loading/LoadingPage';
+import NotFoundPage from '@/NotFoundPage';
+import { Chess } from '@jackstenglein/chess';
+import {
+    MateInOneAttempt,
+    MateInOnePuzzle,
+} from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import { fenToPieceList } from '@jackstenglein/chess-dojo-common/src/mateInOne/fen';
+import AccessTime from '@mui/icons-material/AccessTime';
+import Target from '@mui/icons-material/GpsFixed';
+import Timer from '@mui/icons-material/Timer';
+import {
+    Box,
+    Button,
+    CircularProgress,
+    Container,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const MIN_PUZZLES_FOR_RATING = 10;
+
+type DrillState = 'loading' | 'ready' | 'in_progress' | 'complete';
+
+/** A puzzle with its pre-computed solution and display data. */
+interface PuzzleWithSolution {
+    puzzle: MateInOnePuzzle;
+    /** The correct mating move in SAN notation. */
+    correctSan: string;
+    /** The FEN after the setup move (the position the user must solve). */
+    fenAfterSetup: string;
+    /** 'White' or 'Black', the side that delivers mate. */
+    sideToMove: string;
+    /** Human-readable piece list derived from fenAfterSetup. */
+    pieceList: string;
+}
+
+interface SessionSummary {
+    totalPuzzles: number;
+    correctCount: number;
+    avgResponseTimeMs: number;
+    totalTimeSeconds: number;
+    attempts: MateInOneAttempt[];
+}
+
+/**
+ * Applies the setup move from a puzzle and computes display data for it.
+ *
+ * @param puzzle - The raw puzzle from the API.
+ * @returns The puzzle enriched with solution info and display strings.
+ */
+function computeSolutionFromPuzzle(puzzle: MateInOnePuzzle): PuzzleWithSolution {
+    const chess = new Chess({ fen: puzzle.fen });
+    chess.move(puzzle.moves[0]);
+    const fenAfterSetup = chess.fen();
+    const sideToMove = chess.turn() === 'w' ? 'White' : 'Black';
+    const sol = new Chess({ fen: fenAfterSetup });
+    const correctSan = sol.move(puzzle.moves[1])?.san ?? puzzle.moves[1];
+    return {
+        puzzle,
+        correctSan,
+        fenAfterSetup,
+        sideToMove,
+        pieceList: fenToPieceList(fenAfterSetup),
+    };
+}
+
+/**
+ * Strips check, checkmate, and promotion characters so answers like
+ * "Qh7" match "Qh7#" and "a8Q" matches "a8=Q".
+ *
+ * @param san - A SAN move string.
+ * @returns The normalised lowercase move.
+ */
+function normalizeSan(san: string): string {
+    return san.replace(/[+#=]/g, '').toLowerCase().trim();
+}
+
+/**
+ * Returns true when the user's input matches the correct mating move,
+ * ignoring check/checkmate annotations and promotion `=` characters.
+ *
+ * @param userInput - The raw text the user typed.
+ * @param correctSan - The correct SAN move from the puzzle.
+ * @returns Whether the answer is considered correct.
+ */
+function isCorrectAnswer(userInput: string, correctSan: string): boolean {
+    return normalizeSan(userInput) === normalizeSan(correctSan);
+}
+
+/** Root component: requires authentication. */
+export function MateInOneDrillPage() {
+    const { user, status } = useAuth();
+
+    if (status === AuthStatus.Loading) {
+        return <LoadingPage />;
+    }
+    if (!user) {
+        return <NotFoundPage />;
+    }
+
+    return <MateInOneDrill />;
+}
+
+/** Inner component: manages the full drill lifecycle. */
+function MateInOneDrill() {
+    const submitRequest = useRequest();
+    const [drillState, setDrillState] = useState<DrillState>('loading');
+    const [currentPuzzle, setCurrentPuzzle] = useState<PuzzleWithSolution | null>(null);
+    const [userInput, setUserInput] = useState('');
+    const [feedback, setFeedback] = useState<'correct' | 'incorrect' | null>(null);
+    const [attempts, setAttempts] = useState<MateInOneAttempt[]>([]);
+    const [summary, setSummary] = useState<SessionSummary | null>(null);
+    const [prefetchLoading, setPrefetchLoading] = useState(false);
+
+    const attemptsRef = useRef<MateInOneAttempt[]>([]);
+    const sessionStartRef = useRef<number>(0);
+    const questionStartRef = useRef<number>(0);
+    const sessionCreatedAtRef = useRef<string>('');
+    const prefetchRef = useRef<Promise<PuzzleWithSolution> | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    /** Fetches and computes a single puzzle. */
+    const fetchPuzzle = useCallback(async (): Promise<PuzzleWithSolution> => {
+        const response = await getMateInOnePuzzle();
+        return computeSolutionFromPuzzle(response.data.puzzle);
+    }, []);
+
+    /** Kicks off a background prefetch for the next puzzle. */
+    const prefetchNext = useCallback(() => {
+        prefetchRef.current = fetchPuzzle();
+    }, [fetchPuzzle]);
+
+    /** Loads the first puzzle on mount. */
+    useEffect(() => {
+        fetchPuzzle()
+            .then((p) => {
+                setCurrentPuzzle(p);
+                setDrillState('ready');
+            })
+            .catch(() => {
+                setDrillState('ready');
+            });
+    }, [fetchPuzzle]);
+
+    const startDrill = useCallback(() => {
+        setAttempts([]);
+        attemptsRef.current = [];
+        setFeedback(null);
+        setSummary(null);
+        setUserInput('');
+        sessionStartRef.current = Date.now();
+        sessionCreatedAtRef.current = new Date().toISOString();
+        questionStartRef.current = Date.now();
+        setDrillState('in_progress');
+        prefetchNext();
+        setTimeout(() => inputRef.current?.focus(), 50);
+    }, [prefetchNext]);
+
+    const finishDrill = useCallback(
+        (allAttempts: MateInOneAttempt[]) => {
+            if (allAttempts.length === 0) {
+                setDrillState('ready');
+                return;
+            }
+
+            const totalTimeSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
+            const correctCount = allAttempts.filter((a) => a.isCorrect).length;
+            const avgResponseTimeMs = Math.round(
+                allAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / allAttempts.length,
+            );
+
+            const result: SessionSummary = {
+                totalPuzzles: allAttempts.length,
+                correctCount,
+                avgResponseTimeMs,
+                totalTimeSeconds,
+                attempts: allAttempts,
+            };
+
+            setSummary(result);
+            setDrillState('complete');
+
+            submitRequest.onStart();
+            submitMateInOneSession({
+                ...result,
+                createdAt: sessionCreatedAtRef.current,
+            }).then(
+                () => submitRequest.onSuccess(),
+                (err: unknown) => submitRequest.onFailure(err),
+            );
+        },
+        [submitRequest],
+    );
+
+    const handleStop = useCallback(() => {
+        finishDrill(attemptsRef.current);
+    }, [finishDrill]);
+
+    const advanceToNextPuzzle = useCallback(() => {
+        setUserInput('');
+        setFeedback(null);
+
+        if (!prefetchRef.current) {
+            setPrefetchLoading(true);
+            fetchPuzzle()
+                .then((p) => {
+                    setCurrentPuzzle(p);
+                    setPrefetchLoading(false);
+                    questionStartRef.current = Date.now();
+                    prefetchNext();
+                    setTimeout(() => inputRef.current?.focus(), 50);
+                })
+                .catch(() => setPrefetchLoading(false));
+            return;
+        }
+
+        prefetchRef.current
+            .then((p) => {
+                setCurrentPuzzle(p);
+                setPrefetchLoading(false);
+                questionStartRef.current = Date.now();
+                prefetchNext();
+                setTimeout(() => inputRef.current?.focus(), 50);
+            })
+            .catch(() => {
+                setPrefetchLoading(false);
+            });
+
+        prefetchRef.current = null;
+    }, [fetchPuzzle, prefetchNext]);
+
+    const handleSubmit = useCallback(() => {
+        if (!currentPuzzle || feedback !== null || userInput.trim() === '') return;
+
+        const responseTimeMs = Date.now() - questionStartRef.current;
+        const correct = isCorrectAnswer(userInput, currentPuzzle.correctSan);
+
+        const attempt: MateInOneAttempt = {
+            puzzleId: currentPuzzle.puzzle.id,
+            fen: currentPuzzle.fenAfterSetup,
+            correctMove: currentPuzzle.correctSan,
+            userMove: userInput.trim(),
+            isCorrect: correct,
+            responseTimeMs,
+        };
+
+        const updatedAttempts = [...attemptsRef.current, attempt];
+        attemptsRef.current = updatedAttempts;
+        setAttempts(updatedAttempts);
+
+        const totalTimeSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
+        const correctCount = updatedAttempts.filter((a) => a.isCorrect).length;
+        const avgResponseTimeMs = Math.round(
+            updatedAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / updatedAttempts.length,
+        );
+
+        submitMateInOneSession({
+            totalPuzzles: updatedAttempts.length,
+            correctCount,
+            avgResponseTimeMs,
+            totalTimeSeconds,
+            attempts: updatedAttempts,
+            createdAt: sessionCreatedAtRef.current,
+        }).catch(() => undefined);
+
+        setFeedback(correct ? 'correct' : 'incorrect');
+
+        setTimeout(() => {
+            advanceToNextPuzzle();
+        }, 600);
+    }, [currentPuzzle, feedback, userInput, advanceToNextPuzzle]);
+
+    if (drillState === 'loading') {
+        return (
+            <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
+                <CircularProgress />
+            </Container>
+        );
+    }
+
+    if (drillState === 'ready') {
+        return <ReadyScreen onStart={startDrill} />;
+    }
+
+    if (drillState === 'complete' && summary) {
+        return (
+            <>
+                <CompleteScreen summary={summary} onPlayAgain={startDrill} />
+                <RequestSnackbar request={submitRequest} />
+            </>
+        );
+    }
+
+    return (
+        <InProgressScreen
+            puzzle={currentPuzzle}
+            puzzleNumber={attempts.length + 1}
+            userInput={userInput}
+            onInputChange={setUserInput}
+            onSubmit={handleSubmit}
+            onStop={handleStop}
+            feedback={feedback}
+            prefetchLoading={prefetchLoading}
+            inputRef={inputRef}
+        />
+    );
+}
+
+/**
+ * Landing screen with a two-step armed Start flow.
+ *
+ * @param onStart - Callback invoked when the user confirms they want to start.
+ */
+function ReadyScreen({ onStart }: { onStart: () => void }) {
+    const [armed, setArmed] = useState(false);
+
+    return (
+        <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
+            <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 2 }}>
+                Mate in One Drill
+            </Typography>
+            <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
+                You will see a list of pieces and their squares. Type the mating move in SAN
+                notation (e.g. "Qh7#" or just "Qh7") and press Enter.
+            </Typography>
+            <Typography variant='body1' color='text.secondary' sx={{ mb: 4 }}>
+                {armed
+                    ? 'Ready? Hit GO! to start the timer.'
+                    : 'No board is shown. Visualize the position and find the mate from memory!'}
+            </Typography>
+            <Button
+                variant='contained'
+                size='large'
+                onClick={armed ? onStart : () => setArmed(true)}
+                sx={{ px: 6, py: 1.5 }}
+            >
+                {armed ? 'GO!' : 'Start'}
+            </Button>
+        </Container>
+    );
+}
+
+interface InProgressScreenProps {
+    puzzle: PuzzleWithSolution | null;
+    puzzleNumber: number;
+    userInput: string;
+    onInputChange: (value: string) => void;
+    onSubmit: () => void;
+    onStop: () => void;
+    feedback: 'correct' | 'incorrect' | null;
+    prefetchLoading: boolean;
+    inputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+/**
+ * Active drill screen: shows piece list, accepts typed move, flashes feedback.
+ *
+ * @param puzzle - The current puzzle with solution data.
+ * @param puzzleNumber - 1-based index of the current puzzle in the session.
+ * @param userInput - Current text in the move input field.
+ * @param onInputChange - Callback to update the input value.
+ * @param onSubmit - Callback invoked when the user submits their answer.
+ * @param onStop - Callback invoked when the user ends the session early.
+ * @param feedback - Current feedback state ('correct', 'incorrect', or null).
+ * @param prefetchLoading - Whether the next puzzle is still being fetched.
+ * @param inputRef - Ref to the text input element for programmatic focus.
+ */
+function InProgressScreen({
+    puzzle,
+    puzzleNumber,
+    userInput,
+    onInputChange,
+    onSubmit,
+    onStop,
+    feedback,
+    prefetchLoading,
+    inputRef,
+}: InProgressScreenProps) {
+    if (!puzzle || prefetchLoading) {
+        return (
+            <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
+                <CircularProgress />
+            </Container>
+        );
+    }
+
+    return (
+        <Container maxWidth='sm' sx={{ py: 6, textAlign: 'center' }}>
+            <Typography variant='subtitle1' color='text.secondary' sx={{ mb: 0.5 }}>
+                Puzzle {puzzleNumber}
+            </Typography>
+
+            <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
+                {puzzle.sideToMove} to move and mate in 1
+            </Typography>
+
+            <Box
+                sx={{
+                    py: 3,
+                    px: 2,
+                    mb: 4,
+                    borderRadius: 2,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    backgroundColor:
+                        feedback === 'correct'
+                            ? 'success.main'
+                            : feedback === 'incorrect'
+                              ? 'error.main'
+                              : 'background.paper',
+                    transition: 'background-color 0.15s',
+                }}
+            >
+                <Typography
+                    variant='body1'
+                    sx={{
+                        fontFamily: 'monospace',
+                        fontSize: '1rem',
+                        color: feedback ? 'white' : 'text.primary',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                    }}
+                >
+                    {puzzle.pieceList}
+                </Typography>
+                {feedback === 'incorrect' && (
+                    <Typography variant='body2' sx={{ mt: 1, color: 'white', fontWeight: 'bold' }}>
+                        Correct: {puzzle.correctSan}
+                    </Typography>
+                )}
+            </Box>
+
+            <Stack direction='row' spacing={2} justifyContent='center' alignItems='center'>
+                <TextField
+                    inputRef={inputRef}
+                    value={userInput}
+                    onChange={(e) => onInputChange(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') onSubmit();
+                    }}
+                    placeholder='e.g. Qh7'
+                    disabled={feedback !== null}
+                    size='small'
+                    sx={{ width: 150 }}
+                    autoComplete='off'
+                    autoCorrect='off'
+                    autoCapitalize='off'
+                    spellCheck={false}
+                />
+                <Button
+                    variant='contained'
+                    onClick={onSubmit}
+                    disabled={feedback !== null || userInput.trim() === ''}
+                >
+                    Submit
+                </Button>
+            </Stack>
+
+            <Button
+                variant='outlined'
+                size='small'
+                onClick={onStop}
+                disabled={feedback !== null}
+                sx={{ mt: 3 }}
+            >
+                Stop
+            </Button>
+        </Container>
+    );
+}
+
+interface CompleteScreenProps {
+    summary: SessionSummary;
+    onPlayAgain: () => void;
+}
+
+/**
+ * Summary screen shown after the session ends.
+ *
+ * @param summary - The computed session statistics.
+ * @param onPlayAgain - Callback invoked when the user wants another session.
+ */
+function CompleteScreen({ summary, onPlayAgain }: CompleteScreenProps) {
+    const accuracy =
+        summary.totalPuzzles > 0
+            ? Math.round((summary.correctCount / summary.totalPuzzles) * 100)
+            : 0;
+    const avgTime = (summary.avgResponseTimeMs / 1000).toFixed(1);
+
+    return (
+        <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
+            <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 4 }}>
+                Session Complete!
+            </Typography>
+
+            {summary.totalPuzzles < MIN_PUZZLES_FOR_RATING && (
+                <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
+                    Complete at least {MIN_PUZZLES_FOR_RATING} puzzles in a session to unlock
+                    ratings (coming soon).
+                </Typography>
+            )}
+
+            <Stack spacing={2} sx={{ mb: 4 }}>
+                <StatRow
+                    icon={<Target fontSize='small' />}
+                    label='Accuracy'
+                    value={`${accuracy}% (${summary.correctCount}/${summary.totalPuzzles})`}
+                />
+                <StatRow
+                    icon={<Timer fontSize='small' />}
+                    label='Avg Response Time'
+                    value={`${avgTime}s`}
+                />
+                <StatRow
+                    icon={<AccessTime fontSize='small' />}
+                    label='Total Time'
+                    value={`${summary.totalTimeSeconds}s`}
+                />
+            </Stack>
+
+            <Stack spacing={1} sx={{ mb: 4, maxHeight: 300, overflow: 'auto' }}>
+                {summary.attempts.map((a, i) => (
+                    <Stack
+                        key={i}
+                        direction='row'
+                        justifyContent='space-between'
+                        sx={{
+                            px: 2,
+                            py: 0.5,
+                            borderBottom: '1px solid',
+                            borderColor: 'divider',
+                        }}
+                    >
+                        <Typography fontWeight='bold' sx={{ textAlign: 'left', flex: 1 }}>
+                            {a.puzzleId}
+                        </Typography>
+                        <Typography
+                            sx={{ flex: 1, textAlign: 'center' }}
+                            color={a.isCorrect ? 'success.main' : 'error.main'}
+                        >
+                            {a.isCorrect ? a.userMove : `${a.userMove} (${a.correctMove})`}
+                        </Typography>
+                        <Typography
+                            color='text.secondary'
+                            sx={{ width: { sm: 76 }, textAlign: 'right' }}
+                        >
+                            {(a.responseTimeMs / 1000).toFixed(1)}s
+                        </Typography>
+                    </Stack>
+                ))}
+            </Stack>
+
+            <Button variant='contained' size='large' onClick={onPlayAgain} sx={{ px: 6, py: 1.5 }}>
+                Play Again
+            </Button>
+        </Container>
+    );
+}
+
+/**
+ * A single labeled stat row for the summary table.
+ *
+ * @param icon - An icon element displayed before the label.
+ * @param label - The human-readable label for the stat.
+ * @param value - The formatted value to display.
+ */
+function StatRow({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+    return (
+        <Stack
+            direction='row'
+            justifyContent='space-between'
+            alignItems='center'
+            sx={{
+                px: 2,
+                py: 1,
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+            }}
+        >
+            <Stack direction='row' alignItems='center' spacing={1}>
+                <Box sx={{ color: 'text.secondary', display: 'flex' }}>{icon}</Box>
+                <Typography color='text.secondary'>{label}</Typography>
+            </Stack>
+            <Typography fontWeight='bold'>{value}</Typography>
+        </Stack>
+    );
+}

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -262,7 +262,10 @@ function MateInOneDrill() {
                     prefetchNext();
                     focusInput();
                 })
-                .catch(() => setPrefetchLoading(false));
+                .catch(() => {
+                    setPrefetchLoading(false);
+                    setFetchError(true);
+                });
             return;
         }
 
@@ -276,6 +279,7 @@ function MateInOneDrill() {
             })
             .catch(() => {
                 setPrefetchLoading(false);
+                setFetchError(true);
             });
 
         prefetchRef.current = null;

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -360,7 +360,7 @@ function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError:
     return (
         <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
             <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 2 }}>
-                Mate in One Drill
+                Mate in One Visualization Drill
             </Typography>
             <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
                 You will see a list of pieces and their squares. Type the mating move in SAN

--- a/frontend/src/components/puzzles/mateInOne/computeSessionStats.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/computeSessionStats.test.ts
@@ -1,6 +1,6 @@
 import { MateInOneAttempt } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
 import { describe, expect, it, vi } from 'vitest';
-import { computeSessionStats } from './MateInOneDrillPage';
+import { computeSessionStats } from './mateInOneDrillUtils';
 
 function makeAttempt(overrides: Partial<MateInOneAttempt> = {}): MateInOneAttempt {
     return {

--- a/frontend/src/components/puzzles/mateInOne/computeSessionStats.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/computeSessionStats.test.ts
@@ -1,0 +1,66 @@
+import { MateInOneAttempt } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import { describe, expect, it, vi } from 'vitest';
+import { computeSessionStats } from './MateInOneDrillPage';
+
+function makeAttempt(overrides: Partial<MateInOneAttempt> = {}): MateInOneAttempt {
+    return {
+        puzzleId: 'abc01',
+        fen: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1',
+        correctMove: 'Qh5',
+        userMove: 'Qh5',
+        isCorrect: true,
+        responseTimeMs: 500,
+        ...overrides,
+    };
+}
+
+describe('computeSessionStats', () => {
+    it('counts all correct attempts', () => {
+        const attempts = [makeAttempt(), makeAttempt(), makeAttempt()];
+        const result = computeSessionStats(attempts, Date.now());
+        expect(result.correctCount).toBe(3);
+    });
+
+    it('counts mixed correct/incorrect attempts', () => {
+        const attempts = [
+            makeAttempt({ isCorrect: true }),
+            makeAttempt({ isCorrect: false }),
+            makeAttempt({ isCorrect: true }),
+        ];
+        const result = computeSessionStats(attempts, Date.now());
+        expect(result.correctCount).toBe(2);
+    });
+
+    it('computes average response time', () => {
+        const attempts = [
+            makeAttempt({ responseTimeMs: 200 }),
+            makeAttempt({ responseTimeMs: 400 }),
+            makeAttempt({ responseTimeMs: 600 }),
+        ];
+        const result = computeSessionStats(attempts, Date.now());
+        expect(result.avgResponseTimeMs).toBe(400);
+    });
+
+    it('rounds average response time to nearest integer', () => {
+        const attempts = [
+            makeAttempt({ responseTimeMs: 100 }),
+            makeAttempt({ responseTimeMs: 201 }),
+        ];
+        const result = computeSessionStats(attempts, Date.now());
+        expect(result.avgResponseTimeMs).toBe(151);
+    });
+
+    it('returns 0 for avgResponseTimeMs when there are no attempts', () => {
+        const result = computeSessionStats([], Date.now());
+        expect(result.avgResponseTimeMs).toBe(0);
+    });
+
+    it('computes total time in seconds from session start', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-01-01T00:00:30Z'));
+        const sessionStart = new Date('2025-01-01T00:00:00Z').getTime();
+        const result = computeSessionStats([makeAttempt()], sessionStart);
+        expect(result.totalTimeSeconds).toBe(30);
+        vi.useRealTimers();
+    });
+});

--- a/frontend/src/components/puzzles/mateInOne/mateInOneDrillUtils.ts
+++ b/frontend/src/components/puzzles/mateInOne/mateInOneDrillUtils.ts
@@ -1,0 +1,42 @@
+import { MateInOneAttempt } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+
+/**
+ * Strips check, checkmate, and promotion characters so answers like
+ * "Qh7" match "Qh7#" and "a8Q" matches "a8=Q".
+ *
+ * @param san - A SAN move string.
+ * @returns The normalised lowercase move.
+ */
+export function normalizeSan(san: string): string {
+    return san
+        .replace(/[x+#=-]/g, '')
+        .replace(/[0]/g, 'O')
+        .toLowerCase()
+        .trim();
+}
+
+/**
+ * Returns true when the user's input matches the correct mating move,
+ * ignoring check/checkmate annotations and promotion `=` characters.
+ */
+export function isCorrectAnswer(userInput: string, correctSan: string): boolean {
+    return normalizeSan(userInput) === normalizeSan(correctSan);
+}
+
+/**
+ * Computes summary statistics from a list of attempts.
+ */
+export function computeSessionStats(
+    allAttempts: MateInOneAttempt[],
+    sessionStartMs: number,
+): { totalTimeSeconds: number; correctCount: number; avgResponseTimeMs: number } {
+    const totalTimeSeconds = Math.round((Date.now() - sessionStartMs) / 1000);
+    const correctCount = allAttempts.filter((a) => a.isCorrect).length;
+    const avgResponseTimeMs =
+        allAttempts.length > 0
+            ? Math.round(
+                  allAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / allAttempts.length,
+              )
+            : 0;
+    return { totalTimeSeconds, correctCount, avgResponseTimeMs };
+}

--- a/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isCorrectAnswer, normalizeSan } from './MateInOneDrillPage';
+import { isCorrectAnswer, normalizeSan } from './mateInOneDrillUtils';
 
 describe('normalizeSan', () => {
     it('strips check annotation', () => {

--- a/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
@@ -19,16 +19,20 @@ describe('normalizeSan', () => {
     });
 
     it('handles castling', () => {
-        expect(normalizeSan('O-O')).toBe('o-o');
-        expect(normalizeSan('O-O-O')).toBe('o-o-o');
+        expect(normalizeSan('O-O')).toBe('oo');
+        expect(normalizeSan('O-O-O')).toBe('ooo');
     });
 
     it('handles castling with check', () => {
-        expect(normalizeSan('O-O+')).toBe('o-o');
+        expect(normalizeSan('O-O+')).toBe('oo');
     });
 
     it('trims surrounding whitespace', () => {
         expect(normalizeSan('  Qh7  ')).toBe('qh7');
+    });
+
+    it('strips captures', () => {
+        expect(normalizeSan('Qxh7')).toBe('qh7');
     });
 });
 
@@ -55,5 +59,21 @@ describe('isCorrectAnswer', () => {
 
     it('is case-insensitive', () => {
         expect(isCorrectAnswer('qh7', 'Qh7#')).toBe(true);
+    });
+
+    it('accepts answer without capture notation', () => {
+        expect(isCorrectAnswer('Qh7', 'Qxh7')).toBe(true);
+    });
+
+    it('accepts castling using zeroes', () => {
+        expect(isCorrectAnswer('0-0', 'O-O')).toBe(true);
+    });
+
+    it('accepts castling without dashes', () => {
+        expect(isCorrectAnswer('OO', 'O-O')).toBe(true);
+    });
+
+    it('rejects castling wrong way', () => {
+        expect(isCorrectAnswer('O-O-O', 'O-O')).toBe(false);
     });
 });

--- a/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { isCorrectAnswer, normalizeSan } from './MateInOneDrillPage';
+
+describe('normalizeSan', () => {
+    it('strips check annotation', () => {
+        expect(normalizeSan('Qh7+')).toBe('qh7');
+    });
+
+    it('strips checkmate annotation', () => {
+        expect(normalizeSan('Qh7#')).toBe('qh7');
+    });
+
+    it('strips promotion equals sign', () => {
+        expect(normalizeSan('a8=Q')).toBe('a8q');
+    });
+
+    it('lowercases the result', () => {
+        expect(normalizeSan('Nf3')).toBe('nf3');
+    });
+
+    it('handles castling', () => {
+        expect(normalizeSan('O-O')).toBe('o-o');
+        expect(normalizeSan('O-O-O')).toBe('o-o-o');
+    });
+
+    it('handles castling with check', () => {
+        expect(normalizeSan('O-O+')).toBe('o-o');
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(normalizeSan('  Qh7  ')).toBe('qh7');
+    });
+});
+
+describe('isCorrectAnswer', () => {
+    it('accepts exact match', () => {
+        expect(isCorrectAnswer('Qh7', 'Qh7')).toBe(true);
+    });
+
+    it('accepts answer without checkmate annotation', () => {
+        expect(isCorrectAnswer('Qh7', 'Qh7#')).toBe(true);
+    });
+
+    it('accepts answer without check annotation', () => {
+        expect(isCorrectAnswer('Nf3', 'Nf3+')).toBe(true);
+    });
+
+    it('accepts promotion without equals sign', () => {
+        expect(isCorrectAnswer('a8Q', 'a8=Q')).toBe(true);
+    });
+
+    it('rejects wrong move', () => {
+        expect(isCorrectAnswer('Qh6', 'Qh7#')).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+        expect(isCorrectAnswer('qh7', 'Qh7#')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Adds the Mate in One Visualization Drill. Users are shown a text-only piece list (no board) and must type the mating move in SAN notation. The drill tracks per-puzzle response times, accuracy, and session stats. Sessions are saved to DynamoDB on every answer and on session end.

This is the first of two PRs for #2195. A follow-up PR will add the rating system.

## Related Issues

Fixes #2195

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] New unit tests (vitest) were added
- [ ] New playwright tests were added
- [ ] It was not necessary to add tests due to {{reason}}

## Demo

**Exam card on /tests page:**
<img width="597" height="597" alt="exam card" src="https://github.com/user-attachments/assets/1d43216d-fbe9-4f7a-8491-bc671cdf7cc4" />

**Ready screen:**
<img width="597" height="465" alt="start" src="https://github.com/user-attachments/assets/ac203761-01f9-4fb3-8cef-5da0985a42b5" />

**In-progress drill:**
<img width="597" height="448" alt="question" src="https://github.com/user-attachments/assets/a231a61f-3cad-45ca-92c3-231d4f0087f3" />

**Session complete summary:**
<img width="597" height="602" alt="session complete" src="https://github.com/user-attachments/assets/3ae6627d-f1ae-428b-8b2d-97f5774dee03" />
