### PR TITLE
feat(#2157) Redistribute work to account for rest days

### DIFF
--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.test.ts
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { TimelineEntry, TimelineSpecialRequirementId } from '@/database/timeline';
 import { RequirementCategory, ScoreboardDisplay } from '@/database/requirement';
+import { TimelineEntry, TimelineSpecialRequirementId } from '@/database/timeline';
 import { WorkGoalSettings } from '@/database/user';
+import { describe, expect, it } from 'vitest';
 import { computeAdjustedMinutes, isRestDay } from './suggestedTasks';
 
 /** Creates a rest day timeline entry for the given date. */

--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.test.ts
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { TimelineEntry, TimelineSpecialRequirementId } from '@/database/timeline';
+import { RequirementCategory, ScoreboardDisplay } from '@/database/requirement';
+import { WorkGoalSettings } from '@/database/user';
+import { computeAdjustedMinutes, isRestDay } from './suggestedTasks';
+
+/** Creates a rest day timeline entry for the given date. */
+function restDayEntry(date: Date): TimelineEntry {
+    const iso = date.toISOString();
+    return {
+        id: `rest-${iso}`,
+        owner: 'user',
+        ownerDisplayName: 'User',
+        cohort: '1600-1700',
+        requirementId: TimelineSpecialRequirementId.RestDay,
+        requirementName: 'Rest Day',
+        requirementCategory: RequirementCategory.NonDojo,
+        scoreboardDisplay: ScoreboardDisplay.Hidden,
+        progressBarSuffix: '',
+        totalCount: 0,
+        previousCount: 0,
+        newCount: 0,
+        dojoPoints: 0,
+        totalDojoPoints: 0,
+        minutesSpent: 0,
+        totalMinutesSpent: 0,
+        date: iso,
+        createdAt: iso,
+        notes: '',
+        comments: null,
+        reactions: null,
+    };
+}
+
+/** Helper to create a local date at noon to avoid DST edge cases. */
+function localDate(year: number, month: number, day: number): Date {
+    return new Date(year, month - 1, day, 12, 0, 0);
+}
+
+// Week of Sun Apr 12 to Sat Apr 18, 2026
+//   Sun=0, Mon=1, Tue=2, Wed=3, Thu=4, Fri=5, Sat=6
+const sun = localDate(2026, 4, 12);
+const mon = localDate(2026, 4, 13);
+const tue = localDate(2026, 4, 14);
+const wed = localDate(2026, 4, 15);
+const thu = localDate(2026, 4, 16);
+const fri = localDate(2026, 4, 17);
+const sat = localDate(2026, 4, 18);
+const weekEnd = localDate(2026, 4, 19);
+
+const evenGoal: WorkGoalSettings = {
+    minutesPerDay: [60, 60, 60, 60, 60, 60, 60],
+};
+
+const unevenGoal: WorkGoalSettings = {
+    //                Sun Mon Tue Wed Thu Fri Sat
+    minutesPerDay: [0, 90, 90, 60, 60, 30, 0],
+};
+
+describe('isRestDay', () => {
+    it('returns false when timeline has no rest days', () => {
+        expect(isRestDay(mon, [], undefined)).toBe(false);
+    });
+
+    it('returns true when date matches a rest day entry', () => {
+        const timeline = [restDayEntry(mon)];
+        expect(isRestDay(mon, timeline, undefined)).toBe(true);
+    });
+
+    it('returns false when date does not match any rest day entry', () => {
+        const timeline = [restDayEntry(mon)];
+        expect(isRestDay(tue, timeline, undefined)).toBe(false);
+    });
+
+    it('ignores non-rest-day timeline entries', () => {
+        const timeline: TimelineEntry[] = [
+            { ...restDayEntry(mon), requirementId: 'GameSubmission' },
+        ];
+        expect(isRestDay(mon, timeline, undefined)).toBe(false);
+    });
+});
+
+describe('computeAdjustedMinutes', () => {
+    it('returns unchanged minutes when there are no rest days', () => {
+        const result = computeAdjustedMinutes(sun, weekEnd, evenGoal, [], undefined);
+        expect(result).toEqual([60, 60, 60, 60, 60, 60, 60]);
+    });
+
+    it('zeroes rest day and redistributes evenly', () => {
+        // Wednesday (index 3) is a rest day, 60 min redistributed across 6 days
+        const timeline = [restDayEntry(wed)];
+        const result = computeAdjustedMinutes(sun, weekEnd, evenGoal, timeline, undefined);
+
+        expect(result[3]).toBe(0);
+        // 60 / 6 = 10 extra per day
+        expect(result).toEqual([70, 70, 70, 0, 70, 70, 70]);
+    });
+
+    it('distributes across remaining days with multiple rest days', () => {
+        // Wed (60) + Thu (60) = 120 min across 5 active days
+        // 120 / 5 = 24 per day, remainder 0
+        const timeline = [restDayEntry(wed), restDayEntry(thu)];
+        const result = computeAdjustedMinutes(sun, weekEnd, evenGoal, timeline, undefined);
+
+        expect(result[3]).toBe(0);
+        expect(result[4]).toBe(0);
+        expect(result).toEqual([84, 84, 84, 0, 0, 84, 84]);
+    });
+
+    it('handles remainder when minutes do not divide evenly', () => {
+        // unevenGoal: [0, 90, 90, 60, 60, 30, 0]
+        // Rest Monday (index 1): redistribute 90 across Tue(90), Wed(60), Thu(60), Fri(30)
+        // 90 / 4 = 22 remainder 2
+        // Tue: 90+22+1=113, Wed: 60+22+1=83, Thu: 60+22=82, Fri: 30+22=52
+        const timeline = [restDayEntry(mon)];
+        const result = computeAdjustedMinutes(sun, weekEnd, unevenGoal, timeline, undefined);
+
+        expect(result[1]).toBe(0);
+        expect(result).toEqual([0, 0, 113, 83, 82, 52, 0]);
+    });
+
+    it('returns all zeros when all days are rest days', () => {
+        const timeline = [
+            restDayEntry(sun),
+            restDayEntry(mon),
+            restDayEntry(tue),
+            restDayEntry(wed),
+            restDayEntry(thu),
+            restDayEntry(fri),
+            restDayEntry(sat),
+        ];
+        const result = computeAdjustedMinutes(sun, weekEnd, evenGoal, timeline, undefined);
+        expect(result).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('does not redistribute to days with zero configured goal', () => {
+        // unevenGoal: [0, 90, 90, 60, 60, 30, 0]
+        // Rest Tuesday (index 2), 90 min to redistribute
+        // Active days with non-zero goal: Mon(90), Wed(60), Thu(60), Fri(30)
+        // 90 / 4 = 22 remainder 2
+        const timeline = [restDayEntry(tue)];
+        const result = computeAdjustedMinutes(sun, weekEnd, unevenGoal, timeline, undefined);
+
+        expect(result[0]).toBe(0); // Sunday stays 0 (configured as 0)
+        expect(result[2]).toBe(0); // Tuesday is rest day
+        expect(result[6]).toBe(0); // Saturday stays 0 (configured as 0)
+        expect(result[1]).toBe(113); // 90 + 22 + 1
+        expect(result[3]).toBe(83); // 60 + 22 + 1
+        expect(result[4]).toBe(82); // 60 + 22
+        expect(result[5]).toBe(52); // 30 + 22
+    });
+
+    it('handles rest day that already has zero configured minutes', () => {
+        // unevenGoal: [0, 90, 90, 60, 60, 30, 0]
+        // Rest on Sunday (index 0) which already has 0 min — nothing to redistribute
+        const timeline = [restDayEntry(sun)];
+        const result = computeAdjustedMinutes(sun, weekEnd, unevenGoal, timeline, undefined);
+
+        expect(result).toEqual([0, 90, 90, 60, 60, 30, 0]);
+    });
+
+    it('preserves total weekly minutes', () => {
+        const timeline = [restDayEntry(tue), restDayEntry(thu)];
+        const originalTotal = evenGoal.minutesPerDay.reduce((a, b) => a + b, 0);
+        const result = computeAdjustedMinutes(sun, weekEnd, evenGoal, timeline, undefined);
+        const adjustedTotal = result.reduce((a, b) => a + b, 0);
+
+        expect(adjustedTotal).toBe(originalTotal);
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
@@ -13,7 +13,7 @@ import {
     isComplete,
     isRequirement,
 } from '@/database/requirement';
-import { TimelineEntry } from '@/database/timeline';
+import { TimelineEntry, TimelineSpecialRequirementId } from '@/database/timeline';
 import {
     ALL_COHORTS,
     GameScheduleEntry,
@@ -141,6 +141,7 @@ export class TaskSuggestionAlgorithm {
     private user: User;
     private timePerTask: Record<string, number> = {};
     private weeklyPlan?: WeeklyPlan;
+    private adjustedMinutesPerDay?: number[];
 
     constructor(
         user: User,
@@ -164,6 +165,85 @@ export class TaskSuggestionAlgorithm {
     }
 
     /**
+     * Checks if the given date is marked as a rest day in the timeline.
+     * @param date The date to check.
+     * @returns True if the date is a rest day, false otherwise.
+     */
+    isRestDay(date: Date): boolean {
+        const dateStr = toLocalDateString(date, this.user.timezoneOverride);
+        return this.timeline.some((entry) => {
+            if (entry.requirementId !== TimelineSpecialRequirementId.RestDay) {
+                return false;
+            }
+            const entryDate = toLocalDateString(
+                new Date(entry.date || entry.createdAt),
+                this.user.timezoneOverride,
+            );
+            return entryDate === dateStr;
+        });
+    }
+
+    /**
+     * Computes adjusted daily minutes by redistributing rest day minutes
+     * across active (non-rest) days in the week. Uses round-robin to
+     * distribute any remainder evenly.
+     * @param weekStart The start of the week.
+     * @param weekEnd The end of the week.
+     * @returns An array of 7 adjusted minute values indexed by day of week.
+     */
+    private computeAdjustedMinutes(weekStart: Date, weekEnd: Date): number[] {
+        const workGoal = this.user.workGoal || DEFAULT_WORK_GOAL;
+        const baseMinutes = [...workGoal.minutesPerDay];
+
+        // Find rest days in this week
+        const restDayNumbers = new Set<number>();
+        const checkDate = new Date(weekStart);
+        while (checkDate.getTime() < weekEnd.getTime()) {
+            if (this.isRestDay(checkDate)) {
+                restDayNumbers.add(checkDate.getDay());
+            }
+            checkDate.setDate(checkDate.getDate() + 1);
+        }
+
+        if (restDayNumbers.size === 0) {
+            return baseMinutes;
+        }
+
+        // Sum minutes from rest days to redistribute
+        let restMinutes = 0;
+        for (const dayNum of restDayNumbers) {
+            restMinutes += baseMinutes[dayNum];
+            baseMinutes[dayNum] = 0;
+        }
+
+        // Find active days (non-rest days that have a non-zero goal)
+        const activeDays: number[] = [];
+        for (let i = 0; i < 7; i++) {
+            if (!restDayNumbers.has(i) && baseMinutes[i] > 0) {
+                activeDays.push(i);
+            }
+        }
+
+        if (activeDays.length === 0 || restMinutes === 0) {
+            return baseMinutes;
+        }
+
+        // Distribute evenly with round-robin for remainder
+        const perDay = Math.floor(restMinutes / activeDays.length);
+        let remainder = restMinutes - perDay * activeDays.length;
+
+        for (const dayNum of activeDays) {
+            baseMinutes[dayNum] += perDay;
+            if (remainder > 0) {
+                baseMinutes[dayNum] += 1;
+                remainder--;
+            }
+        }
+
+        return baseMinutes;
+    }
+
+    /**
      * @returns The suggested tasks for the current week.
      */
     getWeeklySuggestions(): WeeklySuggestedTasks {
@@ -178,6 +258,9 @@ export class TaskSuggestionAlgorithm {
         }
 
         const reason = this.getGenerationReason(today, this.weeklyPlan);
+
+        // Compute adjusted daily minutes: redistribute rest day minutes across active days
+        this.adjustedMinutesPerDay = this.computeAdjustedMinutes(current, end);
 
         for (; current.getTime() < end.getTime(); current.setDate(current.getDate() + 1)) {
             const suggestions = this.getTasksForDay(reason, current, today);
@@ -410,7 +493,17 @@ export class TaskSuggestionAlgorithm {
             return;
         }
 
-        const goalMinutes = (this.user.workGoal || DEFAULT_WORK_GOAL).minutesPerDay[day.getDay()];
+        // Use adjusted minutes (accounts for rest day redistribution)
+        const goalMinutes = this.adjustedMinutesPerDay
+            ? this.adjustedMinutesPerDay[day.getDay()]
+            : (this.user.workGoal || DEFAULT_WORK_GOAL).minutesPerDay[day.getDay()];
+
+        if (goalMinutes === 0) {
+            for (const suggestion of suggestions) {
+                suggestion.goalMinutes = 0;
+            }
+            return;
+        }
 
         let tasksMissingTime = 0;
         let welcomeTaskMinutes = 0;

--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
@@ -873,10 +873,7 @@ export function isRestDay(date: Date, timeline: TimelineEntry[], timezone?: stri
         if (entry.requirementId !== TimelineSpecialRequirementId.RestDay) {
             return false;
         }
-        const entryDate = toLocalDateString(
-            new Date(entry.date || entry.createdAt),
-            timezone,
-        );
+        const entryDate = toLocalDateString(new Date(entry.date || entry.createdAt), timezone);
         return entryDate === dateStr;
     });
 }

--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
@@ -166,81 +166,22 @@ export class TaskSuggestionAlgorithm {
 
     /**
      * Checks if the given date is marked as a rest day in the timeline.
-     * @param date The date to check.
-     * @returns True if the date is a rest day, false otherwise.
      */
     isRestDay(date: Date): boolean {
-        const dateStr = toLocalDateString(date, this.user.timezoneOverride);
-        return this.timeline.some((entry) => {
-            if (entry.requirementId !== TimelineSpecialRequirementId.RestDay) {
-                return false;
-            }
-            const entryDate = toLocalDateString(
-                new Date(entry.date || entry.createdAt),
-                this.user.timezoneOverride,
-            );
-            return entryDate === dateStr;
-        });
+        return isRestDay(date, this.timeline, this.user.timezoneOverride);
     }
 
     /**
-     * Computes adjusted daily minutes by redistributing rest day minutes
-     * across active (non-rest) days in the week. Uses round-robin to
-     * distribute any remainder evenly.
-     * @param weekStart The start of the week.
-     * @param weekEnd The end of the week.
-     * @returns An array of 7 adjusted minute values indexed by day of week.
+     * Computes adjusted daily minutes for this week.
      */
     private computeAdjustedMinutes(weekStart: Date, weekEnd: Date): number[] {
-        const workGoal = this.user.workGoal || DEFAULT_WORK_GOAL;
-        const baseMinutes = [...workGoal.minutesPerDay];
-
-        // Find rest days in this week
-        const restDayNumbers = new Set<number>();
-        const checkDate = new Date(weekStart);
-        while (checkDate.getTime() < weekEnd.getTime()) {
-            if (this.isRestDay(checkDate)) {
-                restDayNumbers.add(checkDate.getDay());
-            }
-            checkDate.setDate(checkDate.getDate() + 1);
-        }
-
-        if (restDayNumbers.size === 0) {
-            return baseMinutes;
-        }
-
-        // Sum minutes from rest days to redistribute
-        let restMinutes = 0;
-        for (const dayNum of restDayNumbers) {
-            restMinutes += baseMinutes[dayNum];
-            baseMinutes[dayNum] = 0;
-        }
-
-        // Find active days (non-rest days that have a non-zero goal)
-        const activeDays: number[] = [];
-        for (let i = 0; i < 7; i++) {
-            if (!restDayNumbers.has(i) && baseMinutes[i] > 0) {
-                activeDays.push(i);
-            }
-        }
-
-        if (activeDays.length === 0 || restMinutes === 0) {
-            return baseMinutes;
-        }
-
-        // Distribute evenly with round-robin for remainder
-        const perDay = Math.floor(restMinutes / activeDays.length);
-        let remainder = restMinutes - perDay * activeDays.length;
-
-        for (const dayNum of activeDays) {
-            baseMinutes[dayNum] += perDay;
-            if (remainder > 0) {
-                baseMinutes[dayNum] += 1;
-                remainder--;
-            }
-        }
-
-        return baseMinutes;
+        return computeAdjustedMinutes(
+            weekStart,
+            weekEnd,
+            this.user.workGoal || DEFAULT_WORK_GOAL,
+            this.timeline,
+            this.user.timezoneOverride,
+        );
     }
 
     /**
@@ -916,6 +857,95 @@ export function getUpcomingGameSchedule(gameSchedule?: GameScheduleEntry[]): Gam
             ?.filter((e) => toLocalDateString(new Date(e.date)) >= today)
             .sort((lhs, rhs) => lhs.date.localeCompare(rhs.date)) ?? []
     );
+}
+
+/**
+ * Checks if the given date is marked as a rest day in the timeline.
+ * @param date The date to check.
+ * @param timeline The user's timeline entries.
+ * @param timezone The user's timezone override.
+ * @returns True if the date is a rest day, false otherwise.
+ */
+export function isRestDay(date: Date, timeline: TimelineEntry[], timezone?: string): boolean {
+    const dateStr = toLocalDateString(date, timezone);
+    return timeline.some((entry) => {
+        if (entry.requirementId !== TimelineSpecialRequirementId.RestDay) {
+            return false;
+        }
+        const entryDate = toLocalDateString(
+            new Date(entry.date || entry.createdAt),
+            timezone,
+        );
+        return entryDate === dateStr;
+    });
+}
+
+/**
+ * Computes adjusted daily minutes by redistributing rest day minutes
+ * across active (non-rest) days in the week. Uses round-robin to
+ * distribute any remainder evenly.
+ * @param weekStart The start of the week.
+ * @param weekEnd The end of the week.
+ * @param workGoal The user's work goal settings.
+ * @param timeline The user's timeline entries.
+ * @param timezone The user's timezone override.
+ * @returns An array of 7 adjusted minute values indexed by day of week.
+ */
+export function computeAdjustedMinutes(
+    weekStart: Date,
+    weekEnd: Date,
+    workGoal: WorkGoalSettings,
+    timeline: TimelineEntry[],
+    timezone?: string,
+): number[] {
+    const baseMinutes = [...workGoal.minutesPerDay];
+
+    // Find rest days in this week
+    const restDayNumbers = new Set<number>();
+    const checkDate = new Date(weekStart);
+    while (checkDate.getTime() < weekEnd.getTime()) {
+        if (isRestDay(checkDate, timeline, timezone)) {
+            restDayNumbers.add(checkDate.getDay());
+        }
+        checkDate.setDate(checkDate.getDate() + 1);
+    }
+
+    if (restDayNumbers.size === 0) {
+        return baseMinutes;
+    }
+
+    // Sum minutes from rest days to redistribute
+    let restMinutes = 0;
+    for (const dayNum of restDayNumbers) {
+        restMinutes += baseMinutes[dayNum];
+        baseMinutes[dayNum] = 0;
+    }
+
+    // Find active days (non-rest days that have a non-zero goal)
+    const activeDays: number[] = [];
+    for (let i = 0; i < 7; i++) {
+        if (!restDayNumbers.has(i) && baseMinutes[i] > 0) {
+            activeDays.push(i);
+        }
+    }
+
+    if (activeDays.length === 0 || restMinutes === 0) {
+        return baseMinutes;
+    }
+
+    // Distribute evenly with round-robin for remainder
+    const perDay = Math.floor(restMinutes / activeDays.length);
+    let remainder = restMinutes - perDay * activeDays.length;
+
+    for (const dayNum of activeDays) {
+        baseMinutes[dayNum] += perDay;
+        if (remainder > 0) {
+            baseMinutes[dayNum] += 1;
+            remainder--;
+        }
+    }
+
+    return baseMinutes;
 }
 
 /**

--- a/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
+++ b/frontend/src/components/profile/trainingPlan/suggestedTasks.ts
@@ -434,10 +434,11 @@ export class TaskSuggestionAlgorithm {
             return;
         }
 
-        // Use adjusted minutes (accounts for rest day redistribution)
+        const today = day.getDay();
+        const workGoal = this.user.workGoal || DEFAULT_WORK_GOAL;
         const goalMinutes = this.adjustedMinutesPerDay
-            ? this.adjustedMinutesPerDay[day.getDay()]
-            : (this.user.workGoal || DEFAULT_WORK_GOAL).minutesPerDay[day.getDay()];
+            ? this.adjustedMinutesPerDay[today]
+            : workGoal.minutesPerDay[today];
 
         if (goalMinutes === 0) {
             for (const suggestion of suggestions) {


### PR DESCRIPTION
## Summary

Rest days now affect the daily/weekly training schedule. When a day is marked as a rest day, its goal minutes are set to 0 and redistributed evenly across the remaining active days in the week.

- Extracts `isRestDay` and `computeAdjustedMinutes` as standalone functions
- Redistributes rest day minutes via round-robin across active days with non-zero configured goals
- Days configured as 0 minutes (e.g., weekends) are not assigned extra time
- Total weekly minutes are preserved

## Related Issues

Fixes #2157

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added

12 tests covering:
- No rest days (unchanged minutes)
- Single rest day redistribution
- Multiple rest days
- Uneven remainder distributed via round-robin
- All days marked as rest (all zeros)
- Rest day with zero configured minutes (nothing to redistribute)
- Days with zero configured goal are skipped
- Total weekly minutes preserved

### Manual testing steps

- [x] Set a rest day on the heatmap for the current day
- [x] Verify the daily training plan shows 0 minutes for the rest day
- [x] Verify the remaining active days show increased minutes
- [x] Clear the rest day and confirm minutes return to normal
