### PR TITLE
feat(#2320): Add new Viewer Setting for Coordinate size

### DIFF
--- a/frontend/src/board/Board.tsx
+++ b/frontend/src/board/Board.tsx
@@ -9,13 +9,15 @@ import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { Resizable, ResizeCallbackData } from 'react-resizable';
 import { useLocalStorage } from 'usehooks-ts';
 import './board.css';
-import { getBoardSx, getPieceSx } from './boardThemes';
+import { getBoardSx, getCoordinateSx, getPieceSx } from './boardThemes';
 import { compareNags, getNagGlyph } from './pgn/Nag';
 import { useChess } from './pgn/PgnBoard';
 import ResizeHandle from './pgn/ResizeHandle';
 import {
     BoardStyle,
     BoardStyleKey,
+    CoordinateSize,
+    CoordinateSizeKey,
     CoordinateStyle,
     CoordinateStyleKey,
     PieceStyle,
@@ -266,6 +268,10 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
         CoordinateStyleKey,
         CoordinateStyle.RankFileOnly,
     );
+    const [coordinateSize] = useLocalStorage<CoordinateSize>(
+        CoordinateSizeKey,
+        CoordinateSize.Standard,
+    );
     const [showLegalMoves] = useLocalStorage(ShowLegalMovesKey, true);
     const [showGlyphs] = useLocalStorage(ShowGlyphsKey, false);
 
@@ -421,9 +427,10 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
     }, [board, chess, showGlyphs]);
 
     const pieceSx = getPieceSx(pieceStyle);
