### PR TITLE
feat(#2300): Improve design of rating systems editor

### DIFF
--- a/frontend/src/components/profile/edit/RatingsEditor.test.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.test.tsx
@@ -116,6 +116,20 @@ describe('RatingsEditor initial rendering', () => {
         expect(within(listbox).getByRole('option', { name: 'USCF' })).toBeInTheDocument();
         expect(within(listbox).queryByRole('option', { name: 'Lichess Classical' })).toBeNull();
     });
+
+    it('renders the preferred system first in the editor rows', () => {
+        renderRatingsEditor(
+            editors({
+                [RatingSystem.Chesscom]: { username: 'kaya' },
+                [RatingSystem.Custom]: { name: 'OTB' },
+            }),
+            RatingSystem.Custom,
+        );
+
+        expect(screen.getAllByRole('textbox')[0]).toBe(
+            screen.getByLabelText(/Custom 1 Rating Name/),
+        );
+    });
 });
 
 describe('RatingsEditor add menu', () => {

--- a/frontend/src/components/profile/edit/RatingsEditor.test.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.test.tsx
@@ -1,11 +1,15 @@
 import { RatingSystem } from '@/database/user';
-import { describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { RatingEditor } from './RatingsEditor';
 import {
+    RatingsEditor,
     getInitialVisibleRatingSystems,
     getRatingSystemLabel,
     hasEnteredRatingSystemData,
 } from './RatingsEditor';
+
+afterEach(cleanup);
 
 function editor(overrides: Partial<RatingEditor> = {}): RatingEditor {
     return {
@@ -59,5 +63,57 @@ describe('RatingsEditor visibility helpers', () => {
         expect(getRatingSystemLabel(RatingSystem.Custom)).toBe('Custom');
         expect(getRatingSystemLabel(RatingSystem.Custom2)).toBe('Custom (2)');
         expect(getRatingSystemLabel(RatingSystem.Custom3)).toBe('Custom (3)');
+    });
+});
+
+function renderRatingsEditor(
+    ratingEditors: Record<RatingSystem, RatingEditor>,
+    ratingSystem = RatingSystem.Chesscom,
+) {
+    return render(
+        <RatingsEditor
+            dojoCohort='1600-1700'
+            setDojoCohort={vi.fn()}
+            ratingSystem={ratingSystem}
+            setRatingSystem={vi.fn()}
+            ratingEditors={ratingEditors}
+            setRatingEditors={vi.fn()}
+            enableZenMode={false}
+            setEnableZenMode={vi.fn()}
+            errors={{}}
+        />,
+    );
+}
+
+describe('RatingsEditor initial rendering', () => {
+    it('renders configured systems and hides blank systems', () => {
+        renderRatingsEditor(
+            editors({
+                [RatingSystem.Chesscom]: { username: 'kaya' },
+                [RatingSystem.Uscf]: { username: '12345678', startRating: '1550' },
+            }),
+        );
+
+        expect(screen.getByLabelText(/Chess\.com Username/)).toBeInTheDocument();
+        expect(screen.getByLabelText(/USCF ID/)).toBeInTheDocument();
+        expect(screen.queryByLabelText(/Lichess Username/)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/FIDE ID/)).not.toBeInTheDocument();
+    });
+
+    it('limits preferred dropdown options to visible systems', () => {
+        renderRatingsEditor(
+            editors({
+                [RatingSystem.Chesscom]: { username: 'kaya' },
+                [RatingSystem.Uscf]: { username: '12345678' },
+            }),
+            RatingSystem.Chesscom,
+        );
+
+        fireEvent.mouseDown(screen.getByRole('combobox', { name: /Preferred Rating System/ }));
+        const listbox = screen.getByRole('listbox');
+
+        expect(within(listbox).getByRole('option', { name: 'Chess.com Rapid' })).toBeInTheDocument();
+        expect(within(listbox).getByRole('option', { name: 'USCF' })).toBeInTheDocument();
+        expect(within(listbox).queryByRole('option', { name: 'Lichess Classical' })).toBeNull();
     });
 });

--- a/frontend/src/components/profile/edit/RatingsEditor.test.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.test.tsx
@@ -33,9 +33,9 @@ function editors(
 
 describe('RatingsEditor visibility helpers', () => {
     it('treats standard systems with usernames as configured', () => {
-        expect(hasEnteredRatingSystemData(RatingSystem.Chesscom, editor({ username: 'kaya' }))).toBe(
-            true,
-        );
+        expect(
+            hasEnteredRatingSystemData(RatingSystem.Chesscom, editor({ username: 'kaya' })),
+        ).toBe(true);
         expect(hasEnteredRatingSystemData(RatingSystem.Lichess, editor())).toBe(false);
     });
 
@@ -112,7 +112,9 @@ describe('RatingsEditor initial rendering', () => {
         fireEvent.mouseDown(screen.getByRole('combobox', { name: /Preferred Rating System/ }));
         const listbox = screen.getByRole('listbox');
 
-        expect(within(listbox).getByRole('option', { name: 'Chess.com Rapid' })).toBeInTheDocument();
+        expect(
+            within(listbox).getByRole('option', { name: 'Chess.com Rapid' }),
+        ).toBeInTheDocument();
         expect(within(listbox).getByRole('option', { name: 'USCF' })).toBeInTheDocument();
         expect(within(listbox).queryByRole('option', { name: 'Lichess Classical' })).toBeNull();
     });

--- a/frontend/src/components/profile/edit/RatingsEditor.test.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.test.tsx
@@ -117,3 +117,36 @@ describe('RatingsEditor initial rendering', () => {
         expect(within(listbox).queryByRole('option', { name: 'Lichess Classical' })).toBeNull();
     });
 });
+
+describe('RatingsEditor add menu', () => {
+    it('adds a hidden standard rating system to the editor', () => {
+        renderRatingsEditor(
+            editors({
+                [RatingSystem.Chesscom]: { username: 'kaya' },
+            }),
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add Rating System' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: /Lichess Classical/ }));
+
+        expect(screen.getByLabelText(/Lichess Username/)).toBeInTheDocument();
+    });
+
+    it('makes an added rating system available in the preferred dropdown', () => {
+        renderRatingsEditor(
+            editors({
+                [RatingSystem.Chesscom]: { username: 'kaya' },
+            }),
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add Rating System' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: /Lichess Classical/ }));
+        fireEvent.mouseDown(screen.getByRole('combobox', { name: /Preferred Rating System/ }));
+
+        expect(
+            within(screen.getByRole('listbox')).getByRole('option', {
+                name: 'Lichess Classical',
+            }),
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/profile/edit/RatingsEditor.test.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.test.tsx
@@ -1,0 +1,63 @@
+import { RatingSystem } from '@/database/user';
+import { describe, expect, it } from 'vitest';
+import type { RatingEditor } from './RatingsEditor';
+import {
+    getInitialVisibleRatingSystems,
+    getRatingSystemLabel,
+    hasEnteredRatingSystemData,
+} from './RatingsEditor';
+
+function editor(overrides: Partial<RatingEditor> = {}): RatingEditor {
+    return {
+        username: '',
+        hideUsername: false,
+        startRating: '0',
+        currentRating: '0',
+        name: '',
+        ...overrides,
+    };
+}
+
+function editors(
+    overrides: Partial<Record<RatingSystem, Partial<RatingEditor>>> = {},
+): Record<RatingSystem, RatingEditor> {
+    return Object.values(RatingSystem).reduce<Record<string, RatingEditor>>((result, system) => {
+        result[system] = editor(overrides[system]);
+        return result;
+    }, {}) as Record<RatingSystem, RatingEditor>;
+}
+
+describe('RatingsEditor visibility helpers', () => {
+    it('treats standard systems with usernames as configured', () => {
+        expect(hasEnteredRatingSystemData(RatingSystem.Chesscom, editor({ username: 'kaya' }))).toBe(
+            true,
+        );
+        expect(hasEnteredRatingSystemData(RatingSystem.Lichess, editor())).toBe(false);
+    });
+
+    it('treats custom systems with names or ratings as configured', () => {
+        expect(hasEnteredRatingSystemData(RatingSystem.Custom, editor({ name: 'OTB' }))).toBe(true);
+        expect(
+            hasEnteredRatingSystemData(RatingSystem.Custom2, editor({ currentRating: '1400' })),
+        ).toBe(true);
+        expect(hasEnteredRatingSystemData(RatingSystem.Custom3, editor())).toBe(false);
+    });
+
+    it('always includes the preferred system first', () => {
+        const result = getInitialVisibleRatingSystems(
+            editors({
+                [RatingSystem.Chesscom]: { username: 'kaya' },
+                [RatingSystem.Uscf]: { username: '12345678' },
+            }),
+            RatingSystem.Uscf,
+        );
+
+        expect(result).toEqual([RatingSystem.Uscf, RatingSystem.Chesscom]);
+    });
+
+    it('disambiguates repeated custom rating labels', () => {
+        expect(getRatingSystemLabel(RatingSystem.Custom)).toBe('Custom');
+        expect(getRatingSystemLabel(RatingSystem.Custom2)).toBe('Custom (2)');
+        expect(getRatingSystemLabel(RatingSystem.Custom3)).toBe('Custom (3)');
+    });
+});

--- a/frontend/src/components/profile/edit/RatingsEditor.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.tsx
@@ -11,6 +11,7 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
+import { useMemo, useState } from 'react';
 
 export interface RatingEditor {
     username: string;
@@ -158,6 +159,20 @@ export function RatingsEditor({
     setEnableZenMode,
     errors,
 }: RatingsEditorProps) {
+    const [visibleRatingSystems] = useState<RatingSystem[]>(() =>
+        getInitialVisibleRatingSystems(ratingEditors, ratingSystem),
+    );
+
+    const visibleRatingSystemSet = useMemo(
+        () => new Set(visibleRatingSystems),
+        [visibleRatingSystems],
+    );
+
+    const preferredRatingSystems = useMemo(() => {
+        const systems = Array.from(new Set([ratingSystem, ...visibleRatingSystems]));
+        return orderRatingSystems(systems, ratingSystem);
+    }, [ratingSystem, visibleRatingSystems]);
+
     const setUsername = (ratingSystem: RatingSystem, username: string) => {
         setRatingEditors({
             ...ratingEditors,
@@ -208,7 +223,9 @@ export function RatingsEditor({
         });
     };
 
-    const ratingSystems = RATING_SYSTEM_FORMS.map((rsf) => ({
+    const ratingSystems = RATING_SYSTEM_FORMS.filter((rsf) =>
+        visibleRatingSystemSet.has(rsf.system),
+    ).map((rsf) => ({
         required: ratingSystem === rsf.system,
         label: rsf.label,
         hideLabel: rsf.hideLabel,
@@ -221,6 +238,10 @@ export function RatingsEditor({
         usernameError: errors[`${rsf.system}Username`],
         startRatingError: errors[`${rsf.system}StartRating`],
     }));
+
+    const customRatingSystems = CUSTOM_RATING_SYSTEMS.filter((system) =>
+        visibleRatingSystemSet.has(system),
+    );
 
     return (
         <Stack spacing={4}>
@@ -267,11 +288,9 @@ export function RatingsEditor({
                 error={!!errors.ratingSystem}
                 helperText={errors.ratingSystem}
             >
-                {Object.values(RatingSystem).map((option) => (
+                {preferredRatingSystems.map((option) => (
                     <MenuItem key={option} value={option}>
-                        {formatRatingSystem(option)}
-                        {option === RatingSystem.Custom2 && ' (2)'}
-                        {option === RatingSystem.Custom3 && ' (3)'}
+                        {getRatingSystemLabel(option)}
                     </MenuItem>
                 ))}
             </TextField>
@@ -328,49 +347,53 @@ export function RatingsEditor({
                 </Grid>
             ))}
 
-            {CUSTOM_RATING_SYSTEMS.map((rs, idx) => (
-                <Grid key={rs} container columnGap={2} alignItems='start'>
-                    <Grid size='grow'>
-                        <TextField
-                            label={`Custom ${idx + 1} Rating Name`}
-                            value={ratingEditors[rs].name}
-                            onChange={(event) => setRatingName(rs, event.target.value)}
-                            sx={{ width: 1 }}
-                            error={!!errors[`${rs}Name`]}
-                            helperText={errors[`${rs}Name`] || 'Manually track your rating'}
-                        />
-                    </Grid>
+            {customRatingSystems.map((rs) => {
+                const idx = CUSTOM_RATING_SYSTEMS.indexOf(rs);
 
-                    <Grid size='grow'>
-                        <TextField
-                            required={ratingSystem === rs}
-                            label='Current Rating'
-                            value={ratingEditors[rs].currentRating}
-                            onChange={(event) => setCurrentRating(rs, event.target.value)}
-                            error={!!errors[`${rs}CurrentRating`]}
-                            helperText={
-                                errors[`${rs}CurrentRating`] || 'Your most up to date rating'
-                            }
-                            sx={{ width: 1 }}
-                        />
-                    </Grid>
+                return (
+                    <Grid key={rs} container columnGap={2} alignItems='start'>
+                        <Grid size='grow'>
+                            <TextField
+                                label={`Custom ${idx + 1} Rating Name`}
+                                value={ratingEditors[rs].name}
+                                onChange={(event) => setRatingName(rs, event.target.value)}
+                                sx={{ width: 1 }}
+                                error={!!errors[`${rs}Name`]}
+                                helperText={errors[`${rs}Name`] || 'Manually track your rating'}
+                            />
+                        </Grid>
 
-                    <Grid size='grow'>
-                        <TextField
-                            required={ratingSystem === rs}
-                            label='Start Rating'
-                            value={ratingEditors[rs].startRating}
-                            onChange={(event) => setStartRating(rs, event.target.value)}
-                            error={!!errors[`${rs}StartRating`]}
-                            helperText={
-                                errors[`${rs}StartRating`] ||
-                                'Your rating when you first joined the Dojo'
-                            }
-                            sx={{ width: 1 }}
-                        />
+                        <Grid size='grow'>
+                            <TextField
+                                required={ratingSystem === rs}
+                                label='Current Rating'
+                                value={ratingEditors[rs].currentRating}
+                                onChange={(event) => setCurrentRating(rs, event.target.value)}
+                                error={!!errors[`${rs}CurrentRating`]}
+                                helperText={
+                                    errors[`${rs}CurrentRating`] || 'Your most up to date rating'
+                                }
+                                sx={{ width: 1 }}
+                            />
+                        </Grid>
+
+                        <Grid size='grow'>
+                            <TextField
+                                required={ratingSystem === rs}
+                                label='Start Rating'
+                                value={ratingEditors[rs].startRating}
+                                onChange={(event) => setStartRating(rs, event.target.value)}
+                                error={!!errors[`${rs}StartRating`]}
+                                helperText={
+                                    errors[`${rs}StartRating`] ||
+                                    'Your rating when you first joined the Dojo'
+                                }
+                                sx={{ width: 1 }}
+                            />
+                        </Grid>
                     </Grid>
-                </Grid>
-            ))}
+                );
+            })}
 
             <FormControlLabel
                 label='Enable Zen Mode (hide ratings when viewing your own profile)'

--- a/frontend/src/components/profile/edit/RatingsEditor.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.tsx
@@ -1,5 +1,5 @@
-import { dojoCohorts, formatRatingSystem, RatingSystem } from '@/database/user';
-import { Timeline } from '@mui/icons-material';
+import { dojoCohorts, formatRatingSystem, isCustom, RatingSystem } from '@/database/user';
+import Timeline from '@mui/icons-material/Timeline';
 import {
     Checkbox,
     Divider,
@@ -39,6 +39,112 @@ interface RatingsEditorProps {
     setEnableZenMode: (enabled: boolean) => void;
     /** The errors in the profile editor. */
     errors: Record<string, string>;
+}
+
+const CUSTOM_RATING_SYSTEMS = [RatingSystem.Custom, RatingSystem.Custom2, RatingSystem.Custom3];
+
+const RATING_SYSTEM_FORMS = [
+    {
+        system: RatingSystem.Chesscom,
+        label: 'Chess.com Username',
+        hideLabel: 'Hide Username',
+    },
+    {
+        system: RatingSystem.Lichess,
+        label: 'Lichess Username',
+        hideLabel: 'Hide Username',
+    },
+    {
+        system: RatingSystem.Fide,
+        label: 'FIDE ID',
+        hideLabel: 'Hide ID',
+    },
+    {
+        system: RatingSystem.Uscf,
+        label: 'USCF ID',
+        hideLabel: 'Hide ID',
+    },
+    {
+        system: RatingSystem.Ecf,
+        label: 'ECF Rating Code',
+        hideLabel: 'Hide Rating Code',
+    },
+    {
+        system: RatingSystem.Cfc,
+        label: 'CFC ID',
+        hideLabel: 'Hide ID',
+    },
+    {
+        system: RatingSystem.Dwz,
+        label: 'DWZ ID',
+        hideLabel: 'Hide ID',
+    },
+    {
+        system: RatingSystem.Acf,
+        label: 'ACF ID',
+        hideLabel: 'Hide ID',
+    },
+    {
+        system: RatingSystem.Knsb,
+        label: 'KNSB ID',
+        hideLabel: 'Hide ID',
+    },
+];
+
+const RATING_SYSTEM_ORDER = [
+    ...RATING_SYSTEM_FORMS.map((form) => form.system),
+    ...CUSTOM_RATING_SYSTEMS,
+];
+
+function hasNonDefaultRating(value: string): boolean {
+    const trimmed = value.trim();
+    return trimmed !== '' && trimmed !== '0';
+}
+
+export function hasEnteredRatingSystemData(system: RatingSystem, editor: RatingEditor): boolean {
+    if (isCustom(system)) {
+        return Boolean(
+            editor.name.trim() ||
+                hasNonDefaultRating(editor.currentRating) ||
+                hasNonDefaultRating(editor.startRating),
+        );
+    }
+
+    return Boolean(
+        editor.username.trim() || hasNonDefaultRating(editor.startRating) || editor.hideUsername,
+    );
+}
+
+export function getRatingSystemLabel(system: RatingSystem): string {
+    if (system === RatingSystem.Custom2) {
+        return `${formatRatingSystem(system)} (2)`;
+    }
+    if (system === RatingSystem.Custom3) {
+        return `${formatRatingSystem(system)} (3)`;
+    }
+    return formatRatingSystem(system);
+}
+
+function orderRatingSystems(systems: RatingSystem[], preferred: RatingSystem): RatingSystem[] {
+    return [...systems].sort((lhs, rhs) => {
+        if (lhs === preferred) {
+            return -1;
+        }
+        if (rhs === preferred) {
+            return 1;
+        }
+        return RATING_SYSTEM_ORDER.indexOf(lhs) - RATING_SYSTEM_ORDER.indexOf(rhs);
+    });
+}
+
+export function getInitialVisibleRatingSystems(
+    ratingEditors: Record<RatingSystem, RatingEditor>,
+    preferred: RatingSystem,
+): RatingSystem[] {
+    const systems = RATING_SYSTEM_ORDER.filter(
+        (system) => system === preferred || hasEnteredRatingSystemData(system, ratingEditors[system]),
+    );
+    return orderRatingSystems(systems, preferred);
 }
 
 export function RatingsEditor({
@@ -278,53 +384,3 @@ export function RatingsEditor({
         </Stack>
     );
 }
-
-const CUSTOM_RATING_SYSTEMS = [RatingSystem.Custom, RatingSystem.Custom2, RatingSystem.Custom3];
-
-const RATING_SYSTEM_FORMS = [
-    {
-        system: RatingSystem.Chesscom,
-        label: 'Chess.com Username',
-        hideLabel: 'Hide Username',
-    },
-    {
-        system: RatingSystem.Lichess,
-        label: 'Lichess Username',
-        hideLabel: 'Hide Username',
-    },
-    {
-        system: RatingSystem.Fide,
-        label: 'FIDE ID',
-        hideLabel: 'Hide ID',
-    },
-    {
-        system: RatingSystem.Uscf,
-        label: 'USCF ID',
-        hideLabel: 'Hide ID',
-    },
-    {
-        system: RatingSystem.Ecf,
-        label: 'ECF Rating Code',
-        hideLabel: 'Hide Rating Code',
-    },
-    {
-        system: RatingSystem.Cfc,
-        label: 'CFC ID',
-        hideLabel: 'Hide ID',
-    },
-    {
-        system: RatingSystem.Dwz,
-        label: 'DWZ ID',
-        hideLabel: 'Hide ID',
-    },
-    {
-        system: RatingSystem.Acf,
-        label: 'ACF ID',
-        hideLabel: 'Hide ID',
-    },
-    {
-        system: RatingSystem.Knsb,
-        label: 'KNSB ID',
-        hideLabel: 'Hide ID',
-    },
-];

--- a/frontend/src/components/profile/edit/RatingsEditor.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.tsx
@@ -98,6 +98,10 @@ const RATING_SYSTEM_FORMS = [
     },
 ];
 
+const RATING_SYSTEM_FORMS_BY_SYSTEM = new Map(
+    RATING_SYSTEM_FORMS.map((form) => [form.system, form]),
+);
+
 const RATING_SYSTEM_ORDER = [
     ...RATING_SYSTEM_FORMS.map((form) => form.system),
     ...CUSTOM_RATING_SYSTEMS,
@@ -242,26 +246,6 @@ export function RatingsEditor({
         });
     };
 
-    const ratingSystems = RATING_SYSTEM_FORMS.filter((rsf) =>
-        visibleRatingSystemSet.has(rsf.system),
-    ).map((rsf) => ({
-        required: ratingSystem === rsf.system,
-        label: rsf.label,
-        hideLabel: rsf.hideLabel,
-        username: ratingEditors[rsf.system].username,
-        setUsername: (value: string) => setUsername(rsf.system, value),
-        startRating: ratingEditors[rsf.system].startRating,
-        setStartRating: (value: string) => setStartRating(rsf.system, value),
-        hidden: ratingEditors[rsf.system].hideUsername,
-        setHidden: (value: boolean) => setHidden(rsf.system, value),
-        usernameError: errors[`${rsf.system}Username`],
-        startRatingError: errors[`${rsf.system}StartRating`],
-    }));
-
-    const customRatingSystems = CUSTOM_RATING_SYSTEMS.filter((system) =>
-        visibleRatingSystemSet.has(system),
-    );
-
     return (
         <Stack spacing={4}>
             <Stack
@@ -340,59 +324,70 @@ export function RatingsEditor({
                 </Stack>
             )}
 
-            {ratingSystems.map((rs) => (
-                <Grid key={rs.label} container columnGap={2} alignItems='start'>
-                    <Grid size='grow'>
-                        <TextField
-                            required={rs.required}
-                            label={rs.label}
-                            value={rs.username}
-                            onChange={(event) => rs.setUsername(event.target.value)}
-                            error={!!rs.usernameError}
-                            helperText={
-                                rs.usernameError || rs.label === 'DWZ ID' ? (
-                                    <>
-                                        Learn how to find your DWZ ID{' '}
-                                        <Link href='/help#How%20do%20I%20find%20my%20DWZ%20ID?'>
-                                            here
-                                        </Link>
-                                    </>
-                                ) : (
-                                    "Leave blank if you don't have an account"
-                                )
-                            }
-                            sx={{ width: 1 }}
-                        />
-                    </Grid>
+            {visibleRatingSystems.map((rs) => {
+                if (!isCustom(rs)) {
+                    const form = RATING_SYSTEM_FORMS_BY_SYSTEM.get(rs);
+                    if (!form) {
+                        return null;
+                    }
 
-                    <Grid size='grow'>
-                        <TextField
-                            label='Start Rating'
-                            value={rs.startRating}
-                            onChange={(event) => rs.setStartRating(event.target.value)}
-                            error={!!rs.startRatingError}
-                            helperText={
-                                rs.startRatingError || 'Your rating when you first joined the Dojo'
-                            }
-                            sx={{ width: 1 }}
-                        />
-                    </Grid>
+                    const usernameError = errors[`${rs}Username`];
+                    const startRatingError = errors[`${rs}StartRating`];
 
-                    <Grid size='grow'>
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={rs.hidden}
-                                    onChange={(event) => rs.setHidden(event.target.checked)}
+                    return (
+                        <Grid key={rs} container columnGap={2} alignItems='start'>
+                            <Grid size='grow'>
+                                <TextField
+                                    required={ratingSystem === rs}
+                                    label={form.label}
+                                    value={ratingEditors[rs].username}
+                                    onChange={(event) => setUsername(rs, event.target.value)}
+                                    error={!!usernameError}
+                                    helperText={
+                                        usernameError || form.label === 'DWZ ID' ? (
+                                            <>
+                                                Learn how to find your DWZ ID{' '}
+                                                <Link href='/help#How%20do%20I%20find%20my%20DWZ%20ID?'>
+                                                    here
+                                                </Link>
+                                            </>
+                                        ) : (
+                                            "Leave blank if you don't have an account"
+                                        )
+                                    }
+                                    sx={{ width: 1 }}
                                 />
-                            }
-                            label={rs.hideLabel}
-                        />
-                    </Grid>
-                </Grid>
-            ))}
+                            </Grid>
 
-            {customRatingSystems.map((rs) => {
+                            <Grid size='grow'>
+                                <TextField
+                                    label='Start Rating'
+                                    value={ratingEditors[rs].startRating}
+                                    onChange={(event) => setStartRating(rs, event.target.value)}
+                                    error={!!startRatingError}
+                                    helperText={
+                                        startRatingError ||
+                                        'Your rating when you first joined the Dojo'
+                                    }
+                                    sx={{ width: 1 }}
+                                />
+                            </Grid>
+
+                            <Grid size='grow'>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            checked={ratingEditors[rs].hideUsername}
+                                            onChange={(event) => setHidden(rs, event.target.checked)}
+                                        />
+                                    }
+                                    label={form.hideLabel}
+                                />
+                            </Grid>
+                        </Grid>
+                    );
+                }
+
                 const idx = CUSTOM_RATING_SYSTEMS.indexOf(rs);
 
                 return (

--- a/frontend/src/components/profile/edit/RatingsEditor.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.tsx
@@ -1,11 +1,17 @@
 import { dojoCohorts, formatRatingSystem, isCustom, RatingSystem } from '@/database/user';
+import { RatingSystemIcon } from '@/style/RatingSystemIcons';
+import AddIcon from '@mui/icons-material/Add';
 import Timeline from '@mui/icons-material/Timeline';
 import {
+    Button,
     Checkbox,
     Divider,
     FormControlLabel,
     Grid,
     Link,
+    ListItemIcon,
+    ListItemText,
+    Menu,
     MenuItem,
     Stack,
     TextField,
@@ -159,7 +165,7 @@ export function RatingsEditor({
     setEnableZenMode,
     errors,
 }: RatingsEditorProps) {
-    const [visibleRatingSystems] = useState<RatingSystem[]>(() =>
+    const [visibleRatingSystems, setVisibleRatingSystems] = useState<RatingSystem[]>(() =>
         getInitialVisibleRatingSystems(ratingEditors, ratingSystem),
     );
 
@@ -172,6 +178,19 @@ export function RatingsEditor({
         const systems = Array.from(new Set([ratingSystem, ...visibleRatingSystems]));
         return orderRatingSystems(systems, ratingSystem);
     }, [ratingSystem, visibleRatingSystems]);
+
+    const [addMenuAnchorEl, setAddMenuAnchorEl] = useState<null | HTMLElement>(null);
+    const addMenuOpen = Boolean(addMenuAnchorEl);
+
+    const availableRatingSystems = useMemo(
+        () => RATING_SYSTEM_ORDER.filter((system) => !visibleRatingSystemSet.has(system)),
+        [visibleRatingSystemSet],
+    );
+
+    const addRatingSystem = (system: RatingSystem) => {
+        setVisibleRatingSystems(orderRatingSystems([...visibleRatingSystems, system], ratingSystem));
+        setAddMenuAnchorEl(null);
+    };
 
     const setUsername = (ratingSystem: RatingSystem, username: string) => {
         setRatingEditors({
@@ -294,6 +313,32 @@ export function RatingsEditor({
                     </MenuItem>
                 ))}
             </TextField>
+
+            {availableRatingSystems.length > 0 && (
+                <Stack direction='row' justifyContent='flex-start'>
+                    <Button
+                        variant='outlined'
+                        startIcon={<AddIcon />}
+                        onClick={(event) => setAddMenuAnchorEl(event.currentTarget)}
+                    >
+                        Add Rating System
+                    </Button>
+                    <Menu
+                        anchorEl={addMenuAnchorEl}
+                        open={addMenuOpen}
+                        onClose={() => setAddMenuAnchorEl(null)}
+                    >
+                        {availableRatingSystems.map((system) => (
+                            <MenuItem key={system} onClick={() => addRatingSystem(system)}>
+                                <ListItemIcon>
+                                    <RatingSystemIcon system={system} size='small' />
+                                </ListItemIcon>
+                                <ListItemText primary={getRatingSystemLabel(system)} />
+                            </MenuItem>
+                        ))}
+                    </Menu>
+                </Stack>
+            )}
 
             {ratingSystems.map((rs) => (
                 <Grid key={rs.label} container columnGap={2} alignItems='start'>

--- a/frontend/src/components/profile/edit/RatingsEditor.tsx
+++ b/frontend/src/components/profile/edit/RatingsEditor.tsx
@@ -116,8 +116,8 @@ export function hasEnteredRatingSystemData(system: RatingSystem, editor: RatingE
     if (isCustom(system)) {
         return Boolean(
             editor.name.trim() ||
-                hasNonDefaultRating(editor.currentRating) ||
-                hasNonDefaultRating(editor.startRating),
+            hasNonDefaultRating(editor.currentRating) ||
+            hasNonDefaultRating(editor.startRating),
         );
     }
 
@@ -153,7 +153,8 @@ export function getInitialVisibleRatingSystems(
     preferred: RatingSystem,
 ): RatingSystem[] {
     const systems = RATING_SYSTEM_ORDER.filter(
-        (system) => system === preferred || hasEnteredRatingSystemData(system, ratingEditors[system]),
+        (system) =>
+            system === preferred || hasEnteredRatingSystemData(system, ratingEditors[system]),
     );
     return orderRatingSystems(systems, preferred);
 }
@@ -192,7 +193,9 @@ export function RatingsEditor({
     );
 
     const addRatingSystem = (system: RatingSystem) => {
-        setVisibleRatingSystems(orderRatingSystems([...visibleRatingSystems, system], ratingSystem));
+        setVisibleRatingSystems(
+            orderRatingSystems([...visibleRatingSystems, system], ratingSystem),
+        );
         setAddMenuAnchorEl(null);
     };
 
@@ -378,7 +381,9 @@ export function RatingsEditor({
                                     control={
                                         <Checkbox
                                             checked={ratingEditors[rs].hideUsername}
-                                            onChange={(event) => setHidden(rs, event.target.checked)}
+                                            onChange={(event) =>
+                                                setHidden(rs, event.target.checked)
+                                            }
                                         />
                                     }
                                     label={form.hideLabel}


### PR DESCRIPTION
## Summary

Adds a visibility-based rating systems editor for profile settings. Blank rating systems are hidden by default, configured or preferred systems remain visible, and users can add hidden rating systems from an “Add Rating System” menu.

Also limits the preferred rating dropdown to visible systems and ensures the preferred system is rendered first.

## Related Issues

Fixes #2300

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

## Demo

**New rating systems editor**
<img width="1690" height="739" alt="rating" src="https://github.com/user-attachments/assets/68e2c7e0-aff9-4c4d-b29f-57d4fcfede83" />

**Rating system dropdown menu**
<img width="1415" height="821" alt="Rating system dropdown" src="https://github.com/user-attachments/assets/99b57d25-5e37-4938-9f9b-385ddc006d9f" />
