### PR TITLE
fix: add 59s period to pgn clock validation

### DIFF
--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockTextField.tsx
@@ -14,6 +14,11 @@ const d = new Date();
 d.setHours(0, 0, 0);
 
 const defaultDateTime = DateTime.fromJSDate(d);
+const hasClockError = (seconds: number, maxSeconds?: number): boolean => {
+    if (maxSeconds === undefined) return false;
+    const effectiveMax = seconds % 60 === 0 ? maxSeconds + 59 : maxSeconds;
+    return seconds > effectiveMax;
+};
 
 interface ClockTextFieldProps {
     move: Move;
@@ -44,7 +49,7 @@ const ClockTextField = ({ move, label, maxSeconds }: ClockTextFieldProps) => {
     if (clockFieldFormat === ClockFieldFormat.SingleFieldInTotalMinutes) {
         const seconds = clockToSeconds(move.commentDiag?.clk) || 0;
         const displayValue = seconds > 0 ? String(Math.floor(seconds / 60)) : '';
-
+        const error = hasClockError(seconds, maxSeconds);
         return (
             <TextField
                 id={BlockBoardKeyboardShortcuts}
@@ -72,11 +77,9 @@ const ClockTextField = ({ move, label, maxSeconds }: ClockTextFieldProps) => {
                 slotProps={{
                     htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
                 }}
-                error={Boolean(maxSeconds && seconds > maxSeconds)}
+                error={error}
                 helperText={
-                    maxSeconds && seconds > maxSeconds
-                        ? 'Gained more time than possible according to time control'
-                        : undefined
+                    error ? 'Gained more time than possible according to time control' : undefined
                 }
             />
         );
@@ -84,6 +87,7 @@ const ClockTextField = ({ move, label, maxSeconds }: ClockTextFieldProps) => {
 
     if (clockFieldFormat === ClockFieldFormat.SingleField) {
         const seconds = clockToSeconds(move.commentDiag?.clk) ?? 0;
+        const error = hasClockError(seconds, maxSeconds);
         return (
             <TimeField
                 id={BlockBoardKeyboardShortcuts}
@@ -93,11 +97,9 @@ const ClockTextField = ({ move, label, maxSeconds }: ClockTextFieldProps) => {
                 onChange={(value) => onChangeClock(chess, move, value)}
                 fullWidth
                 className={BlockBoardKeyboardShortcuts}
-                error={Boolean(maxSeconds && seconds > maxSeconds)}
+                error={error}
                 helperText={
-                    maxSeconds && seconds > maxSeconds
-                        ? 'Gained more time than possible according to time control'
-                        : undefined
+                    error ? 'Gained more time than possible according to time control' : undefined
                 }
             />
         );
@@ -106,8 +108,7 @@ const ClockTextField = ({ move, label, maxSeconds }: ClockTextFieldProps) => {
     if (clockFieldFormat === ClockFieldFormat.ThreeField) {
         const timeSlots = getTimeSlotsFromMove(move);
         const seconds = timeSlots.hours * 3600 + timeSlots.minutes * 60 + timeSlots.seconds;
-
-        const error = maxSeconds !== undefined && seconds > maxSeconds;
+        const error = hasClockError(seconds, maxSeconds);
         const shouldAutoFocusMinutes = maxSeconds !== undefined && maxSeconds < 3600;
 
         const handleHoursFocus = () => {


### PR DESCRIPTION
## Summary

fixes clock validation throwing errors when users log exact minutes without seconds.
added a modulo 60 check to grant a 59s grace period if the input ends in :00.

## Related Issues
Fixes #2231