### PR TITLE
fix: add fallback rating for exam attempts

### DIFF
--- a/frontend/src/app/(scoreboard)/tests/[type]/[id]/exam/ExamPage.tsx
+++ b/frontend/src/app/(scoreboard)/tests/[type]/[id]/exam/ExamPage.tsx
@@ -228,7 +228,7 @@ export const InProgressExam: React.FC<InProgressExamProps> = ({
                 pgn: selectedProblem === i ? pgnApi.current?.getPgn() || '' : pgn,
             })),
             cohort: user.dojoCohort,
-            rating: getNormalizedRating(getCurrentRating(user), user.ratingSystem),
+            rating: getNormalizedRating(getCurrentRating(user), user.ratingSystem) || 0,
             timeUsedSeconds: Math.round(countdown.elapsedTime),
             createdAt: '',
             inProgress,
@@ -321,7 +321,7 @@ export const InProgressExam: React.FC<InProgressExamProps> = ({
                 pgn,
             })),
             cohort: user.dojoCohort,
-            rating: getNormalizedRating(getCurrentRating(user), user.ratingSystem),
+            rating: getNormalizedRating(getCurrentRating(user), user.ratingSystem) || 0,
             timeUsedSeconds: Math.round(countdown.elapsedTime),
             createdAt: new Date().toISOString(),
         };


### PR DESCRIPTION
## Summary

fixes backend throwing "attempt.rating is required" error when unrated users take a tactics test. added a || 0 fallback to the rating payload in ExamPage so the auto-save doesn't fail validation and delete their progress.

## Related Issues

Fixes #2292 


