### PR TITLE
fix(#2182): avoid profanity filter false positives on bio

### DIFF
--- a/backend/user/update/main.go
+++ b/backend/user/update/main.go
@@ -24,6 +24,7 @@ import (
 var repository = database.DynamoDB
 var mediaStore database.MediaStore = database.S3
 var stage = os.Getenv("stage")
+var profanityDetector = goaway.NewProfanityDetector().WithExactWord(true)
 
 const (
 	referralSheetId = "198Me8Qm7YVKEtlY0Y56PbePaJz-Quqr4cA6hhhdRkgc"
@@ -81,8 +82,9 @@ func Handler(ctx context.Context, event api.Request) (api.Response, error) {
 	}
 	// Validates that the bio does not contain profanity
 	if update.Bio != nil {
-		if goaway.IsProfane(*update.Bio) {
-			return api.Failure(errors.New(400, "Invalid request: bio contains inappropriate language", "")), nil
+		if profanityDetector.IsProfane(*update.Bio) {
+			flagged := profanityDetector.ExtractProfanity(*update.Bio)
+			return api.Failure(errors.New(400, fmt.Sprintf("Invalid request: bio contains inappropriate language: %q", flagged), "")), nil
 		}
 	}
 	if err := saveReferralSource(ctx, user, update); err != nil {

--- a/backend/user/update/update_test.go
+++ b/backend/user/update/update_test.go
@@ -130,6 +130,57 @@ func TestUpdateUser(t *testing.T) {
 				DojoCohort: "2400+",
 			},
 		},
+		{
+			name:     "BioWithAsSuch",
+			username: testUsername,
+			update: &database.UserUpdate{
+				Bio: aws.String("As such, I enjoy chess."),
+			},
+			wantCode: 200,
+			wantUser: &database.User{
+				Username:     testUsername,
+				Email:        testEmail,
+				Name:         testName,
+				DisplayName:  "testDisplayName",
+				Bio:          "As such, I enjoy chess.",
+				RatingSystem: database.Fide,
+				DojoCohort:   "2400+",
+			},
+		},
+		{
+			name:     "BioWithAsSold",
+			username: testUsername,
+			update: &database.UserUpdate{
+				Bio: aws.String("Sold as sold."),
+			},
+			wantCode: 200,
+			wantUser: &database.User{
+				Username:     testUsername,
+				Email:        testEmail,
+				Name:         testName,
+				DisplayName:  "testDisplayName",
+				Bio:          "Sold as sold.",
+				RatingSystem: database.Fide,
+				DojoCohort:   "2400+",
+			},
+		},
+		{
+			name:     "BioWithCommonAssSubstrings",
+			username: testUsername,
+			update: &database.UserUpdate{
+				Bio: aws.String("I enjoy classroom assessment and passage analysis."),
+			},
+			wantCode: 200,
+			wantUser: &database.User{
+				Username:     testUsername,
+				Email:        testEmail,
+				Name:         testName,
+				DisplayName:  "testDisplayName",
+				Bio:          "I enjoy classroom assessment and passage analysis.",
+				RatingSystem: database.Fide,
+				DojoCohort:   "2400+",
+			},
+		},
 	}
 
 	for _, tc := range table {


### PR DESCRIPTION
## Summary

Fixes false positives in the bio profanity filter where benign phrases like "As such", "As sold", "classroom", or "passage" were flagged because the underlying `go-away` library defaults to substring matching.

- Switched to a package-scoped `goaway.ProfanityDetector` with `WithExactWord(true)` so only whole-word matches trigger the filter.
- Included the flagged word in the 400 error message so users can see what tripped the filter and correct it.
- Added regression tests for the reported phrases plus common `ass` substrings, keeping the existing real-profanity rejection test in place.

## Related Issues

Fixes #2182

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

Added Go unit tests in `backend/user/update/update_test.go` covering the reported false positives ("As such", "As sold") and common `ass` substrings ("classroom", "assessment", "passage"). No vitest/playwright tests since the change is backend-only.

