### PR TITLE
fix(#2316): Show actual cohort in switch prompt

### DIFF
--- a/frontend/src/components/profile/SwitchCohortPrompt.test.tsx
+++ b/frontend/src/components/profile/SwitchCohortPrompt.test.tsx
@@ -19,11 +19,7 @@ vi.mock('@/api/Api', () => ({
 }));
 
 vi.mock('@/components/navigation/Link', () => ({
-    Link: ({
-        href,
-        children,
-        ...props
-    }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    Link: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
         <a href={href} {...props}>
             {children}
         </a>

--- a/frontend/src/components/profile/SwitchCohortPrompt.test.tsx
+++ b/frontend/src/components/profile/SwitchCohortPrompt.test.tsx
@@ -1,0 +1,95 @@
+import type React from 'react';
+
+import { RatingSystem, User } from '@/database/user';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SwitchCohortPrompt } from './SwitchCohortPrompt';
+
+const mocks = vi.hoisted(() => ({
+    user: undefined as User | undefined,
+    updateUser: vi.fn(),
+}));
+
+vi.mock('@/auth/Auth', () => ({
+    useAuth: () => ({ user: mocks.user }),
+}));
+
+vi.mock('@/api/Api', () => ({
+    useApi: () => ({ updateUser: mocks.updateUser }),
+}));
+
+vi.mock('@/components/navigation/Link', () => ({
+    Link: ({
+        href,
+        children,
+        ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+function makeUser(overrides: Partial<User> = {}): User {
+    return {
+        username: 'realraptor',
+        displayName: 'realraptor',
+        discordUsername: 'realraptor',
+        dojoCohort: '1300-1400',
+        bio: '',
+        ratingSystem: RatingSystem.Fide,
+        ratings: {
+            [RatingSystem.Fide]: {
+                username: '123456',
+                startRating: 1698,
+                currentRating: 1698,
+                hideUsername: false,
+            },
+        },
+        progress: {},
+        disableBookingNotifications: false,
+        disableCancellationNotifications: false,
+        isAdmin: false,
+        isCalendarAdmin: false,
+        isTournamentAdmin: false,
+        isBetaTester: false,
+        isCoach: false,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-05-23T00:00:00Z',
+        numberOfGraduations: 0,
+        previousCohort: '',
+        lastGraduatedAt: '',
+        enableLightMode: false,
+        enableZenMode: false,
+        timezoneOverride: '',
+        timeFormat: '24',
+        hasCreatedProfile: true,
+        followerCount: 0,
+        followingCount: 0,
+        referralSource: '',
+        totalDojoScore: 0,
+        subscriptionStatus: 'NOT_SUBSCRIBED',
+        exams: {},
+        weekStart: 1,
+        ...overrides,
+    } as User;
+}
+
+describe('SwitchCohortPrompt', () => {
+    beforeEach(() => {
+        mocks.user = undefined;
+        mocks.updateUser.mockReset();
+    });
+
+    afterEach(cleanup);
+
+    it('shows the stored current cohort as the source cohort in the 2026 switch prompt', async () => {
+        mocks.user = makeUser();
+
+        render(<SwitchCohortPrompt />);
+
+        expect(await screen.findByText('New Cohorts Released')).toBeInTheDocument();
+        expect(screen.getByText('1300-1400')).toBeInTheDocument();
+        expect(screen.queryByText('1400-1500')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/profile/SwitchCohortPrompt.tsx
+++ b/frontend/src/components/profile/SwitchCohortPrompt.tsx
@@ -37,13 +37,14 @@ export function SwitchCohortPrompt() {
     const [open, setOpen] = useState(false);
     const [forceClose, setForceClose] = useState(false);
 
-    const [oldCohort, newCohort] = getSuggestedCohorts(user);
+    const [oldSuggestedCohort, newCohort] = getSuggestedCohorts(user);
+    const currentCohort = user?.dojoCohort;
     const request = useRequest();
 
     const showSwitchCohorts =
-        oldCohort !== newCohort &&
+        oldSuggestedCohort !== newCohort &&
         user &&
-        user.dojoCohort !== newCohort &&
+        currentCohort !== newCohort &&
         user.cohortVersion !== CURRENT_COHORT_VERSION;
 
     useEffect(() => {
@@ -102,8 +103,8 @@ export function SwitchCohortPrompt() {
                     <DialogContentText>
                         The Dojo has recalculated the cohort ranges for all rating systems. As a
                         result, we strongly suggest changing your cohort from{' '}
-                        <strong>{oldCohort}</strong> to <strong>{newCohort}</strong>. This will
-                        place you with sparring partners more similar in strength and give you
+                        <strong>{currentCohort}</strong> to <strong>{newCohort}</strong>. This
+                        will place you with sparring partners more similar in strength and give you
                         training material better suited to your level.
                         <br />
                         You can find more information in the FAQs on our{' '}

--- a/frontend/src/components/profile/SwitchCohortPrompt.tsx
+++ b/frontend/src/components/profile/SwitchCohortPrompt.tsx
@@ -103,8 +103,8 @@ export function SwitchCohortPrompt() {
                     <DialogContentText>
                         The Dojo has recalculated the cohort ranges for all rating systems. As a
                         result, we strongly suggest changing your cohort from{' '}
-                        <strong>{currentCohort}</strong> to <strong>{newCohort}</strong>. This
-                        will place you with sparring partners more similar in strength and give you
+                        <strong>{currentCohort}</strong> to <strong>{newCohort}</strong>. This will
+                        place you with sparring partners more similar in strength and give you
                         training material better suited to your level.
                         <br />
                         You can find more information in the FAQs on our{' '}


### PR DESCRIPTION
## Summary

The cohort switch prompt was showing the old rating-table suggested cohort as the “from” cohort instead of the user’s actual current Dojo cohort. This fixes the prompt to display the stored current cohort.
## Related Issues

Fixes #2316

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

