### PR TITLE
feat(#2195) mate in one ratings

### DIFF
--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -355,6 +355,9 @@ type User struct {
 	// The user's best-ever square color drill rating (0-1500).
 	SquareColorRating float32 `dynamodbav:"squareColorRating,omitempty" json:"squareColorRating,omitempty"`
 
+	// The user's best-ever mate-in-one drill block rating (0-2500).
+	MateInOneRating float32 `dynamodbav:"mateInOneRating,omitempty" json:"mateInOneRating,omitempty"`
+
 	// The id of the user's game review cohort, if they are a member of the Game & Profile Review tier.
 	GameReviewCohortId string `dynamodbav:"gameReviewCohortId,omitempty" json:"gameReviewCohortId,omitempty"`
 

--- a/backend/puzzleService/mateInOne/submit.ts
+++ b/backend/puzzleService/mateInOne/submit.ts
@@ -1,10 +1,14 @@
-import { PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { ConditionalCheckFailedException, PutItemCommand } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import {
     MateInOneSessionResult,
     SubmitMateInOneSessionResponse,
     submitMateInOneSessionSchema,
 } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import {
+    PUZZLES_PER_BLOCK,
+    computeMateInOneRating,
+} from '@jackstenglein/chess-dojo-common/src/mateInOne/rating';
 import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import {
     errToApiGatewayProxyResultV2,
@@ -12,16 +16,28 @@ import {
     requireUserInfo,
     success,
 } from '../../directoryService/api';
-import { dynamo } from '../../directoryService/database';
+import {
+    UpdateItemBuilder,
+    attributeNotExists,
+    dynamo,
+    lessThan,
+    or,
+} from '../../directoryService/database';
 
 const mateInOneResultsTable = `${process.env.stage}-mate-in-one-results`;
+const usersTable = `${process.env.stage}-users`;
 
 /**
  * Handles POST /puzzle/mate-in-one/session.
- * Validates and persists a mate-in-one drill session result to DynamoDB.
+ *
+ * Validates and persists a mate-in-one drill block result to DynamoDB. When the
+ * submission represents a complete 10-puzzle block, computes the server-side
+ * rating and conditionally updates the user's best-ever mate-in-one rating only
+ * if the new rating exceeds the previous PR. Partial-block submissions (aborts)
+ * are persisted without a rating and do not touch the user record.
  *
  * @param event - The API Gateway proxy event.
- * @returns An empty response on success.
+ * @returns A response with the computed rating on full blocks, otherwise empty.
  */
 export const submitSessionHandler: APIGatewayProxyHandlerV2 = async (event) => {
     try {
@@ -29,11 +45,22 @@ export const submitSessionHandler: APIGatewayProxyHandlerV2 = async (event) => {
         const userInfo = requireUserInfo(event);
         const request = parseBody(event, submitMateInOneSessionSchema);
 
+        const correctCount = request.attempts.filter((a) => a.isCorrect).length;
+        const isFullBlock = request.attempts.length === PUZZLES_PER_BLOCK;
+
         const result: MateInOneSessionResult = {
             ...request,
             username: userInfo.username,
             createdAt: request.createdAt ?? new Date().toISOString(),
         };
+
+        const response: SubmitMateInOneSessionResponse = {};
+
+        if (isFullBlock) {
+            const rating = computeMateInOneRating(correctCount, request.totalTimeSeconds);
+            result.rating = rating;
+            response.rating = rating;
+        }
 
         await dynamo.send(
             new PutItemCommand({
@@ -42,7 +69,26 @@ export const submitSessionHandler: APIGatewayProxyHandlerV2 = async (event) => {
             }),
         );
 
-        const response: SubmitMateInOneSessionResponse = {};
+        if (isFullBlock && response.rating !== undefined) {
+            try {
+                const builder = new UpdateItemBuilder()
+                    .key('username', userInfo.username)
+                    .table(usersTable)
+                    .set('mateInOneRating', response.rating)
+                    .condition(
+                        or(
+                            attributeNotExists('mateInOneRating'),
+                            lessThan('mateInOneRating', response.rating),
+                        ),
+                    );
+                await builder.send();
+            } catch (err) {
+                if (!(err instanceof ConditionalCheckFailedException)) {
+                    throw err;
+                }
+            }
+        }
+
         return success(response);
     } catch (err) {
         return errToApiGatewayProxyResultV2(err);

--- a/backend/puzzleService/serverless.yml
+++ b/backend/puzzleService/serverless.yml
@@ -113,6 +113,10 @@ functions:
         Action:
           - dynamodb:PutItem
         Resource: !GetAtt MateInOneResultsTable.Arn
+      - Effect: Allow
+        Action:
+          - dynamodb:UpdateItem
+        Resource: ${param:UsersTableArn}
 
 resources:
   Conditions:

--- a/common/src/database/user.ts
+++ b/common/src/database/user.ts
@@ -124,6 +124,9 @@ export interface User {
     /** The user's best-ever square color drill rating (0-1500). */
     squareColorRating?: number;
 
+    /** The user's best-ever mate-in-one drill block rating (0-2500). */
+    mateInOneRating?: number;
+
     /** The user's firebase cloud messaging tokens. */
     firebaseTokens?: string[];
 

--- a/common/src/mateInOne/__tests__/rating.test.ts
+++ b/common/src/mateInOne/__tests__/rating.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import { PUZZLES_PER_BLOCK, computeMateInOneRating } from '../rating';
+
+const min = (m: number) => m * 60;
+
+describe('PUZZLES_PER_BLOCK', () => {
+    it('equals 10', () => {
+        expect(PUZZLES_PER_BLOCK).toBe(10);
+    });
+});
+
+describe('computeMateInOneRating - score 0', () => {
+    it('returns 0 regardless of time', () => {
+        expect(computeMateInOneRating(0, 0)).toBe(0);
+        expect(computeMateInOneRating(0, min(5))).toBe(0);
+        expect(computeMateInOneRating(0, min(60))).toBe(0);
+    });
+});
+
+describe("computeMateInOneRating - Jesse's examples", () => {
+    it('score 1 t=35min → 350', () => {
+        expect(computeMateInOneRating(1, min(35))).toBe(350);
+    });
+
+    it('score 1 t=45min → 300 (floor)', () => {
+        expect(computeMateInOneRating(1, min(45))).toBe(300);
+    });
+
+    it('score 7 t=5min → 2199', () => {
+        expect(computeMateInOneRating(7, min(5))).toBe(2199);
+    });
+
+    it('score 7 t=10min → 2150 (rounded from 2149.5)', () => {
+        expect(computeMateInOneRating(7, min(10))).toBe(2150);
+    });
+
+    it('score 7 t=15min → 2100', () => {
+        expect(computeMateInOneRating(7, min(15))).toBe(2100);
+    });
+
+    it('score 7 t=20min → 2000 (cliff)', () => {
+        expect(computeMateInOneRating(7, min(20))).toBe(2000);
+    });
+
+    it('score 10 t=8min → 2500', () => {
+        expect(computeMateInOneRating(10, min(8))).toBe(2500);
+    });
+});
+
+describe('computeMateInOneRating - scores 1-5 boundaries', () => {
+    it('score 1 at t=40 → 300 (floor wins)', () => {
+        expect(computeMateInOneRating(1, min(40))).toBe(300);
+    });
+
+    it('score 1 at t=10 → 600 (cap value)', () => {
+        expect(computeMateInOneRating(1, min(10))).toBe(600);
+    });
+
+    it('score 5 at t=40 → 1500', () => {
+        expect(computeMateInOneRating(5, min(40))).toBe(1500);
+    });
+
+    it('score 5 at t=10 → 1800', () => {
+        expect(computeMateInOneRating(5, min(10))).toBe(1800);
+    });
+
+    it('score 5 at t=5 → 1800 (cap)', () => {
+        expect(computeMateInOneRating(5, min(5))).toBe(1800);
+    });
+
+    it('score 3 at t=25 → 1050 (linear midpoint)', () => {
+        // 300*3 + (40-25)*10 = 900 + 150 = 1050
+        expect(computeMateInOneRating(3, min(25))).toBe(1050);
+    });
+});
+
+describe('computeMateInOneRating - score 6 boundaries', () => {
+    it('t=40 → 1800', () => {
+        expect(computeMateInOneRating(6, min(40))).toBe(1800);
+    });
+
+    it('t=41 → 1800 (floor)', () => {
+        expect(computeMateInOneRating(6, min(41))).toBe(1800);
+    });
+
+    it('t=15 → 1900 (slow band wins)', () => {
+        expect(computeMateInOneRating(6, min(15))).toBe(1900);
+    });
+
+    it('t=14.999 → 2000 (fast band starts; ε-test)', () => {
+        expect(computeMateInOneRating(6, min(14.999))).toBe(2000);
+    });
+
+    it('t=15.001 → 1900 (slow band; ε-test)', () => {
+        expect(computeMateInOneRating(6, min(15.001))).toBe(1900);
+    });
+
+    it('t=5 → 2099 (cap value at fast edge)', () => {
+        expect(computeMateInOneRating(6, min(5))).toBe(2099);
+    });
+
+    it('t=4 → 2099 (cap)', () => {
+        expect(computeMateInOneRating(6, min(4))).toBe(2099);
+    });
+});
+
+describe('computeMateInOneRating - score 7 boundaries', () => {
+    it('t=14.999 → 2100 (interp band; ε-test)', () => {
+        expect(computeMateInOneRating(7, min(14.999))).toBe(2100);
+    });
+
+    it('t=15.001 → 2000 (floor; ε-test)', () => {
+        expect(computeMateInOneRating(7, min(15.001))).toBe(2000);
+    });
+
+    it('t=4 → 2199 (cap)', () => {
+        expect(computeMateInOneRating(7, min(4))).toBe(2199);
+    });
+});
+
+describe('computeMateInOneRating - score 8 boundaries', () => {
+    it('t=15 → 2200', () => {
+        expect(computeMateInOneRating(8, min(15))).toBe(2200);
+    });
+
+    it('t=14.999 → 2200 (interp; ε-test)', () => {
+        expect(computeMateInOneRating(8, min(14.999))).toBe(2200);
+    });
+
+    it('t=15.001 → 2100 (floor; ε-test)', () => {
+        expect(computeMateInOneRating(8, min(15.001))).toBe(2100);
+    });
+
+    it('t=5 → 2299', () => {
+        expect(computeMateInOneRating(8, min(5))).toBe(2299);
+    });
+});
+
+describe('computeMateInOneRating - score 9 boundaries', () => {
+    it('t=15 → 2300', () => {
+        expect(computeMateInOneRating(9, min(15))).toBe(2300);
+    });
+
+    it('t=14.999 → 2300 (interp; ε-test)', () => {
+        expect(computeMateInOneRating(9, min(14.999))).toBe(2300);
+    });
+
+    it('t=15.001 → 2200 (floor; ε-test)', () => {
+        expect(computeMateInOneRating(9, min(15.001))).toBe(2200);
+    });
+
+    it('t=5 → 2399', () => {
+        expect(computeMateInOneRating(9, min(5))).toBe(2399);
+    });
+});
+
+describe('computeMateInOneRating - score 10 boundaries', () => {
+    it('t=15 → 2400 (interp band wins)', () => {
+        expect(computeMateInOneRating(10, min(15))).toBe(2400);
+    });
+
+    it('t=14.999 → 2400 (interp; ε-test)', () => {
+        expect(computeMateInOneRating(10, min(14.999))).toBe(2400);
+    });
+
+    it('t=15.001 → 2300 (floor; ε-test)', () => {
+        expect(computeMateInOneRating(10, min(15.001))).toBe(2300);
+    });
+
+    it('t=10 → 2500 (cap value at fast edge)', () => {
+        expect(computeMateInOneRating(10, min(10))).toBe(2500);
+    });
+
+    it('t=10.001 → 2500 (interp; ε-test)', () => {
+        expect(computeMateInOneRating(10, min(10.001))).toBe(2500);
+    });
+
+    it('t=9.999 → 2500 (cap; ε-test)', () => {
+        expect(computeMateInOneRating(10, min(9.999))).toBe(2500);
+    });
+
+    it('t=12.5 → 2450 (linear midpoint)', () => {
+        // 2400 + (15 - 12.5) * 20 = 2450
+        expect(computeMateInOneRating(10, min(12.5))).toBe(2450);
+    });
+});
+
+describe('computeMateInOneRating - returns integers', () => {
+    for (const score of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+        it(`score ${score}, t=12min returns an integer`, () => {
+            const r = computeMateInOneRating(score, min(12));
+            expect(Number.isInteger(r)).toBe(true);
+        });
+    }
+});

--- a/common/src/mateInOne/api.ts
+++ b/common/src/mateInOne/api.ts
@@ -44,6 +44,8 @@ export interface MateInOneSessionResult extends SubmitMateInOneSessionRequest {
     username: string;
     /** The ISO 8601 timestamp when the session was created. */
     createdAt: string;
+    /** The server-computed rating for this block, present only on full 10-puzzle blocks. */
+    rating?: number;
 }
 
 /** A mate-in-one puzzle from the Lichess database. */
@@ -62,5 +64,11 @@ export interface GetMateInOnePuzzleResponse {
     puzzle: MateInOnePuzzle;
 }
 
-/** Response from submitting a mate-in-one session (empty for PR 1). */
-export type SubmitMateInOneSessionResponse = Record<string, never>;
+/** Response from submitting a mate-in-one session. */
+export interface SubmitMateInOneSessionResponse {
+    /**
+     * The server-computed rating for this 10-puzzle block. Omitted on partial-block
+     * (aborted) submissions where attempts.length < 10.
+     */
+    rating?: number;
+}

--- a/common/src/mateInOne/rating.ts
+++ b/common/src/mateInOne/rating.ts
@@ -1,0 +1,119 @@
+/** Number of mate-in-one puzzles in a single rating block. */
+export const PUZZLES_PER_BLOCK = 10;
+
+/**
+ * One band row of the mate-in-one rating table. The rating returned for a
+ * given (score, t) is: floor when t > slowMin, cap when t < fastMin, and a
+ * linear interpolation between (slowMin, slowRating) and (fastMin, fastRating)
+ * inside the band.
+ */
+interface BandRow {
+    /** Score (number correct out of 10) this row applies to. */
+    score: number;
+    /** The slow edge of the band (in minutes). */
+    slowMin: number;
+    /** The fast edge of the band (in minutes). */
+    fastMin: number;
+    /** Rating at the slow edge of the band. */
+    slowRating: number;
+    /** Rating at the fast edge of the band. */
+    fastRating: number;
+    /** Rating returned when t > slowMin (clamped floor). */
+    floor: number;
+    /** Rating returned when t < fastMin (clamped cap). */
+    cap: number;
+}
+
+/**
+ * Per-score band rows. Boundary inclusivity (pinned by tests):
+ * - Score 1-5: at t=40 the floor wins; at t=10 the cap wins.
+ * - Score 6: at t=40 → 1800; at t=15 → 1900 (slow band wins); below t=15 is the
+ *   second band starting at 2000; at t=5 → 2099 (cap).
+ * - Score 7-9: at t=15 → 2100/2200/2300 (interp band wins); above t=15 is floor;
+ *   at t=5 → 2199/2299/2399 (cap).
+ * - Score 10: at t=15 → 2400 (interp band wins); at t=10 → 2500 (cap).
+ *
+ * Score 6 has two bands stacked, so it is handled specially in the function.
+ * All other scores have a single linear band.
+ */
+const BAND_TABLE: Record<number, BandRow[]> = {
+    1: [{ score: 1, slowMin: 40, fastMin: 10, slowRating: 300, fastRating: 600, floor: 300, cap: 600 }],
+    2: [{ score: 2, slowMin: 40, fastMin: 10, slowRating: 600, fastRating: 900, floor: 600, cap: 900 }],
+    3: [{ score: 3, slowMin: 40, fastMin: 10, slowRating: 900, fastRating: 1200, floor: 900, cap: 1200 }],
+    4: [{ score: 4, slowMin: 40, fastMin: 10, slowRating: 1200, fastRating: 1500, floor: 1200, cap: 1500 }],
+    5: [{ score: 5, slowMin: 40, fastMin: 10, slowRating: 1500, fastRating: 1800, floor: 1500, cap: 1800 }],
+    6: [
+        { score: 6, slowMin: 40, fastMin: 15, slowRating: 1800, fastRating: 1900, floor: 1800, cap: 1900 },
+        { score: 6, slowMin: 15, fastMin: 5, slowRating: 2000, fastRating: 2099, floor: 2000, cap: 2099 },
+    ],
+    7: [{ score: 7, slowMin: 15, fastMin: 5, slowRating: 2100, fastRating: 2199, floor: 2000, cap: 2199 }],
+    8: [{ score: 8, slowMin: 15, fastMin: 5, slowRating: 2200, fastRating: 2299, floor: 2100, cap: 2299 }],
+    9: [{ score: 9, slowMin: 15, fastMin: 5, slowRating: 2300, fastRating: 2399, floor: 2200, cap: 2399 }],
+    10: [{ score: 10, slowMin: 15, fastMin: 10, slowRating: 2400, fastRating: 2500, floor: 2300, cap: 2500 }],
+};
+
+/**
+ * Linearly interpolates a rating within a band between (slowMin, slowRating)
+ * and (fastMin, fastRating). Caller must ensure t is within the band.
+ *
+ * @param t Time in minutes.
+ * @param row The band row.
+ * @returns The interpolated rating (not yet rounded).
+ */
+function interpolate(t: number, row: BandRow): number {
+    const span = row.slowMin - row.fastMin;
+    if (span === 0) return row.slowRating;
+    const fraction = (row.slowMin - t) / span;
+    return row.slowRating + fraction * (row.fastRating - row.slowRating);
+}
+
+/**
+ * Computes the mate-in-one rating for a single 10-problem block.
+ *
+ * The rating follows a fixed lookup table keyed by score (number correct out
+ * of 10) and total active solve time, with linear interpolation inside each
+ * time band. Outside bands the rating is clamped to the band floor or cap.
+ * Score 0 is always 0. See the rating section of the mate-in-one drill spec
+ * for the full table and boundary tie-breaks.
+ *
+ * @param correct Number of correctly solved problems (0-10).
+ * @param totalTimeSeconds Total active solve time for the block in seconds (excluding paused time).
+ * @returns Integer rating, floor 0.
+ */
+export function computeMateInOneRating(correct: number, totalTimeSeconds: number): number {
+    if (correct <= 0) return 0;
+    const score = Math.min(10, Math.max(0, Math.round(correct)));
+    if (score === 0) return 0;
+
+    const t = totalTimeSeconds / 60;
+    const rows = BAND_TABLE[score];
+
+    if (score >= 1 && score <= 5) {
+        const row = rows[0];
+        if (t >= row.slowMin) return row.floor;
+        if (t < row.fastMin) return row.cap;
+        return Math.round(interpolate(t, row));
+    }
+
+    if (score === 6) {
+        const slow = rows[0];
+        const fast = rows[1];
+        if (t > slow.slowMin) return slow.floor;
+        if (t >= fast.slowMin) return Math.round(interpolate(t, slow));
+        if (t >= fast.fastMin) return Math.round(interpolate(t, fast));
+        return fast.cap;
+    }
+
+    if (score >= 7 && score <= 9) {
+        const row = rows[0];
+        if (t > row.slowMin) return row.floor;
+        if (t < row.fastMin) return row.cap;
+        return Math.round(interpolate(t, row));
+    }
+
+    // score === 10
+    const row = rows[0];
+    if (t > row.slowMin) return row.floor;
+    if (t < row.fastMin) return row.cap;
+    return Math.round(interpolate(t, row));
+}

--- a/frontend/src/components/profile/info/DojoScoreCard.tsx
+++ b/frontend/src/components/profile/info/DojoScoreCard.tsx
@@ -222,25 +222,6 @@ const DojoScoreCard: React.FC<DojoScoreCardProps> = ({ user, cohort }) => {
                             />
                         );
                     })}
-
-                    <Grid size={{ xs: 12 }}>
-                        <Typography
-                            variant='subtitle2'
-                            color='text.secondary'
-                            sx={{ fontWeight: 'bold', mb: 0.5 }}
-                        >
-                            Drill Ratings
-                        </Typography>
-                        <Stack
-                            direction='row'
-                            justifyContent='space-between'
-                            alignItems='center'
-                            sx={{ px: 0.5 }}
-                        >
-                            <Typography color='text.secondary'>Mate-in-One</Typography>
-                            <Typography fontWeight='bold'>{user.mateInOneRating ?? 'N/A'}</Typography>
-                        </Stack>
-                    </Grid>
                 </Grid>
             </CardContent>
         </Card>

--- a/frontend/src/components/profile/info/DojoScoreCard.tsx
+++ b/frontend/src/components/profile/info/DojoScoreCard.tsx
@@ -222,6 +222,25 @@ const DojoScoreCard: React.FC<DojoScoreCardProps> = ({ user, cohort }) => {
                             />
                         );
                     })}
+
+                    <Grid size={{ xs: 12 }}>
+                        <Typography
+                            variant='subtitle2'
+                            color='text.secondary'
+                            sx={{ fontWeight: 'bold', mb: 0.5 }}
+                        >
+                            Drill Ratings
+                        </Typography>
+                        <Stack
+                            direction='row'
+                            justifyContent='space-between'
+                            alignItems='center'
+                            sx={{ px: 0.5 }}
+                        >
+                            <Typography color='text.secondary'>Mate-in-One</Typography>
+                            <Typography fontWeight='bold'>{user.mateInOneRating ?? 'N/A'}</Typography>
+                        </Stack>
+                    </Grid>
                 </Grid>
             </CardContent>
         </Card>

--- a/frontend/src/components/profile/stats/DrillRatingsCard.test.tsx
+++ b/frontend/src/components/profile/stats/DrillRatingsCard.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DrillRatingsCard } from './DrillRatingsCard';
+
+describe('DrillRatingsCard', () => {
+    it('renders the mate-in-one personal best rating', () => {
+        render(<DrillRatingsCard mateInOneRating={1850} />);
+
+        expect(screen.getByText('Drill Ratings')).toBeInTheDocument();
+        expect(screen.getByText('Mate-in-One PR')).toBeInTheDocument();
+        expect(screen.getByText('1850')).toBeInTheDocument();
+    });
+
+    it('renders nothing when the mate-in-one rating is missing', () => {
+        const { container } = render(<DrillRatingsCard />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when the mate-in-one rating is zero', () => {
+        const { container } = render(<DrillRatingsCard mateInOneRating={0} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/frontend/src/components/profile/stats/DrillRatingsCard.tsx
+++ b/frontend/src/components/profile/stats/DrillRatingsCard.tsx
@@ -1,0 +1,47 @@
+import Target from '@mui/icons-material/GpsFixed';
+import { Card, CardContent, Grid, Stack, Typography } from '@mui/material';
+
+interface DrillRatingsCardProps {
+    mateInOneRating?: number;
+}
+
+export function DrillRatingsCard({ mateInOneRating }: DrillRatingsCardProps) {
+    if (!mateInOneRating || mateInOneRating <= 0) {
+        return null;
+    }
+
+    return (
+        <Card variant='outlined'>
+            <CardContent>
+                <Stack spacing={2}>
+                    <Typography variant='h6'>
+                        <Target
+                            color='primary'
+                            fontSize='large'
+                            sx={{ marginRight: 1.5, verticalAlign: 'middle' }}
+                        />
+                        Drill Ratings
+                    </Typography>
+                    <Grid container justifyContent='center'>
+                        <Grid size={{ xs: 12, sm: 4 }} display='flex' justifyContent='center'>
+                            <Stack alignItems='center'>
+                                <Typography variant='body1' color='text.secondary'>
+                                    Mate-in-One PR
+                                </Typography>
+                                <Typography
+                                    sx={{
+                                        fontSize: '2rem',
+                                        lineHeight: 1,
+                                        fontWeight: 'bold',
+                                    }}
+                                >
+                                    {mateInOneRating}
+                                </Typography>
+                            </Stack>
+                        </Grid>
+                    </Grid>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}

--- a/frontend/src/components/profile/stats/StatsTab.tsx
+++ b/frontend/src/components/profile/stats/StatsTab.tsx
@@ -11,6 +11,7 @@ import {
 import { isCustom } from '@jackstenglein/chess-dojo-common/src/ratings/ratings';
 import { Button, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { DrillRatingsCard } from './DrillRatingsCard';
 import RatingCard from './RatingCard';
 import TacticsScoreCard from './TacticsScoreCard';
 
@@ -137,6 +138,8 @@ const StatsTab: React.FC<StatsTabProps> = ({ user }) => {
                     />
                 );
             })}
+
+            <DrillRatingsCard mateInOneRating={user.mateInOneRating} />
 
             <TacticsScoreCard user={user} />
         </Stack>

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -14,6 +14,8 @@ import {
 import { fenToPieceList } from '@jackstenglein/chess-dojo-common/src/mateInOne/fen';
 import { PUZZLES_PER_BLOCK } from '@jackstenglein/chess-dojo-common/src/mateInOne/rating';
 import AccessTime from '@mui/icons-material/AccessTime';
+import ArrowDownward from '@mui/icons-material/ArrowDownward';
+import ArrowUpward from '@mui/icons-material/ArrowUpward';
 import Target from '@mui/icons-material/GpsFixed';
 import Timer from '@mui/icons-material/Timer';
 import {
@@ -54,7 +56,6 @@ interface BlockSummary {
     totalTimeSeconds: number;
     avgResponseTimeMs: number;
     rating: number;
-    isNewPR: boolean;
     attempts: MateInOneAttempt[];
 }
 
@@ -127,6 +128,9 @@ function MateInOneDrill() {
     const blockCreatedAtRef = useRef<string>('');
     const prefetchRef = useRef<Promise<PuzzleWithSolution> | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
+    /** Snapshot of the user's PR taken when a drill starts, so the complete-screen diff
+     * is computed against the pre-drill rating even after `updateUser` lands. */
+    const previousBestRef = useRef<number | undefined>(user?.mateInOneRating);
 
     const FOCUS_DELAY_MS = 50;
     const focusInput = useCallback(() => {
@@ -180,6 +184,7 @@ function MateInOneDrill() {
             accumulatedMsRef.current = 0;
             runningSinceMsRef.current = performance.now();
             blockCreatedAtRef.current = new Date().toISOString();
+            previousBestRef.current = user?.mateInOneRating;
             setDrillState('in_progress');
             fetchPuzzle()
                 .then((p) => {
@@ -199,6 +204,12 @@ function MateInOneDrill() {
 
     const startDrill = useCallback(() => startBlock(), [startBlock]);
 
+    useEffect(() => {
+        if (drillState === 'ready') {
+            previousBestRef.current = user?.mateInOneRating;
+        }
+    }, [drillState, user?.mateInOneRating]);
+
     /**
      * Finalizes a complete 10-puzzle block: freezes timer, computes rating, fires submission.
      *
@@ -214,15 +225,12 @@ function MateInOneDrill() {
             const elapsedMs = accumulatedMsRef.current;
             const stats = computeSessionStats(finalAttempts, elapsedMs);
             const rating = stats.rating ?? 0;
-            const previousPR = user?.mateInOneRating;
-            const isNewPR = previousPR === undefined || rating > previousPR;
 
             const summary: BlockSummary = {
                 correctCount: stats.correctCount,
                 totalTimeSeconds: stats.totalTimeSeconds,
                 avgResponseTimeMs: stats.avgResponseTimeMs,
                 rating,
-                isNewPR,
                 attempts: finalAttempts,
             };
             setBlockSummary(summary);
@@ -411,6 +419,7 @@ function MateInOneDrill() {
             <>
                 <BlockCompleteScreen
                     summary={blockSummary}
+                    personalBest={previousBestRef.current}
                     submitting={submitting}
                     submitFailed={submitRequest.isFailure()}
                     onContinue={() => startBlock()}
@@ -462,11 +471,8 @@ function ReadyScreen({
                 Mate in One Visualization Drill
             </Typography>
             {personalBest !== undefined && (
-                <Typography
-                    variant='subtitle1'
-                    sx={{ color: 'primary.main', fontWeight: 'bold', mb: 2 }}
-                >
-                    Personal best: {personalBest}
+                <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>
+                    Your best rating: {personalBest}
                 </Typography>
             )}
             <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
@@ -716,6 +722,7 @@ function PausedScreen({ elapsedMs, puzzlesAnswered, onResume, onEndSession }: Pa
 
 interface BlockCompleteScreenProps {
     summary: BlockSummary;
+    personalBest?: number;
     submitting: boolean;
     submitFailed: boolean;
     onContinue: () => void;
@@ -726,15 +733,17 @@ interface BlockCompleteScreenProps {
 /**
  * Summary screen shown after a 10-puzzle block completes.
  *
- * @param summary - The computed block statistics including rating and isNewPR.
+ * @param summary - The computed block statistics.
+ * @param personalBest - The user's previous best rating (pre-drill snapshot), if any.
  * @param submitting - Whether the canonical block submission is in flight.
  * @param submitFailed - Whether the canonical block submission failed.
- * @param onContinue - Callback to start the next block.
+ * @param onContinue - Callback to start a new drill.
  * @param onRetry - Callback to retry the failed submission.
  * @param onEndSession - Callback to end the session and return to the landing screen.
  */
 function BlockCompleteScreen({
     summary,
+    personalBest,
     submitting,
     submitFailed,
     onContinue,
@@ -743,6 +752,10 @@ function BlockCompleteScreen({
 }: BlockCompleteScreenProps) {
     const accuracy = Math.round((summary.correctCount / PUZZLES_PER_BLOCK) * 100);
     const avgTime = (summary.avgResponseTimeMs / 1000).toFixed(1);
+    const showDiff =
+        summary.rating > 0 && personalBest !== undefined && summary.rating !== personalBest;
+    const isNewPR =
+        summary.rating > 0 && (personalBest === undefined || summary.rating > personalBest);
 
     return (
         <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
@@ -752,12 +765,40 @@ function BlockCompleteScreen({
             <Typography variant='h2' sx={{ fontWeight: 'bold', color: 'primary.main', mb: 1 }}>
                 {summary.rating}
             </Typography>
-            {summary.isNewPR && summary.rating > 0 && (
-                <Typography
-                    variant='subtitle1'
-                    sx={{ color: 'success.main', fontWeight: 'bold', mb: 3 }}
+            {showDiff && (
+                <Stack
+                    direction='row'
+                    alignItems='center'
+                    justifyContent='center'
+                    spacing={0.5}
+                    sx={{ mb: 1 }}
                 >
-                    New PR!
+                    {summary.rating > personalBest! ? (
+                        <ArrowUpward color='success' sx={{ fontSize: '1.5rem' }} />
+                    ) : (
+                        <ArrowDownward color='error' sx={{ fontSize: '1.5rem' }} />
+                    )}
+                    <Typography
+                        variant='h6'
+                        sx={{ fontWeight: 'bold' }}
+                        color={summary.rating > personalBest! ? 'success.main' : 'error.main'}
+                    >
+                        {summary.rating > personalBest! ? '+' : ''}
+                        {summary.rating - personalBest!}
+                    </Typography>
+                </Stack>
+            )}
+            {isNewPR && (
+                <Typography
+                    variant='h6'
+                    sx={{ fontWeight: 'bold', color: 'warning.main', mb: 1 }}
+                >
+                    New Personal Best!
+                </Typography>
+            )}
+            {personalBest !== undefined && (
+                <Typography variant='body1' color='text.secondary' sx={{ mb: 3 }}>
+                    Personal Best: {personalBest}
                 </Typography>
             )}
 

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -12,6 +12,7 @@ import {
     MateInOnePuzzle,
 } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
 import { fenToPieceList } from '@jackstenglein/chess-dojo-common/src/mateInOne/fen';
+import { PUZZLES_PER_BLOCK } from '@jackstenglein/chess-dojo-common/src/mateInOne/rating';
 import AccessTime from '@mui/icons-material/AccessTime';
 import Target from '@mui/icons-material/GpsFixed';
 import Timer from '@mui/icons-material/Timer';
@@ -28,9 +29,7 @@ import { Key } from 'chessground/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { computeSessionStats, isCorrectAnswer } from './mateInOneDrillUtils';
 
-const MIN_PUZZLES_FOR_RATING = 10;
-
-type DrillState = 'loading' | 'ready' | 'in_progress' | 'complete';
+type DrillState = 'loading' | 'ready' | 'in_progress' | 'block_complete' | 'paused';
 
 /** A puzzle with its pre-computed solution and display data. */
 interface PuzzleWithSolution {
@@ -49,11 +48,14 @@ interface PuzzleWithSolution {
     pieceList: string;
 }
 
-interface SessionSummary {
-    totalPuzzles: number;
+/** Summary of a completed 10-puzzle block. */
+interface BlockSummary {
+    blockNumber: number;
     correctCount: number;
-    avgResponseTimeMs: number;
     totalTimeSeconds: number;
+    avgResponseTimeMs: number;
+    rating: number;
+    isNewPR: boolean;
     attempts: MateInOneAttempt[];
 }
 
@@ -100,26 +102,44 @@ export function MateInOneDrillPage() {
 
 /** Inner component: manages the full drill lifecycle. */
 function MateInOneDrill() {
+    const { user, updateUser } = useAuth();
     const submitRequest = useRequest();
     const [drillState, setDrillState] = useState<DrillState>('loading');
     const [currentPuzzle, setCurrentPuzzle] = useState<PuzzleWithSolution | null>(null);
     const [userInput, setUserInput] = useState('');
     const [feedback, setFeedback] = useState<'correct' | 'incorrect' | null>(null);
     const [attempts, setAttempts] = useState<MateInOneAttempt[]>([]);
-    const [summary, setSummary] = useState<SessionSummary | null>(null);
+    const [blockNumber, setBlockNumber] = useState(1);
+    const [blockSummary, setBlockSummary] = useState<BlockSummary | null>(null);
+    const [pauseRequested, setPauseRequested] = useState(false);
+    const [pausedElapsedMs, setPausedElapsedMs] = useState(0);
     const [prefetchLoading, setPrefetchLoading] = useState(false);
     const [fetchError, setFetchError] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
 
     const attemptsRef = useRef<MateInOneAttempt[]>([]);
-    const sessionStartRef = useRef<number>(0);
+    /** Total accumulated active solve time for the current block, in ms. Excludes paused time. */
+    const accumulatedMsRef = useRef<number>(0);
+    /**
+     * The performance.now() value when the stopwatch started running. Null when paused.
+     * Use performance.now() (not Date.now()) so wall-clock changes can't skew the timer.
+     */
+    const runningSinceMsRef = useRef<number | null>(null);
     const questionStartRef = useRef<number>(0);
-    const sessionCreatedAtRef = useRef<string>('');
+    const blockCreatedAtRef = useRef<string>('');
     const prefetchRef = useRef<Promise<PuzzleWithSolution> | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
     const FOCUS_DELAY_MS = 50;
     const focusInput = useCallback(() => {
         setTimeout(() => inputRef.current?.focus(), FOCUS_DELAY_MS);
+    }, []);
+
+    /** Returns the active solve time for the current block in ms (excluding paused time). */
+    const getElapsedMs = useCallback(() => {
+        const running =
+            runningSinceMsRef.current !== null ? performance.now() - runningSinceMsRef.current : 0;
+        return accumulatedMsRef.current + running;
     }, []);
 
     /** Fetches and computes a single puzzle. */
@@ -147,84 +167,121 @@ function MateInOneDrill() {
             });
     }, [fetchPuzzle]);
 
-    const startDrill = useCallback(() => {
-        setAttempts([]);
-        attemptsRef.current = [];
-        setFeedback(null);
-        setSummary(null);
-        setUserInput('');
-        setCurrentPuzzle(null);
-        prefetchRef.current = null;
-        sessionStartRef.current = Date.now();
-        sessionCreatedAtRef.current = new Date().toISOString();
-        setDrillState('in_progress');
-        fetchPuzzle()
-            .then((p) => {
-                setCurrentPuzzle(p);
-                setFetchError(false);
-                questionStartRef.current = Date.now();
-                prefetchNext();
-                focusInput();
-            })
-            .catch(() => {
-                setFetchError(true);
-                setDrillState('ready');
-            });
-    }, [fetchPuzzle, prefetchNext, focusInput]);
-
-    const finishDrill = useCallback(
-        (allAttempts: MateInOneAttempt[]) => {
-            if (allAttempts.length === 0) {
-                setDrillState('ready');
-                return;
-            }
-
-            const { totalTimeSeconds, correctCount, avgResponseTimeMs } = computeSessionStats(
-                allAttempts,
-                sessionStartRef.current,
-            );
-
-            const result: SessionSummary = {
-                totalPuzzles: allAttempts.length,
-                correctCount,
-                avgResponseTimeMs,
-                totalTimeSeconds,
-                attempts: allAttempts,
-            };
-
-            setSummary(result);
-            setDrillState('complete');
-
-            submitRequest.onStart();
-            submitMateInOneSession({
-                ...result,
-                createdAt: sessionCreatedAtRef.current,
-            }).then(
-                () => submitRequest.onSuccess(),
-                (err: unknown) => submitRequest.onFailure(err),
-            );
+    /**
+     * Resets all per-block state and starts a fresh block timer + first puzzle fetch.
+     *
+     * @param nextBlockNumber - 1-based block number to begin.
+     */
+    const startBlock = useCallback(
+        (nextBlockNumber: number) => {
+            setAttempts([]);
+            attemptsRef.current = [];
+            setFeedback(null);
+            setBlockSummary(null);
+            setUserInput('');
+            setPauseRequested(false);
+            setPausedElapsedMs(0);
+            setCurrentPuzzle(null);
+            prefetchRef.current = null;
+            accumulatedMsRef.current = 0;
+            runningSinceMsRef.current = performance.now();
+            blockCreatedAtRef.current = new Date().toISOString();
+            setBlockNumber(nextBlockNumber);
+            setDrillState('in_progress');
+            fetchPuzzle()
+                .then((p) => {
+                    setCurrentPuzzle(p);
+                    setFetchError(false);
+                    questionStartRef.current = performance.now();
+                    prefetchNext();
+                    focusInput();
+                })
+                .catch(() => {
+                    setFetchError(true);
+                    setDrillState('ready');
+                });
         },
-        [submitRequest],
+        [fetchPuzzle, prefetchNext, focusInput],
     );
 
-    const handleStop = useCallback(() => {
-        finishDrill(attemptsRef.current);
-    }, [finishDrill]);
+    const startDrill = useCallback(() => startBlock(1), [startBlock]);
+
+    /**
+     * Finalizes a complete 10-puzzle block: freezes timer, computes rating, fires submission.
+     *
+     * @param finalAttempts - The 10 attempts that make up the block.
+     */
+    const finalizeBlock = useCallback(
+        (finalAttempts: MateInOneAttempt[]) => {
+            // Freeze the stopwatch.
+            if (runningSinceMsRef.current !== null) {
+                accumulatedMsRef.current += performance.now() - runningSinceMsRef.current;
+                runningSinceMsRef.current = null;
+            }
+            const elapsedMs = accumulatedMsRef.current;
+            const stats = computeSessionStats(finalAttempts, elapsedMs);
+            const rating = stats.rating ?? 0;
+            const previousPR = user?.mateInOneRating;
+            const isNewPR = previousPR === undefined || rating > previousPR;
+
+            const summary: BlockSummary = {
+                blockNumber,
+                correctCount: stats.correctCount,
+                totalTimeSeconds: stats.totalTimeSeconds,
+                avgResponseTimeMs: stats.avgResponseTimeMs,
+                rating,
+                isNewPR,
+                attempts: finalAttempts,
+            };
+            setBlockSummary(summary);
+            setDrillState('block_complete');
+
+            setSubmitting(true);
+            submitRequest.onStart();
+            submitMateInOneSession({
+                totalPuzzles: finalAttempts.length,
+                correctCount: stats.correctCount,
+                avgResponseTimeMs: stats.avgResponseTimeMs,
+                totalTimeSeconds: stats.totalTimeSeconds,
+                attempts: finalAttempts,
+                createdAt: blockCreatedAtRef.current,
+            }).then(
+                (response) => {
+                    submitRequest.onSuccess();
+                    setSubmitting(false);
+                    const serverRating = response.data.rating;
+                    if (
+                        serverRating !== undefined &&
+                        (user?.mateInOneRating === undefined || serverRating > user.mateInOneRating)
+                    ) {
+                        updateUser({ mateInOneRating: serverRating });
+                    }
+                },
+                (err: unknown) => {
+                    submitRequest.onFailure(err);
+                    setSubmitting(false);
+                },
+            );
+        },
+        [submitRequest, blockNumber, user, updateUser],
+    );
 
     const advanceToNextPuzzle = useCallback(() => {
         setUserInput('');
         setFeedback(null);
 
+        const onPuzzle = (p: PuzzleWithSolution) => {
+            setCurrentPuzzle(p);
+            setPrefetchLoading(false);
+            questionStartRef.current = performance.now();
+            prefetchNext();
+            focusInput();
+        };
+
         if (!prefetchRef.current) {
             setPrefetchLoading(true);
             fetchPuzzle()
-                .then((p) => {
-                    setCurrentPuzzle(p);
-                    setPrefetchLoading(false);
-                    questionStartRef.current = Date.now();
-                    prefetchNext();
-                    focusInput();
-                })
+                .then(onPuzzle)
                 .catch(() => {
                     setPrefetchLoading(false);
                     setFetchError(true);
@@ -232,26 +289,62 @@ function MateInOneDrill() {
             return;
         }
 
-        prefetchRef.current
-            .then((p) => {
-                setCurrentPuzzle(p);
-                setPrefetchLoading(false);
-                questionStartRef.current = Date.now();
-                prefetchNext();
-                focusInput();
-            })
-            .catch(() => {
-                setPrefetchLoading(false);
-                setFetchError(true);
-            });
-
+        prefetchRef.current.then(onPuzzle).catch(() => {
+            setPrefetchLoading(false);
+            setFetchError(true);
+        });
         prefetchRef.current = null;
     }, [fetchPuzzle, prefetchNext, focusInput]);
+
+    /** Handles the user's "Continue" click after a feedback flash. */
+    const handleContinue = useCallback(() => {
+        const filled = attemptsRef.current.length;
+        if (filled >= PUZZLES_PER_BLOCK) {
+            // Block already finalized while feedback was showing; nothing to do.
+            return;
+        }
+        if (pauseRequested) {
+            // Freeze stopwatch and enter paused state.
+            if (runningSinceMsRef.current !== null) {
+                accumulatedMsRef.current += performance.now() - runningSinceMsRef.current;
+                runningSinceMsRef.current = null;
+            }
+            setPausedElapsedMs(accumulatedMsRef.current);
+            setPauseRequested(false);
+            setDrillState('paused');
+            setFeedback(null);
+            setUserInput('');
+            return;
+        }
+        advanceToNextPuzzle();
+    }, [advanceToNextPuzzle, pauseRequested]);
+
+    const handleResume = useCallback(() => {
+        runningSinceMsRef.current = performance.now();
+        setDrillState('in_progress');
+        advanceToNextPuzzle();
+    }, [advanceToNextPuzzle]);
+
+    /**
+     * Ends the session while paused. The most recent per-attempt save already wrote
+     * a partial-block row to the server (with attempts.length < 10, so no rating).
+     * We just navigate back to the landing screen, no extra request needed.
+     */
+    const handleEndSession = useCallback(() => {
+        runningSinceMsRef.current = null;
+        accumulatedMsRef.current = 0;
+        attemptsRef.current = [];
+        setAttempts([]);
+        setBlockSummary(null);
+        setPauseRequested(false);
+        setPausedElapsedMs(0);
+        setDrillState('ready');
+    }, []);
 
     const handleSubmit = useCallback(() => {
         if (!currentPuzzle || feedback !== null || userInput.trim() === '') return;
 
-        const responseTimeMs = Date.now() - questionStartRef.current;
+        const responseTimeMs = performance.now() - questionStartRef.current;
         const correct = isCorrectAnswer(userInput, currentPuzzle.correctSan);
 
         const attempt: MateInOneAttempt = {
@@ -260,29 +353,37 @@ function MateInOneDrill() {
             correctMove: currentPuzzle.correctSan,
             userMove: userInput.trim(),
             isCorrect: correct,
-            responseTimeMs,
+            responseTimeMs: Math.round(responseTimeMs),
         };
 
         const updatedAttempts = [...attemptsRef.current, attempt];
         attemptsRef.current = updatedAttempts;
         setAttempts(updatedAttempts);
 
-        const { totalTimeSeconds, correctCount, avgResponseTimeMs } = computeSessionStats(
-            updatedAttempts,
-            sessionStartRef.current,
-        );
+        const elapsedMs = getElapsedMs();
+        const stats = computeSessionStats(updatedAttempts, elapsedMs);
 
+        if (updatedAttempts.length === PUZZLES_PER_BLOCK) {
+            // Final attempt of the block. finalizeBlock fires the canonical submission
+            // (with the createdAt that earlier per-attempt saves used). No extra
+            // mid-block save here, otherwise we'd race with the server-side rating write.
+            setFeedback(correct ? 'correct' : 'incorrect');
+            finalizeBlock(updatedAttempts);
+            return;
+        }
+
+        // Partial block: save progress so an interrupted block isn't lost.
         submitMateInOneSession({
             totalPuzzles: updatedAttempts.length,
-            correctCount,
-            avgResponseTimeMs,
-            totalTimeSeconds,
+            correctCount: stats.correctCount,
+            avgResponseTimeMs: stats.avgResponseTimeMs,
+            totalTimeSeconds: stats.totalTimeSeconds,
             attempts: updatedAttempts,
-            createdAt: sessionCreatedAtRef.current,
+            createdAt: blockCreatedAtRef.current,
         }).catch(() => undefined);
 
         setFeedback(correct ? 'correct' : 'incorrect');
-    }, [currentPuzzle, feedback, userInput]);
+    }, [currentPuzzle, feedback, userInput, getElapsedMs, finalizeBlock]);
 
     if (drillState === 'loading') {
         return (
@@ -296,10 +397,28 @@ function MateInOneDrill() {
         return <ReadyScreen onStart={startDrill} fetchError={fetchError} />;
     }
 
-    if (drillState === 'complete' && summary) {
+    if (drillState === 'paused') {
+        return (
+            <PausedScreen
+                elapsedMs={pausedElapsedMs}
+                puzzlesAnswered={attemptsRef.current.length}
+                onResume={handleResume}
+                onEndSession={handleEndSession}
+            />
+        );
+    }
+
+    if (drillState === 'block_complete' && blockSummary) {
         return (
             <>
-                <CompleteScreen summary={summary} onPlayAgain={startDrill} />
+                <BlockCompleteScreen
+                    summary={blockSummary}
+                    submitting={submitting}
+                    submitFailed={submitRequest.isFailure()}
+                    onContinue={() => startBlock(blockSummary.blockNumber + 1)}
+                    onRetry={() => finalizeBlock(blockSummary.attempts)}
+                    onEndSession={handleEndSession}
+                />
                 <RequestSnackbar request={submitRequest} />
             </>
         );
@@ -308,12 +427,14 @@ function MateInOneDrill() {
     return (
         <InProgressScreen
             puzzle={currentPuzzle}
-            puzzleNumber={attempts.length + 1}
+            blockNumber={blockNumber}
+            puzzleNumberInBlock={attempts.length + 1}
             userInput={userInput}
             onInputChange={setUserInput}
             onSubmit={handleSubmit}
-            onContinue={advanceToNextPuzzle}
-            onStop={handleStop}
+            onContinue={handleContinue}
+            pauseRequested={pauseRequested}
+            onRequestPause={() => setPauseRequested(true)}
             feedback={feedback}
             prefetchLoading={prefetchLoading}
             inputRef={inputRef}
@@ -325,6 +446,7 @@ function MateInOneDrill() {
  * Landing screen with a two-step armed Start flow.
  *
  * @param onStart - Callback invoked when the user confirms they want to start.
+ * @param fetchError - Whether the initial puzzle fetch failed.
  */
 function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError: boolean }) {
     const [armed, setArmed] = useState(false);
@@ -337,6 +459,10 @@ function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError:
             <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
                 You will see a list of pieces and their squares. Type the mating move in SAN
                 notation (e.g. "Qh7#" or just "Qh7") and press Enter.
+            </Typography>
+            <Typography variant='body2' color='warning.main' sx={{ mb: 1, fontWeight: 'bold' }}>
+                This drill is very hard. Your rating is computed every {PUZZLES_PER_BLOCK} problems;
+                you can pause between problems with the Pause button.
             </Typography>
             <Typography variant='body1' color='text.secondary' sx={{ mb: 4 }}>
                 {armed
@@ -362,12 +488,14 @@ function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError:
 
 interface InProgressScreenProps {
     puzzle: PuzzleWithSolution | null;
-    puzzleNumber: number;
+    blockNumber: number;
+    puzzleNumberInBlock: number;
     userInput: string;
     onInputChange: (value: string) => void;
     onSubmit: () => void;
     onContinue: () => void;
-    onStop: () => void;
+    pauseRequested: boolean;
+    onRequestPause: () => void;
     feedback: 'correct' | 'incorrect' | null;
     prefetchLoading: boolean;
     inputRef: React.RefObject<HTMLInputElement | null>;
@@ -377,24 +505,28 @@ interface InProgressScreenProps {
  * Active drill screen: shows piece list, accepts typed move, flashes feedback.
  *
  * @param puzzle - The current puzzle with solution data.
- * @param puzzleNumber - 1-based index of the current puzzle in the session.
+ * @param blockNumber - 1-based current block number.
+ * @param puzzleNumberInBlock - 1-based puzzle index within the current block.
  * @param userInput - Current text in the move input field.
  * @param onInputChange - Callback to update the input value.
  * @param onSubmit - Callback invoked when the user submits their answer.
- * @param onContinue - Callback invoked when the user continues to the next puzzle.
- * @param onStop - Callback invoked when the user ends the session early.
+ * @param onContinue - Callback invoked when the user advances after feedback.
+ * @param pauseRequested - Whether the user has armed a pause for the next problem boundary.
+ * @param onRequestPause - Callback invoked when the user clicks "Pause after this problem".
  * @param feedback - Current feedback state ('correct', 'incorrect', or null).
  * @param prefetchLoading - Whether the next puzzle is still being fetched.
  * @param inputRef - Ref to the text input element for programmatic focus.
  */
 function InProgressScreen({
     puzzle,
-    puzzleNumber,
+    blockNumber,
+    puzzleNumberInBlock,
     userInput,
     onInputChange,
     onSubmit,
-    onStop,
     onContinue,
+    pauseRequested,
+    onRequestPause,
     feedback,
     prefetchLoading,
     inputRef,
@@ -410,7 +542,7 @@ function InProgressScreen({
     return (
         <Container maxWidth='sm' sx={{ py: 4, textAlign: 'center' }}>
             <Typography variant='subtitle1' color='text.secondary' sx={{ mb: 0.5 }}>
-                Puzzle {puzzleNumber}
+                Block {blockNumber} · Puzzle {puzzleNumberInBlock} / {PUZZLES_PER_BLOCK}
             </Typography>
 
             <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
@@ -485,8 +617,13 @@ function InProgressScreen({
                     {feedback ? 'Continue' : 'Submit'}
                 </Button>
 
-                <Button variant='outlined' color='error' onClick={onStop}>
-                    Stop
+                <Button
+                    variant='outlined'
+                    color='warning'
+                    onClick={onRequestPause}
+                    disabled={pauseRequested}
+                >
+                    {pauseRequested ? 'Pause queued' : 'Pause after this problem'}
                 </Button>
             </Stack>
 
@@ -519,42 +656,106 @@ function InProgressScreen({
     );
 }
 
-interface CompleteScreenProps {
-    summary: SessionSummary;
-    onPlayAgain: () => void;
+interface PausedScreenProps {
+    elapsedMs: number;
+    puzzlesAnswered: number;
+    onResume: () => void;
+    onEndSession: () => void;
 }
 
 /**
- * Summary screen shown after the session ends.
+ * Paused screen shown between problems. Hides the puzzle text and freezes the
+ * block timer. The user can resume to continue the same block, or end the
+ * session. Ending while paused leaves the partial-block row already saved on
+ * the server intact (no rating, no PR update).
  *
- * @param summary - The computed session statistics.
- * @param onPlayAgain - Callback invoked when the user wants another session.
+ * @param elapsedMs - Active solve time accumulated so far in the current block.
+ * @param puzzlesAnswered - Number of puzzles already answered in this block.
+ * @param onResume - Callback to resume the block.
+ * @param onEndSession - Callback to abort the session and return to the landing screen.
  */
-function CompleteScreen({ summary, onPlayAgain }: CompleteScreenProps) {
-    const accuracy =
-        summary.totalPuzzles > 0
-            ? Math.round((summary.correctCount / summary.totalPuzzles) * 100)
-            : 0;
+function PausedScreen({ elapsedMs, puzzlesAnswered, onResume, onEndSession }: PausedScreenProps) {
+    const totalSeconds = Math.round(elapsedMs / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    const display = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+
+    return (
+        <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
+            <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 3 }}>
+                Paused
+            </Typography>
+            <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
+                {display} elapsed · {puzzlesAnswered} / {PUZZLES_PER_BLOCK} puzzles answered
+            </Typography>
+            <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
+                The timer is frozen. Resume to continue this block, or end the session. Your
+                progress so far is already saved.
+            </Typography>
+            <Stack direction='row' spacing={2} justifyContent='center'>
+                <Button variant='contained' size='large' onClick={onResume} sx={{ px: 4 }}>
+                    Resume
+                </Button>
+                <Button variant='outlined' color='error' size='large' onClick={onEndSession}>
+                    End session
+                </Button>
+            </Stack>
+        </Container>
+    );
+}
+
+interface BlockCompleteScreenProps {
+    summary: BlockSummary;
+    submitting: boolean;
+    submitFailed: boolean;
+    onContinue: () => void;
+    onRetry: () => void;
+    onEndSession: () => void;
+}
+
+/**
+ * Summary screen shown after a 10-puzzle block completes.
+ *
+ * @param summary - The computed block statistics including rating and isNewPR.
+ * @param submitting - Whether the canonical block submission is in flight.
+ * @param submitFailed - Whether the canonical block submission failed.
+ * @param onContinue - Callback to start the next block.
+ * @param onRetry - Callback to retry the failed submission.
+ * @param onEndSession - Callback to end the session and return to the landing screen.
+ */
+function BlockCompleteScreen({
+    summary,
+    submitting,
+    submitFailed,
+    onContinue,
+    onRetry,
+    onEndSession,
+}: BlockCompleteScreenProps) {
+    const accuracy = Math.round((summary.correctCount / PUZZLES_PER_BLOCK) * 100);
     const avgTime = (summary.avgResponseTimeMs / 1000).toFixed(1);
 
     return (
         <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
-            <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 4 }}>
-                Session Complete!
+            <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 1 }}>
+                Block {summary.blockNumber} Complete!
             </Typography>
-
-            {summary.totalPuzzles < MIN_PUZZLES_FOR_RATING && (
-                <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
-                    Complete at least {MIN_PUZZLES_FOR_RATING} puzzles in a session to unlock
-                    ratings (coming soon).
+            <Typography variant='h2' sx={{ fontWeight: 'bold', color: 'primary.main', mb: 1 }}>
+                {summary.rating}
+            </Typography>
+            {summary.isNewPR && summary.rating > 0 && (
+                <Typography
+                    variant='subtitle1'
+                    sx={{ color: 'success.main', fontWeight: 'bold', mb: 3 }}
+                >
+                    New PR!
                 </Typography>
             )}
 
             <Stack spacing={2} sx={{ mb: 4 }}>
                 <StatRow
                     icon={<Target fontSize='small' />}
-                    label='Accuracy'
-                    value={`${accuracy}% (${summary.correctCount}/${summary.totalPuzzles})`}
+                    label='Score'
+                    value={`${summary.correctCount} / ${PUZZLES_PER_BLOCK} (${accuracy}%)`}
                 />
                 <StatRow
                     icon={<Timer fontSize='small' />}
@@ -600,9 +801,45 @@ function CompleteScreen({ summary, onPlayAgain }: CompleteScreenProps) {
                 ))}
             </Stack>
 
-            <Button variant='contained' size='large' onClick={onPlayAgain} sx={{ px: 6, py: 1.5 }}>
-                Play Again
-            </Button>
+            {submitFailed && !submitting && (
+                <Typography variant='body2' color='error' sx={{ mb: 2 }}>
+                    Could not save this block. Retry to record your rating.
+                </Typography>
+            )}
+
+            <Stack direction='row' spacing={2} justifyContent='center'>
+                {submitFailed ? (
+                    <Button variant='contained' size='large' onClick={onRetry} sx={{ px: 4 }}>
+                        Retry save
+                    </Button>
+                ) : (
+                    <Button
+                        variant='contained'
+                        size='large'
+                        onClick={onContinue}
+                        disabled={submitting}
+                        sx={{ px: 4 }}
+                    >
+                        {submitting ? (
+                            <>
+                                <CircularProgress size={18} sx={{ mr: 1, color: 'inherit' }} />
+                                Saving...
+                            </>
+                        ) : (
+                            'Continue to next block'
+                        )}
+                    </Button>
+                )}
+                <Button
+                    variant='outlined'
+                    color='error'
+                    size='large'
+                    onClick={onEndSession}
+                    disabled={submitting}
+                >
+                    End session
+                </Button>
+            </Stack>
         </Container>
     );
 }

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -752,8 +752,10 @@ function BlockCompleteScreen({
 }: BlockCompleteScreenProps) {
     const accuracy = Math.round((summary.correctCount / PUZZLES_PER_BLOCK) * 100);
     const avgTime = (summary.avgResponseTimeMs / 1000).toFixed(1);
-    const showDiff =
-        summary.rating > 0 && personalBest !== undefined && summary.rating !== personalBest;
+    const ratingDiff =
+        summary.rating > 0 && personalBest !== undefined && summary.rating !== personalBest
+            ? summary.rating - personalBest
+            : null;
     const isNewPR =
         summary.rating > 0 && (personalBest === undefined || summary.rating > personalBest);
 
@@ -765,7 +767,7 @@ function BlockCompleteScreen({
             <Typography variant='h2' sx={{ fontWeight: 'bold', color: 'primary.main', mb: 1 }}>
                 {summary.rating}
             </Typography>
-            {showDiff && (
+            {ratingDiff !== null && (
                 <Stack
                     direction='row'
                     alignItems='center'
@@ -773,7 +775,7 @@ function BlockCompleteScreen({
                     spacing={0.5}
                     sx={{ mb: 1 }}
                 >
-                    {summary.rating > personalBest! ? (
+                    {ratingDiff > 0 ? (
                         <ArrowUpward color='success' sx={{ fontSize: '1.5rem' }} />
                     ) : (
                         <ArrowDownward color='error' sx={{ fontSize: '1.5rem' }} />
@@ -781,10 +783,10 @@ function BlockCompleteScreen({
                     <Typography
                         variant='h6'
                         sx={{ fontWeight: 'bold' }}
-                        color={summary.rating > personalBest! ? 'success.main' : 'error.main'}
+                        color={ratingDiff > 0 ? 'success.main' : 'error.main'}
                     >
-                        {summary.rating > personalBest! ? '+' : ''}
-                        {summary.rating - personalBest!}
+                        {ratingDiff > 0 ? '+' : ''}
+                        {ratingDiff}
                     </Typography>
                 </Stack>
             )}

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -170,37 +170,34 @@ function MateInOneDrill() {
     }, [fetchPuzzle]);
 
     /** Resets all per-drill state and starts a fresh timer + first puzzle fetch. */
-    const startBlock = useCallback(
-        () => {
-            setAttempts([]);
-            attemptsRef.current = [];
-            setFeedback(null);
-            setBlockSummary(null);
-            setUserInput('');
-            setPauseRequested(false);
-            setPausedElapsedMs(0);
-            setCurrentPuzzle(null);
-            prefetchRef.current = null;
-            accumulatedMsRef.current = 0;
-            runningSinceMsRef.current = performance.now();
-            blockCreatedAtRef.current = new Date().toISOString();
-            previousBestRef.current = user?.mateInOneRating;
-            setDrillState('in_progress');
-            fetchPuzzle()
-                .then((p) => {
-                    setCurrentPuzzle(p);
-                    setFetchError(false);
-                    questionStartRef.current = performance.now();
-                    prefetchNext();
-                    focusInput();
-                })
-                .catch(() => {
-                    setFetchError(true);
-                    setDrillState('ready');
-                });
-        },
-        [fetchPuzzle, prefetchNext, focusInput],
-    );
+    const startBlock = useCallback(() => {
+        setAttempts([]);
+        attemptsRef.current = [];
+        setFeedback(null);
+        setBlockSummary(null);
+        setUserInput('');
+        setPauseRequested(false);
+        setPausedElapsedMs(0);
+        setCurrentPuzzle(null);
+        prefetchRef.current = null;
+        accumulatedMsRef.current = 0;
+        runningSinceMsRef.current = performance.now();
+        blockCreatedAtRef.current = new Date().toISOString();
+        previousBestRef.current = user?.mateInOneRating;
+        setDrillState('in_progress');
+        fetchPuzzle()
+            .then((p) => {
+                setCurrentPuzzle(p);
+                setFetchError(false);
+                questionStartRef.current = performance.now();
+                prefetchNext();
+                focusInput();
+            })
+            .catch(() => {
+                setFetchError(true);
+                setDrillState('ready');
+            });
+    }, [fetchPuzzle, prefetchNext, focusInput]);
 
     const startDrill = useCallback(() => startBlock(), [startBlock]);
 
@@ -705,8 +702,8 @@ function PausedScreen({ elapsedMs, puzzlesAnswered, onResume, onEndSession }: Pa
                 {display} elapsed · {puzzlesAnswered} / {PUZZLES_PER_BLOCK} puzzles answered
             </Typography>
             <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
-                The timer is frozen. Resume to continue, or end the session. Your progress so
-                far is already saved.
+                The timer is frozen. Resume to continue, or end the session. Your progress so far is
+                already saved.
             </Typography>
             <Stack direction='row' spacing={2} justifyContent='center'>
                 <Button variant='contained' size='large' onClick={onResume} sx={{ px: 4 }}>
@@ -791,10 +788,7 @@ function BlockCompleteScreen({
                 </Stack>
             )}
             {isNewPR && (
-                <Typography
-                    variant='h6'
-                    sx={{ fontWeight: 'bold', color: 'warning.main', mb: 1 }}
-                >
+                <Typography variant='h6' sx={{ fontWeight: 'bold', color: 'warning.main', mb: 1 }}>
                     New Personal Best!
                 </Typography>
             )}

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -386,7 +386,13 @@ function MateInOneDrill() {
     }
 
     if (drillState === 'ready') {
-        return <ReadyScreen onStart={startDrill} fetchError={fetchError} />;
+        return (
+            <ReadyScreen
+                onStart={startDrill}
+                fetchError={fetchError}
+                personalBest={user?.mateInOneRating}
+            />
+        );
     }
 
     if (drillState === 'paused') {
@@ -439,7 +445,15 @@ function MateInOneDrill() {
  * @param onStart - Callback invoked when the user confirms they want to start.
  * @param fetchError - Whether the initial puzzle fetch failed.
  */
-function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError: boolean }) {
+function ReadyScreen({
+    onStart,
+    fetchError,
+    personalBest,
+}: {
+    onStart: () => void;
+    fetchError: boolean;
+    personalBest?: number;
+}) {
     const [armed, setArmed] = useState(false);
 
     return (
@@ -447,6 +461,14 @@ function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError:
             <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 2 }}>
                 Mate in One Visualization Drill
             </Typography>
+            {personalBest !== undefined && (
+                <Typography
+                    variant='subtitle1'
+                    sx={{ color: 'primary.main', fontWeight: 'bold', mb: 2 }}
+                >
+                    Personal best: {personalBest}
+                </Typography>
+            )}
             <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
                 You will see a list of pieces and their squares. Type the mating move in SAN
                 notation (e.g. "Qh7#" or just "Qh7") and press Enter.

--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -48,9 +48,8 @@ interface PuzzleWithSolution {
     pieceList: string;
 }
 
-/** Summary of a completed 10-puzzle block. */
+/** Summary of a completed 10-puzzle drill. */
 interface BlockSummary {
-    blockNumber: number;
     correctCount: number;
     totalTimeSeconds: number;
     avgResponseTimeMs: number;
@@ -109,7 +108,6 @@ function MateInOneDrill() {
     const [userInput, setUserInput] = useState('');
     const [feedback, setFeedback] = useState<'correct' | 'incorrect' | null>(null);
     const [attempts, setAttempts] = useState<MateInOneAttempt[]>([]);
-    const [blockNumber, setBlockNumber] = useState(1);
     const [blockSummary, setBlockSummary] = useState<BlockSummary | null>(null);
     const [pauseRequested, setPauseRequested] = useState(false);
     const [pausedElapsedMs, setPausedElapsedMs] = useState(0);
@@ -167,13 +165,9 @@ function MateInOneDrill() {
             });
     }, [fetchPuzzle]);
 
-    /**
-     * Resets all per-block state and starts a fresh block timer + first puzzle fetch.
-     *
-     * @param nextBlockNumber - 1-based block number to begin.
-     */
+    /** Resets all per-drill state and starts a fresh timer + first puzzle fetch. */
     const startBlock = useCallback(
-        (nextBlockNumber: number) => {
+        () => {
             setAttempts([]);
             attemptsRef.current = [];
             setFeedback(null);
@@ -186,7 +180,6 @@ function MateInOneDrill() {
             accumulatedMsRef.current = 0;
             runningSinceMsRef.current = performance.now();
             blockCreatedAtRef.current = new Date().toISOString();
-            setBlockNumber(nextBlockNumber);
             setDrillState('in_progress');
             fetchPuzzle()
                 .then((p) => {
@@ -204,7 +197,7 @@ function MateInOneDrill() {
         [fetchPuzzle, prefetchNext, focusInput],
     );
 
-    const startDrill = useCallback(() => startBlock(1), [startBlock]);
+    const startDrill = useCallback(() => startBlock(), [startBlock]);
 
     /**
      * Finalizes a complete 10-puzzle block: freezes timer, computes rating, fires submission.
@@ -225,7 +218,6 @@ function MateInOneDrill() {
             const isNewPR = previousPR === undefined || rating > previousPR;
 
             const summary: BlockSummary = {
-                blockNumber,
                 correctCount: stats.correctCount,
                 totalTimeSeconds: stats.totalTimeSeconds,
                 avgResponseTimeMs: stats.avgResponseTimeMs,
@@ -263,7 +255,7 @@ function MateInOneDrill() {
                 },
             );
         },
-        [submitRequest, blockNumber, user, updateUser],
+        [submitRequest, user, updateUser],
     );
 
     const advanceToNextPuzzle = useCallback(() => {
@@ -415,7 +407,7 @@ function MateInOneDrill() {
                     summary={blockSummary}
                     submitting={submitting}
                     submitFailed={submitRequest.isFailure()}
-                    onContinue={() => startBlock(blockSummary.blockNumber + 1)}
+                    onContinue={() => startBlock()}
                     onRetry={() => finalizeBlock(blockSummary.attempts)}
                     onEndSession={handleEndSession}
                 />
@@ -427,7 +419,6 @@ function MateInOneDrill() {
     return (
         <InProgressScreen
             puzzle={currentPuzzle}
-            blockNumber={blockNumber}
             puzzleNumberInBlock={attempts.length + 1}
             userInput={userInput}
             onInputChange={setUserInput}
@@ -461,7 +452,7 @@ function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError:
                 notation (e.g. "Qh7#" or just "Qh7") and press Enter.
             </Typography>
             <Typography variant='body2' color='warning.main' sx={{ mb: 1, fontWeight: 'bold' }}>
-                This drill is very hard. Your rating is computed every {PUZZLES_PER_BLOCK} problems;
+                This drill is very hard. Your rating is computed after {PUZZLES_PER_BLOCK} problems;
                 you can pause between problems with the Pause button.
             </Typography>
             <Typography variant='body1' color='text.secondary' sx={{ mb: 4 }}>
@@ -488,7 +479,6 @@ function ReadyScreen({ onStart, fetchError }: { onStart: () => void; fetchError:
 
 interface InProgressScreenProps {
     puzzle: PuzzleWithSolution | null;
-    blockNumber: number;
     puzzleNumberInBlock: number;
     userInput: string;
     onInputChange: (value: string) => void;
@@ -505,8 +495,7 @@ interface InProgressScreenProps {
  * Active drill screen: shows piece list, accepts typed move, flashes feedback.
  *
  * @param puzzle - The current puzzle with solution data.
- * @param blockNumber - 1-based current block number.
- * @param puzzleNumberInBlock - 1-based puzzle index within the current block.
+ * @param puzzleNumberInBlock - 1-based puzzle index within the drill.
  * @param userInput - Current text in the move input field.
  * @param onInputChange - Callback to update the input value.
  * @param onSubmit - Callback invoked when the user submits their answer.
@@ -519,7 +508,6 @@ interface InProgressScreenProps {
  */
 function InProgressScreen({
     puzzle,
-    blockNumber,
     puzzleNumberInBlock,
     userInput,
     onInputChange,
@@ -542,7 +530,7 @@ function InProgressScreen({
     return (
         <Container maxWidth='sm' sx={{ py: 4, textAlign: 'center' }}>
             <Typography variant='subtitle1' color='text.secondary' sx={{ mb: 0.5 }}>
-                Block {blockNumber} · Puzzle {puzzleNumberInBlock} / {PUZZLES_PER_BLOCK}
+                Puzzle {puzzleNumberInBlock} / {PUZZLES_PER_BLOCK}
             </Typography>
 
             <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
@@ -689,8 +677,8 @@ function PausedScreen({ elapsedMs, puzzlesAnswered, onResume, onEndSession }: Pa
                 {display} elapsed · {puzzlesAnswered} / {PUZZLES_PER_BLOCK} puzzles answered
             </Typography>
             <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
-                The timer is frozen. Resume to continue this block, or end the session. Your
-                progress so far is already saved.
+                The timer is frozen. Resume to continue, or end the session. Your progress so
+                far is already saved.
             </Typography>
             <Stack direction='row' spacing={2} justifyContent='center'>
                 <Button variant='contained' size='large' onClick={onResume} sx={{ px: 4 }}>
@@ -737,7 +725,7 @@ function BlockCompleteScreen({
     return (
         <Container maxWidth='sm' sx={{ py: 8, textAlign: 'center' }}>
             <Typography variant='h4' sx={{ fontWeight: 'bold', mb: 1 }}>
-                Block {summary.blockNumber} Complete!
+                Drill Complete!
             </Typography>
             <Typography variant='h2' sx={{ fontWeight: 'bold', color: 'primary.main', mb: 1 }}>
                 {summary.rating}
@@ -803,7 +791,7 @@ function BlockCompleteScreen({
 
             {submitFailed && !submitting && (
                 <Typography variant='body2' color='error' sx={{ mb: 2 }}>
-                    Could not save this block. Retry to record your rating.
+                    Could not save this drill. Retry to record your rating.
                 </Typography>
             )}
 
@@ -826,7 +814,7 @@ function BlockCompleteScreen({
                                 Saving...
                             </>
                         ) : (
-                            'Continue to next block'
+                            'Try again'
                         )}
                     </Button>
                 )}

--- a/frontend/src/components/puzzles/mateInOne/computeSessionStats.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/computeSessionStats.test.ts
@@ -1,5 +1,5 @@
 import { MateInOneAttempt } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { computeSessionStats } from './mateInOneDrillUtils';
 
 function makeAttempt(overrides: Partial<MateInOneAttempt> = {}): MateInOneAttempt {
@@ -55,12 +55,8 @@ describe('computeSessionStats', () => {
         expect(result.avgResponseTimeMs).toBe(0);
     });
 
-    it('computes total time in seconds from session start', () => {
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date('2025-01-01T00:00:30Z'));
-        const sessionStart = new Date('2025-01-01T00:00:00Z').getTime();
-        const result = computeSessionStats([makeAttempt()], sessionStart);
+    it('rounds total time milliseconds to seconds', () => {
+        const result = computeSessionStats([makeAttempt()], 30_000);
         expect(result.totalTimeSeconds).toBe(30);
-        vi.useRealTimers();
     });
 });

--- a/frontend/src/components/puzzles/mateInOne/mateInOneDrillUtils.ts
+++ b/frontend/src/components/puzzles/mateInOne/mateInOneDrillUtils.ts
@@ -1,4 +1,8 @@
 import { MateInOneAttempt } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
+import {
+    PUZZLES_PER_BLOCK,
+    computeMateInOneRating,
+} from '@jackstenglein/chess-dojo-common/src/mateInOne/rating';
 
 /**
  * Strips check, checkmate, and promotion characters so answers like
@@ -18,19 +22,39 @@ export function normalizeSan(san: string): string {
 /**
  * Returns true when the user's input matches the correct mating move,
  * ignoring check/checkmate annotations and promotion `=` characters.
+ *
+ * @param userInput - The text the user typed.
+ * @param correctSan - The puzzle's correct mating move in SAN.
+ * @returns Whether the user's input matches the correct move.
  */
 export function isCorrectAnswer(userInput: string, correctSan: string): boolean {
     return normalizeSan(userInput) === normalizeSan(correctSan);
 }
 
+/** Aggregate stats for a list of mate-in-one attempts. */
+export interface SessionStats {
+    /** Total active solve time across the attempts, in seconds. */
+    totalTimeSeconds: number;
+    /** Number of correct attempts. */
+    correctCount: number;
+    /** Average per-attempt response time in milliseconds. */
+    avgResponseTimeMs: number;
+    /** The block rating, present only when the block is exactly PUZZLES_PER_BLOCK long. */
+    rating?: number;
+}
+
 /**
  * Computes summary statistics from a list of attempts.
+ *
+ * @param allAttempts - The attempts to summarize.
+ * @param totalTimeMs - Total active solve time across the attempts (paused time excluded).
+ * @returns The aggregate stats, including a rating when the block is exactly 10 puzzles.
  */
 export function computeSessionStats(
     allAttempts: MateInOneAttempt[],
-    sessionStartMs: number,
-): { totalTimeSeconds: number; correctCount: number; avgResponseTimeMs: number } {
-    const totalTimeSeconds = Math.round((Date.now() - sessionStartMs) / 1000);
+    totalTimeMs: number,
+): SessionStats {
+    const totalTimeSeconds = Math.round(totalTimeMs / 1000);
     const correctCount = allAttempts.filter((a) => a.isCorrect).length;
     const avgResponseTimeMs =
         allAttempts.length > 0
@@ -38,5 +62,10 @@ export function computeSessionStats(
                   allAttempts.reduce((sum, a) => sum + a.responseTimeMs, 0) / allAttempts.length,
               )
             : 0;
-    return { totalTimeSeconds, correctCount, avgResponseTimeMs };
+
+    const stats: SessionStats = { totalTimeSeconds, correctCount, avgResponseTimeMs };
+    if (allAttempts.length === PUZZLES_PER_BLOCK) {
+        stats.rating = computeMateInOneRating(correctCount, totalTimeSeconds);
+    }
+    return stats;
 }


### PR DESCRIPTION
## Summary

Implements the rating system for the Mate-in-One drill (Part 2 of #2195): per-drill rating from a fixed lookup table with linear interpolation, persists the user's personal best, and adds a "pause after this problem" flow. Personal best is shown on the drill landing screen and the completion screen.

## Related Issues

Fixes #2195

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

## Demo
**Start screen**
<img width="798" height="433" alt="startscreen" src="https://github.com/user-attachments/assets/091244ee-a246-471a-9377-be436cad9604" />

**In progress with new pause button**
<img width="815" height="377" alt="Pause button" src="https://github.com/user-attachments/assets/e4712bca-6916-4dc4-9271-bf059403a5ca" />

**Paused screen**
<img width="1194" height="395" alt="Paused screen" src="https://github.com/user-attachments/assets/1639a825-e0a9-4b69-b1ac-c40823b9b7c7" />

**New Drill ratings tab shown on profile**
<img width="1527" height="1100" alt="image" src="https://github.com/user-attachments/assets/0dd0f48d-a666-4f13-8879-caaa1acd8d6f" />