+    const coordinateSx = getCoordinateSx(coordinateSize);
 
     return (
-        <Box width={1} height={1} sx={{ ...pieceSx, ...getBoardSx(boardStyle) }}>
+        <Box width={1} height={1} sx={{ ...pieceSx, ...getBoardSx(boardStyle), ...coordinateSx }}>
             <div
                 data-testid='chessground-board'
                 ref={boardRef}

--- a/frontend/src/board/board.css
+++ b/frontend/src/board/board.css
@@ -2,6 +2,12 @@
 @import '../../node_modules/chessground/assets/chessground.brown.css';
 @import '../../node_modules/chessground/assets/chessground.cburnett.css';
 
+.cg-wrap coords {
+    font-size: var(--coordinate-font-size, 9px);
+    font-weight: var(--coordinate-font-weight, 600);
+    opacity: var(--coordinate-opacity, 0.8);
+}
+
 .cg-wrap coords.ranks {
     right: 0 !important;
     top: 1px !important;
@@ -20,7 +26,7 @@
 .cg-wrap coords.squares:nth-child(2n) coord:nth-child(2n + 1),
 .cg-wrap coords.squares:nth-child(2n + 1) coord:nth-child(2n) {
     color: var(--light-square-coord-color) !important;
-    font-weight: 600;
+    font-weight: var(--coordinate-font-weight, 600);
 }
 
 .cg-wrap coords.ranks coord:nth-child(2n),
@@ -30,7 +36,7 @@
 .cg-wrap coords.squares:nth-child(2n) coord:nth-child(2n),
 .cg-wrap coords.squares:nth-child(2n + 1) coord:nth-child(2n + 1) {
     color: var(--dark-square-coord-color) !important;
-    font-weight: 600;
+    font-weight: var(--coordinate-font-weight, 600);
 }
 
 .cg-wrap coords.files {

--- a/frontend/src/board/boardThemes.test.ts
+++ b/frontend/src/board/boardThemes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getCoordinateSx } from './boardThemes';
+import { CoordinateSize } from './pgn/boardTools/underboard/settings/viewerSettingsConstants';
+
+vi.mock('./pgn/boardTools/underboard/settings/ViewerSettings', () => ({
+    BoardStyle: {
+        Standard: 'STANDARD',
+        Moon: 'MOON',
+        Summer: 'SUMMER',
+        Wood: 'WOOD',
+        Walnut: 'WALNUT',
+        CherryBlossom: 'CHERRY_BLOSSOM',
+        Ocean: 'OCEAN',
+    },
+    PieceStyle: {
+        Standard: 'STANDARD',
+        Pixel: 'PIXEL',
+        Spatial: 'WOOD',
+        Celtic: 'CELTIC',
+        Fantasy: 'FANTASY',
+        Chessnut: 'CHERRY',
+        Cburnett: 'WALNUT',
+        ThreeD: 'THREE_D',
+        ThreeDRedBlue: 'THREE_D_RED_BLUE',
+        Disguised: 'DISGUISED',
+        Invisible: 'INVISIBLE',
+    },
+}));
+
+describe('getCoordinateSx', () => {
+    it('returns the default Chessground coordinate values for standard coordinates', () => {
+        expect(getCoordinateSx(CoordinateSize.Standard)).toEqual({
+            '--coordinate-font-size': '9px',
+            '--coordinate-font-weight': 600,
+            '--coordinate-opacity': 0.8,
+        });
+    });
+
+    it('returns more readable values for large coordinates', () => {
+        expect(getCoordinateSx(CoordinateSize.Large)).toEqual({
+            '--coordinate-font-size': '11px',
+            '--coordinate-font-weight': 800,
+            '--coordinate-opacity': 1,
+        });
+    });
+});

--- a/frontend/src/board/boardThemes.test.ts
+++ b/frontend/src/board/boardThemes.test.ts
@@ -40,7 +40,7 @@ describe('getCoordinateSx', () => {
 
     it('returns more readable values for large coordinates', () => {
         expect(getCoordinateSx(CoordinateSize.Large)).toEqual({
-            '--coordinate-font-size': '11px',
+            '--coordinate-font-size': '13px',
             '--coordinate-font-weight': 800,
             '--coordinate-opacity': 1,
         });

--- a/frontend/src/board/boardThemes.test.ts
+++ b/frontend/src/board/boardThemes.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { getCoordinateSx } from './boardThemes';
 import { CoordinateSize } from './pgn/boardTools/underboard/settings/viewerSettingsConstants';
@@ -42,5 +44,16 @@ describe('getCoordinateSx', () => {
             '--coordinate-font-weight': 800,
             '--coordinate-opacity': 1,
         });
+    });
+});
+
+describe('board coordinate stylesheet contract', () => {
+    it('uses coordinate CSS variables for size, weight, and opacity', () => {
+        const cssPath = path.resolve(process.cwd(), 'src/board/board.css');
+        const css = readFileSync(cssPath, 'utf8');
+
+        expect(css).toContain('font-size: var(--coordinate-font-size, 9px)');
+        expect(css).toContain('font-weight: var(--coordinate-font-weight, 600)');
+        expect(css).toContain('opacity: var(--coordinate-opacity, 0.8)');
     });
 });

--- a/frontend/src/board/boardThemes.ts
+++ b/frontend/src/board/boardThemes.ts
@@ -1,10 +1,17 @@
 import { grey } from '@mui/material/colors';
 import { BoardStyle, PieceStyle } from './pgn/boardTools/underboard/settings/ViewerSettings';
+import { CoordinateSize } from './pgn/boardTools/underboard/settings/viewerSettingsConstants';
 
 interface BoardSx {
     '--board-background': string;
     '--light-square-coord-color': string;
     '--dark-square-coord-color': string;
+}
+
+interface CoordinateSx {
+    '--coordinate-font-size': string;
+    '--coordinate-font-weight': number;
+    '--coordinate-opacity': number;
 }
 
 interface PieceSx {
@@ -71,6 +78,28 @@ export function getBoardSx(style: BoardStyle): BoardSx {
                 '--board-background': `url('/static/board/backgrounds/wood.jpg')`,
                 '--dark-square-coord-color': '#d9a55a',
                 '--light-square-coord-color': '#88471d',
+            };
+    }
+}
+
+/**
+ * Returns CSS vars for coordinate readability.
+ * Standard preserves Chessground's defaults. Large improves readability without
+ * making every-square coordinates too crowded on smaller boards.
+ */
+export function getCoordinateSx(size: CoordinateSize): CoordinateSx {
+    switch (size) {
+        case CoordinateSize.Standard:
+            return {
+                '--coordinate-font-size': '9px',
+                '--coordinate-font-weight': 600,
+                '--coordinate-opacity': 0.8,
+            };
+        case CoordinateSize.Large:
+            return {
+                '--coordinate-font-size': '11px',
+                '--coordinate-font-weight': 800,
+                '--coordinate-opacity': 1,
             };
     }
 }

--- a/frontend/src/board/boardThemes.ts
+++ b/frontend/src/board/boardThemes.ts
@@ -97,7 +97,7 @@ export function getCoordinateSx(size: CoordinateSize): CoordinateSx {
             };
         case CoordinateSize.Large:
             return {
-                '--coordinate-font-size': '11px',
+                '--coordinate-font-size': '13px',
                 '--coordinate-font-weight': 800,
                 '--coordinate-opacity': 1,
             };

--- a/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.test.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.test.tsx
@@ -1,10 +1,6 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import ViewerSettings, {
-    CoordinateSize,
-    CoordinateSizeKey,
-    ViewerSetting,
-} from './ViewerSettings';
+import ViewerSettings, { CoordinateSize, CoordinateSizeKey, ViewerSetting } from './ViewerSettings';
 
 vi.mock('./KeyboardShortcuts', () => ({
     default: () => null,

--- a/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.test.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ViewerSettings, {
+    CoordinateSize,
+    CoordinateSizeKey,
+    ViewerSetting,
+} from './ViewerSettings';
+
+vi.mock('./KeyboardShortcuts', () => ({
+    default: () => null,
+}));
+
+afterEach(() => {
+    cleanup();
+    localStorage.clear();
+});
+
+describe('ViewerSettings coordinate size', () => {
+    it('shows the coordinate size setting with the standard default', () => {
+        render(<ViewerSettings />);
+
+        expect(screen.getByRole('combobox', { name: 'Coordinate Size' })).toHaveTextContent(
+            'Standard',
+        );
+    });
+
+    it('persists the large coordinate size selection', async () => {
+        render(<ViewerSettings />);
+
+        fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Coordinate Size' }));
+        const listbox = await screen.findByRole('listbox');
+        fireEvent.click(within(listbox).getByRole('option', { name: 'Large' }));
+
+        expect(localStorage.getItem(CoordinateSizeKey)).toBe(JSON.stringify(CoordinateSize.Large));
+    });
+
+    it('can be hidden by enabledSettings', () => {
+        render(<ViewerSettings enabledSettings={{ [ViewerSetting.CoordinateStyle]: true }} />);
+
+        expect(screen.queryByRole('combobox', { name: 'Coordinate Size' })).not.toBeInTheDocument();
+    });
+
+    it('can be shown by enabledSettings', () => {
+        render(<ViewerSettings enabledSettings={{ [ViewerSetting.CoordinateSize]: true }} />);
+
+        expect(screen.getByRole('combobox', { name: 'Coordinate Size' })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 import { useLocalStorage } from 'usehooks-ts';
 import KeyboardShortcuts, { KeyboardShortcutsProps } from './KeyboardShortcuts';
+import { CoordinateSize, CoordinateSizeKey } from './viewerSettingsConstants';
 
 export { CoordinateSize, CoordinateSizeKey } from './viewerSettingsConstants';
 
@@ -99,6 +100,7 @@ export enum ViewerSetting {
     BoardStyle,
     PieceStyle,
     CoordinateStyle,
+    CoordinateSize,
     StartEndButtonBehavior,
     VariationBehavior,
     CapturedMaterialDisplay,
@@ -126,6 +128,10 @@ const ViewerSettings = ({
     const [coordinateStyle, setCoordinateStyle] = useLocalStorage<CoordinateStyle>(
         CoordinateStyleKey,
         CoordinateStyle.RankFileOnly,
+    );
+    const [coordinateSize, setCoordinateSize] = useLocalStorage<CoordinateSize>(
+        CoordinateSizeKey,
+        CoordinateSize.Standard,
     );
     const [goToEndBehavior, setGoToEndBehavior] = useLocalStorage<string>(
         GoToEndButtonBehaviorKey,
@@ -223,6 +229,18 @@ const ViewerSettings = ({
                     <MenuItem value={CoordinateStyle.None}>None</MenuItem>
                     <MenuItem value={CoordinateStyle.RankFileOnly}>Rank and File Only</MenuItem>
                     <MenuItem value={CoordinateStyle.AllSquares}>Every Square</MenuItem>
+                </TextField>
+            )}
+
+            {(!enabledSettings || enabledSettings[ViewerSetting.CoordinateSize]) && (
+                <TextField
+                    select
+                    label='Coordinate Size'
+                    value={coordinateSize}
+                    onChange={(e) => setCoordinateSize(e.target.value as CoordinateSize)}
+                >
+                    <MenuItem value={CoordinateSize.Standard}>Standard</MenuItem>
+                    <MenuItem value={CoordinateSize.Large}>Large</MenuItem>
                 </TextField>
             )}
 

--- a/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
@@ -15,6 +15,8 @@ import {
 import { useLocalStorage } from 'usehooks-ts';
 import KeyboardShortcuts, { KeyboardShortcutsProps } from './KeyboardShortcuts';
 
+export { CoordinateSize, CoordinateSizeKey } from './viewerSettingsConstants';
+
 export const BoardStyleKey = 'boardStyle';
 export const PieceStyleKey = 'pieceStyle';
 export const CoordinateStyleKey = 'coordinateStyle';

--- a/frontend/src/board/pgn/boardTools/underboard/settings/viewerSettingsConstants.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/viewerSettingsConstants.ts
@@ -1,0 +1,6 @@
+export const CoordinateSizeKey = 'coordinateSize';
+
+export enum CoordinateSize {
+    Standard = 'STANDARD',
+    Large = 'LARGE',
+}

--- a/frontend/src/components/puzzles/checkmate/PuzzleSettings.tsx
+++ b/frontend/src/components/puzzles/checkmate/PuzzleSettings.tsx
@@ -29,6 +29,7 @@ const viewerSettings = {
     [ViewerSetting.BoardStyle]: true,
     [ViewerSetting.PieceStyle]: true,
     [ViewerSetting.CoordinateStyle]: true,
+    [ViewerSetting.CoordinateSize]: true,
     [ViewerSetting.StartEndButtonBehavior]: true,
     [ViewerSetting.VariationBehavior]: true,
     [ViewerSetting.ShowLegalMoves]: true,


### PR DESCRIPTION
## Summary

Adds a new Viewer Settings option, `Coordinate Size`, so users can make board coordinates easier to read. The new `Large` option increases coordinate font size, weight, and opacity while preserving the existing `Coordinate Style` options.

## Related Issues

Fixes #2320

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

## Demo

**Coordinate Size set on Large**
<img width="1713" height="982" alt="image" src="https://github.com/user-attachments/assets/b31ed90b-6ad3-46e8-91b3-360e316361f0" />