### PR TITLE
refactor: per-section save/cancel buttons with unsaved changes dialog

### DIFF
--- a/frontend/src/app/(scoreboard)/profile/edit/ProfileEditorPage.tsx
+++ b/frontend/src/app/(scoreboard)/profile/edit/ProfileEditorPage.tsx
@@ -26,18 +26,23 @@ import NotInterestedIcon from '@mui/icons-material/NotInterested';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import SaveIcon from '@mui/icons-material/Save';
 import TimelineIcon from '@mui/icons-material/Timeline';
-import { LoadingButton } from '@mui/lab';
 import {
     Alert,
     Button,
     Card,
     CardContent,
     Container,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
     Grid,
     Stack,
     Typography,
 } from '@mui/material';
-import React, { useState } from 'react';
+import { useNavigationGuard } from 'next-navigation-guard';
+import React, { useEffect, useState } from 'react';
 
 export const MAX_PROFILE_PICTURE_SIZE_MB = 9;
 
@@ -103,8 +108,14 @@ function getUpdate(
     const update: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(formFields)) {
-        if (user[key as keyof User] !== value) {
-            update[key as keyof User] = value;
+        const userValue = user[key as keyof User];
+
+        if (typeof value === 'object' && value !== null) {
+            if (JSON.stringify(userValue) !== JSON.stringify(value)) {
+                update[key] = value;
+            }
+        } else if (userValue !== value) {
+            update[key] = value;
         }
     }
 
@@ -112,13 +123,12 @@ function getUpdate(
         update.profilePictureData = profilePictureData;
     }
 
-    if (Object.entries(update).length === 0) {
+    if (Object.keys(update).length === 0) {
         return undefined;
     }
 
-    return update;
+    return update as Partial<UserUpdate>;
 }
-
 export function encodeFileToBase64(file: File): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
@@ -140,70 +150,156 @@ export function ProfileEditorPage({ user }: { user: User }) {
     const { setImageBypass } = useCache();
     const router = useRouter();
 
-    const [displayName, setDisplayName] = useState(user.displayName);
+    const [displayName, setDisplayName] = useState(user.displayName || '');
     const [dojoCohort, setDojoCohort] = useState(
         user.dojoCohort !== 'NO_COHORT' ? user.dojoCohort : '',
     );
-    const [bio, setBio] = useState(user.bio);
+    const [bio, setBio] = useState(user.bio || '');
     const [coachBio, setCoachBio] = useState(user.coachBio || '');
     const [timezone, setTimezone] = useState(user.timezoneOverride || DefaultTimezone);
 
     const [ratingSystem, setRatingSystem] = useState(user.ratingSystem);
     const [ratingEditors, setRatingEditors] = useState(getRatingEditors(user.ratings));
-    const [enableZenMode, setEnableZenMode] = useState(user.enableZenMode);
+    const [enableZenMode, setEnableZenMode] = useState(user.enableZenMode || false);
 
-    const [notificationSettings, setNotificationSettings] = useState(user.notificationSettings);
+    const [notificationSettings, setNotificationSettings] = useState(
+        user.notificationSettings || {},
+    );
 
     const [profilePictureUrl, setProfilePictureUrl] = useState<string>();
     const [profilePictureData, setProfilePictureData] = useState<string>();
 
     const [errors, setErrors] = useState<Record<string, string>>({});
+    const [bypassGuard, setBypassGuard] = useState(false);
     const request = useRequest<string>();
 
-    const update = getUpdate(
+    const personalUpdate = getUpdate(
         user,
         {
             displayName: displayName.trim(),
-            dojoCohort,
-            bio,
-            coachBio,
-            timezoneOverride: timezone,
-            ratingSystem,
-            ratings: getRatingsFromEditors(ratingEditors),
-            enableZenMode,
-            notificationSettings,
+            bio: bio === '' && user.bio === undefined ? undefined : bio,
+            coachBio: coachBio === '' && user.coachBio === undefined ? undefined : coachBio,
+            timezoneOverride:
+                timezone === DefaultTimezone && !user.timezoneOverride
+                    ? user.timezoneOverride
+                    : timezone,
         },
         profilePictureData,
     );
-    const changesMade = update !== undefined;
 
-    const onSave = () => {
-        if (update === undefined) {
-            return;
-        }
+    const personalChangesMade = Boolean(personalUpdate);
+
+    const ratingsUpdate = getUpdate(
+        user,
+        {
+            dojoCohort: dojoCohort === '' ? 'NO_COHORT' : dojoCohort,
+            ratingSystem,
+            ratings:
+                JSON.stringify(ratingEditors) === JSON.stringify(getRatingEditors(user.ratings))
+                    ? user.ratings
+                    : getRatingsFromEditors(ratingEditors),
+            enableZenMode:
+                !enableZenMode && user.enableZenMode === undefined ? undefined : enableZenMode,
+        },
+        undefined,
+    );
+
+    const ratingsChangesMade = Boolean(ratingsUpdate);
+
+    const notificationsUpdate = getUpdate(
+        user,
+        {
+            notificationSettings:
+                JSON.stringify(notificationSettings) ===
+                JSON.stringify(user.notificationSettings || {})
+                    ? user.notificationSettings
+                    : notificationSettings,
+        },
+        undefined,
+    );
+
+    const notificationsChangesMade = Boolean(notificationsUpdate);
+
+    const hasUnsavedChanges =
+        !bypassGuard && (personalChangesMade || ratingsChangesMade || notificationsChangesMade);
+
+    const navGuard = useNavigationGuard({
+        enabled: hasUnsavedChanges,
+    });
+
+    useEffect(() => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (hasUnsavedChanges) {
+                e.preventDefault();
+                e.returnValue = 'You have unsaved changes. Are you sure you want to leave?';
+            }
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [hasUnsavedChanges]);
+
+    const saveSection = (updatePayload: Partial<UserUpdate>) => {
+        request.onStart();
+        api.updateUser(updatePayload)
+            .then(() => {
+                request.onSuccess('Settings updated');
+                trackEvent(EventType.EditProfile, {
+                    fields: Object.keys(updatePayload),
+                });
+                setUserProperties({ ...user, ...updatePayload });
+
+                if (updatePayload.profilePictureData !== undefined) {
+                    setImageBypass(Date.now());
+                }
+
+                setBypassGuard(true);
+                router.push('/profile');
+            })
+            .catch((err) => {
+                request.onFailure(err);
+            });
+    };
+
+    const onSavePersonal = () => {
+        if (!personalChangesMade) return;
         const newErrors: Record<string, string> = {};
-        if (!displayName.trim()) {
-            newErrors.displayName = 'This field is required';
+        if (!displayName.trim()) newErrors.displayName = 'This field is required';
+
+        setErrors(newErrors);
+        if (Object.keys(newErrors).length > 0) return;
+
+        if (personalUpdate) {
+            saveSection(personalUpdate);
         }
-        if (dojoCohort === '') {
-            newErrors.dojoCohort = 'This field is required';
-        }
-        if ((ratingSystem as string) === '') {
-            newErrors.ratingSystem = 'This field is required';
-        }
+    };
+
+    const onCancelPersonal = () => {
+        setDisplayName(user.displayName || '');
+        setBio(user.bio || '');
+        setCoachBio(user.coachBio || '');
+        setTimezone(user.timezoneOverride || DefaultTimezone);
+        setProfilePictureUrl(undefined);
+        setProfilePictureData(undefined);
+        setErrors({});
+    };
+
+    const onSaveRatings = () => {
+        if (!ratingsChangesMade) return;
+        const newErrors: Record<string, string> = {};
+
+        if (dojoCohort === '') newErrors.dojoCohort = 'This field is required';
+        if ((ratingSystem as string) === '') newErrors.ratingSystem = 'This field is required';
 
         if (!isCustom(ratingSystem) && !ratingEditors[ratingSystem].username.trim()) {
             newErrors[`${ratingSystem}Username`] =
-                `This field is required when using ${formatRatingSystem(
-                    ratingSystem,
-                )} rating system.`;
+                `This field is required when using ${formatRatingSystem(ratingSystem)} rating system.`;
         }
 
         for (const rs of Object.keys(ratingEditors)) {
             const startRating = parseRating(ratingEditors[rs as RatingSystem].startRating);
-            if (startRating < 0) {
-                newErrors[`${rs}StartRating`] = 'Rating must be an integer >= 0';
-            }
+            if (startRating < 0) newErrors[`${rs}StartRating`] = 'Rating must be an integer >= 0';
+
             if (isCustom(rs)) {
                 const name = ratingEditors[rs as RatingSystem].name;
                 const currentRating = parseRating(ratingEditors[rs as RatingSystem].currentRating);
@@ -225,29 +321,34 @@ export function ProfileEditorPage({ user }: { user: User }) {
         }
 
         setErrors(newErrors);
-        if (Object.entries(newErrors).length > 0) {
-            logger.debug?.('New Errors: ', newErrors);
+        if (Object.keys(newErrors).length > 0) {
             return;
         }
 
-        request.onStart();
+        if (ratingsUpdate) {
+            saveSection(ratingsUpdate);
+        }
+    };
 
-        api.updateUser(update)
-            .then(() => {
-                request.onSuccess('Profile updated');
-                trackEvent(EventType.EditProfile, {
-                    fields: Object.keys(update),
-                });
-                setUserProperties({ ...user, ...update });
+    const onCancelRatings = () => {
+        setDojoCohort(user.dojoCohort !== 'NO_COHORT' ? user.dojoCohort : '');
+        setRatingSystem(user.ratingSystem);
+        setRatingEditors(getRatingEditors(user.ratings));
+        setEnableZenMode(user.enableZenMode || false);
+        setErrors({});
+    };
 
-                if (update.profilePictureData !== undefined) {
-                    setImageBypass(Date.now());
-                }
-                router.push('/profile');
-            })
-            .catch((err) => {
-                request.onFailure(err);
-            });
+    const onSaveNotifications = () => {
+        if (!notificationsChangesMade) return;
+        setErrors({});
+        if (notificationsUpdate) {
+            saveSection(notificationsUpdate);
+        }
+    };
+
+    const onCancelNotifications = () => {
+        setNotificationSettings(user.notificationSettings || {});
+        setErrors({});
     };
 
     const scrollToId = (id: string) => (e: React.MouseEvent) => {
@@ -270,10 +371,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
                         borderRightWidth: 1,
                         borderColor: 'divider',
                     }}
-                    size={{
-                        xs: 0,
-                        sm: 'auto',
-                    }}
+                    size={{ xs: 0, sm: 'auto' }}
                 >
                     <Card
                         variant='outlined'
@@ -287,41 +385,29 @@ export function ProfileEditorPage({ user }: { user: User }) {
                                 <Link href='#personal' onClick={scrollToId('personal')}>
                                     <InfoIcon
                                         fontSize='small'
-                                        sx={{
-                                            verticalAlign: 'middle',
-                                            marginRight: '0.2em',
-                                        }}
-                                    />
+                                        sx={{ verticalAlign: 'middle', marginRight: '0.2em' }}
+                                    />{' '}
                                     Personal Info
                                 </Link>
                                 <Link href='#ratings' onClick={scrollToId('ratings')}>
                                     <TimelineIcon
                                         fontSize='small'
-                                        sx={{
-                                            verticalAlign: 'middle',
-                                            marginRight: '0.2em',
-                                        }}
-                                    />
+                                        sx={{ verticalAlign: 'middle', marginRight: '0.2em' }}
+                                    />{' '}
                                     Ratings
                                 </Link>
                                 <Link href='#notifications' onClick={scrollToId('notifications')}>
                                     <NotificationsIcon
                                         fontSize='small'
-                                        sx={{
-                                            verticalAlign: 'middle',
-                                            marginRight: '0.2em',
-                                        }}
-                                    />
+                                        sx={{ verticalAlign: 'middle', marginRight: '0.2em' }}
+                                    />{' '}
                                     Notifications
                                 </Link>
                                 <Link href='#subscription' onClick={scrollToId('subscription')}>
                                     <MonetizationOnIcon
                                         fontSize='small'
-                                        sx={{
-                                            verticalAlign: 'middle',
-                                            marginRight: '0.2em',
-                                        }}
-                                    />
+                                        sx={{ verticalAlign: 'middle', marginRight: '0.2em' }}
+                                    />{' '}
                                     Subscription/Billing
                                 </Link>
                             </Stack>
@@ -329,14 +415,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
                     </Card>
                 </Grid>
 
-                <Grid
-                    size={{
-                        xs: 12,
-                        sm: 'grow',
-                        md: 'grow',
-                        lg: 'grow',
-                    }}
-                >
+                <Grid size={{ xs: 12, sm: 'grow', md: 'grow', lg: 'grow' }}>
                     {user.dojoCohort !== 'NO_COHORT' &&
                         user.dojoCohort !== '' &&
                         !dojoCohorts.includes(user.dojoCohort) && (
@@ -348,40 +427,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
                         )}
 
                     <Stack spacing={5}>
-                        <Stack
-                            direction='row'
-                            alignItems='center'
-                            justifyContent='space-between'
-                            flexWrap='wrap'
-                            rowGap={2}
-                        >
-                            <Typography variant='h4' mr={2}>
-                                Edit Settings
-                            </Typography>
-
-                            <Stack direction='row' spacing={2}>
-                                <LoadingButton
-                                    variant='contained'
-                                    onClick={onSave}
-                                    loading={request.status === RequestStatus.Loading}
-                                    disabled={!changesMade}
-                                    startIcon={<SaveIcon />}
-                                >
-                                    Save
-                                </LoadingButton>
-
-                                <Button
-                                    component={Link}
-                                    variant='contained'
-                                    color='error'
-                                    disableElevation
-                                    href='/profile'
-                                    startIcon={<NotInterestedIcon />}
-                                >
-                                    Cancel
-                                </Button>
-                            </Stack>
-                        </Stack>
+                        <Typography variant='h4'>Edit Settings</Typography>
 
                         {Object.values(errors).length > 0 && (
                             <Alert severity='error' sx={{ mb: 3 }} variant='filled'>
@@ -389,44 +435,132 @@ export function ProfileEditorPage({ user }: { user: User }) {
                             </Alert>
                         )}
 
-                        <PersonalInfoEditor
-                            user={user}
-                            displayName={displayName}
-                            setDisplayName={setDisplayName}
-                            bio={bio}
-                            setBio={setBio}
-                            coachBio={coachBio}
-                            setCoachBio={setCoachBio}
-                            timezone={timezone}
-                            setTimezone={setTimezone}
-                            profilePictureUrl={profilePictureUrl}
-                            setProfilePictureUrl={setProfilePictureUrl}
-                            setProfilePictureData={setProfilePictureData}
-                            errors={errors}
-                            request={request}
-                        />
+                        <Stack spacing={2}>
+                            <PersonalInfoEditor
+                                user={user}
+                                displayName={displayName}
+                                setDisplayName={setDisplayName}
+                                bio={bio}
+                                setBio={setBio}
+                                coachBio={coachBio}
+                                setCoachBio={setCoachBio}
+                                timezone={timezone}
+                                setTimezone={setTimezone}
+                                profilePictureUrl={profilePictureUrl}
+                                setProfilePictureUrl={setProfilePictureUrl}
+                                setProfilePictureData={setProfilePictureData}
+                                errors={errors}
+                                request={request}
+                            />
+                            <Stack direction='row' spacing={2} justifyContent='flex-end'>
+                                <Button
+                                    variant='contained'
+                                    onClick={onSavePersonal}
+                                    disabled={!personalChangesMade}
+                                    loading={request.status === RequestStatus.Loading}
+                                    startIcon={<SaveIcon />}
+                                >
+                                    Save
+                                </Button>
 
-                        <RatingsEditor
-                            dojoCohort={dojoCohort}
-                            setDojoCohort={setDojoCohort}
-                            ratingSystem={ratingSystem}
-                            setRatingSystem={setRatingSystem}
-                            ratingEditors={ratingEditors}
-                            setRatingEditors={setRatingEditors}
-                            enableZenMode={enableZenMode}
-                            setEnableZenMode={setEnableZenMode}
-                            errors={errors}
-                        />
+                                <Button
+                                    variant='contained'
+                                    color='error'
+                                    disableElevation
+                                    onClick={onCancelPersonal}
+                                    disabled={!personalChangesMade}
+                                    startIcon={<NotInterestedIcon />}
+                                >
+                                    Cancel
+                                </Button>
+                            </Stack>
+                        </Stack>
 
-                        <NotificationSettingsEditor
-                            notificationSettings={notificationSettings}
-                            setNotificationSettings={setNotificationSettings}
-                        />
+                        <Stack spacing={2}>
+                            <RatingsEditor
+                                dojoCohort={dojoCohort}
+                                setDojoCohort={setDojoCohort}
+                                ratingSystem={ratingSystem}
+                                setRatingSystem={setRatingSystem}
+                                ratingEditors={ratingEditors}
+                                setRatingEditors={setRatingEditors}
+                                enableZenMode={enableZenMode}
+                                setEnableZenMode={setEnableZenMode}
+                                errors={errors}
+                            />
+                            <Stack direction='row' spacing={2} justifyContent='flex-end'>
+                                <Button
+                                    variant='contained'
+                                    onClick={onSaveRatings}
+                                    disabled={!ratingsChangesMade}
+                                    loading={request.status === RequestStatus.Loading}
+                                    startIcon={<SaveIcon />}
+                                >
+                                    Save
+                                </Button>
+
+                                <Button
+                                    variant='contained'
+                                    color='error'
+                                    disableElevation
+                                    onClick={onCancelRatings}
+                                    disabled={!ratingsChangesMade}
+                                    startIcon={<NotInterestedIcon />}
+                                >
+                                    Cancel
+                                </Button>
+                            </Stack>
+                        </Stack>
+
+                        <Stack spacing={2}>
+                            <NotificationSettingsEditor
+                                notificationSettings={notificationSettings}
+                                setNotificationSettings={setNotificationSettings}
+                            />
+                            <Stack direction='row' spacing={2} justifyContent='flex-end'>
+                                <Button
+                                    variant='contained'
+                                    onClick={onSaveNotifications}
+                                    disabled={!notificationsChangesMade}
+                                    loading={request.status === RequestStatus.Loading}
+                                    startIcon={<SaveIcon />}
+                                >
+                                    Save
+                                </Button>
+
+                                <Button
+                                    variant='contained'
+                                    color='error'
+                                    disableElevation
+                                    onClick={onCancelNotifications}
+                                    disabled={!notificationsChangesMade}
+                                    startIcon={<NotInterestedIcon />}
+                                >
+                                    Cancel
+                                </Button>
+                            </Stack>
+                        </Stack>
 
                         <SubscriptionManager user={user} />
                     </Stack>
                 </Grid>
             </Grid>
+
+            <Dialog open={navGuard.active} onClose={navGuard.reject}>
+                <DialogTitle>Unsaved Changes</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        You have unsaved changes in your settings. If you leave now, your changes
+                        will be lost. Are you sure you want to leave?
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={navGuard.reject}>Stay on Page</Button>
+                    <Button color='error' onClick={navGuard.accept}>
+                        Leave Without Saving
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </Container>
     );
 }


### PR DESCRIPTION
## Summary

refactored the settings page to use per-section save/cancel buttons. also added a navigation guard like the one on the game analysis board.

split the global update state into three isolated trackers for personal, ratings, and notifications. each section now has its own save/cancel buttons that only activate when something in that specific section changes. buttons are faded and non-clickable by default and light up when a change is detected.

upgraded getUpdate to deep compare objects with JSON.stringify since reference checks on ratings and notificationSettings were causing false positives and keeping buttons permanently lit. added a bypassGuard flag so saving and redirecting to /profile doesn't accidentally trip the nav guard before state clears. also fixed some default state mismatches like bio vs bio || '' so cancel properly zeroes out the form and re-disables the buttons.

## Related Issues

Closes #2306 

## Demo

<img width="1601" height="871" alt="image" src="https://github.com/user-attachments/assets/42e394ec-8356-4dc2-a212-4722be9ab780" />

<img width="867" height="315" alt="Screenshot 2026-05-22 010043" src="https://github.com/user-attachments/assets/de674849-ea51-415d-aefe-8981affa5dc2" />
