### PR TITLE
feat: add clouddb icon to engine lines

### DIFF
--- a/frontend/src/board/pgn/explorer/ChessDb.tsx
+++ b/frontend/src/board/pgn/explorer/ChessDb.tsx
@@ -95,7 +95,13 @@ export function ChessDBTab({ moves, loading, error, requestAnalysis }: ChessDBTa
     }
 
     const onClickMove = (params: GridRowParams<ChessDbMove>) => {
-        chess?.move(params.id as string);
+        const move = chess?.move(params.id as string);
+
+        if (move) {
+            move.commentDiag = move.commentDiag || {};
+            move.commentDiag.dojoEngine = 'CloudDB';
+        }
+
         reconcile();
     };
 

--- a/frontend/src/board/pgn/pgnText/MoveButton.tsx
+++ b/frontend/src/board/pgn/pgnText/MoveButton.tsx
@@ -40,6 +40,9 @@ import { useChess } from '../PgnBoard';
 
 export function getTextColor(move: Move, inline?: boolean, highlightEngineLines?: boolean): string {
     if (highlightEngineLines && move.commentDiag?.dojoEngine) {
+        if (move.commentDiag.dojoEngine === 'CloudDB') {
+            return 'primary.main';
+        }
         return 'error.main';
     }
     for (const nag of move.nags || []) {

--- a/frontend/src/components/games/view/GameMoveButtonExtras.tsx
+++ b/frontend/src/components/games/view/GameMoveButtonExtras.tsx
@@ -7,7 +7,7 @@ import { MoveButtonSlotProps } from '@/board/pgn/pgnText/MoveButton';
 import Avatar from '@/profile/Avatar';
 import { StockfishIcon } from '@/style/ChessIcons';
 import { Move } from '@jackstenglein/chess';
-import { Warning } from '@mui/icons-material';
+import { Cloud, Warning } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 
 export const GameMoveButtonExtras = ({
@@ -56,7 +56,18 @@ export const GameMoveButtonExtras = ({
         }
     }
 
-    if (move.commentDiag?.dojoEngine && !move.previous?.commentDiag?.dojoEngine) {
+    const engine = move.commentDiag?.dojoEngine;
+    const prevEngine = move.previous?.commentDiag?.dojoEngine;
+
+    if (engine && engine !== prevEngine) {
+        if (engine === 'CloudDB') {
+            return (
+                <Tooltip title='This line was found with the Cloud Database.'>
+                    <Cloud fontSize='small' sx={{ ml: 0.5 }} color='inherit' />
+                </Tooltip>
+            );
+        }
+
         return (
             <Tooltip title='This line was found with the engine.'>
                 <StockfishIcon fontSize='small' sx={{ ml: 0.5 }} color='error' />


### PR DESCRIPTION
## Summary

added cloud icon and blue text for clouddb moves in the pgn viewer to tell them apart from stockfish lines.
fixed the source check so the cloud icon correctly appears when switching directly from stockfish to clouddb. changed icon colors to inherit so they dont disappear when u click a move and the background turns blue.

## Demo
<img width="635" height="611" alt="image" src="https://github.com/user-attachments/assets/4d83f750-1cf6-4270-b1a3-cebe58ff4922" />


Fixes #2216 
