### PR TITLE
fix(#2317): cap exam ratings at a minimum of 0

### DIFF
--- a/backend/pgnService/exam/regression.ts
+++ b/backend/pgnService/exam/regression.ts
@@ -5,12 +5,9 @@ import {
     DynamoDBClient,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import {
-    Exam,
-    isValidExamType,
-} from '@jackstenglein/chess-dojo-common/src/database/exam';
+import { Exam, isValidExamType } from '@jackstenglein/chess-dojo-common/src/database/exam';
 import { UserExamSummary } from '@jackstenglein/chess-dojo-common/src/database/user';
-import { getRegression } from '@jackstenglein/chess-dojo-common/src/exam/scores';
+import { getRegression, predictExamRating } from '@jackstenglein/chess-dojo-common/src/exam/scores';
 import { DynamoDBRecord, DynamoDBStreamHandler } from 'aws-lambda';
 
 const dynamo = new DynamoDBClient({ region: 'us-east-1' });
@@ -38,9 +35,7 @@ async function processRecord(record: DynamoDBRecord) {
         return;
     }
 
-    const exam = unmarshall(
-        record.dynamodb?.NewImage as Record<string, AttributeValue>,
-    ) as Exam;
+    const exam = unmarshall(record.dynamodb?.NewImage as Record<string, AttributeValue>) as Exam;
 
     if (!isValidExamType(exam.type)) {
         return;
@@ -62,7 +57,7 @@ async function processRecord(record: DynamoDBRecord) {
                 examType: exam.type,
                 cohortRange: exam.cohortRange,
                 createdAt: answer.createdAt,
-                rating: regression.predict(answer.score),
+                rating: predictExamRating(regression, answer.score),
             },
         });
     }

--- a/common/src/exam/scores.test.ts
+++ b/common/src/exam/scores.test.ts
@@ -1,0 +1,18 @@
+import { SimpleLinearRegression } from 'ml-regression-simple-linear';
+import { describe, expect, it } from 'vitest';
+import { predictExamRating } from './scores';
+
+describe('predictExamRating', () => {
+    it('returns raw regression predictions when they are positive', () => {
+        const regression = new SimpleLinearRegression([10, 20, 30], [1000, 1500, 2000]);
+
+        expect(predictExamRating(regression, 20)).toBe(1500);
+    });
+
+    it('caps negative regression predictions at 0', () => {
+        const regression = new SimpleLinearRegression([10, 20, 30], [1000, 1500, 2000]);
+
+        expect(regression.predict(-20)).toBeLessThan(0);
+        expect(predictExamRating(regression, -20)).toBe(0);
+    });
+});

--- a/common/src/exam/scores.ts
+++ b/common/src/exam/scores.ts
@@ -105,9 +105,7 @@ export function getSolutionScore(
                 move.userData = {
                     score: parseInt(scoreSearch[1]),
                 };
-                move.commentAfter = move.commentAfter
-                    ?.replace(scoreSearch[0], '')
-                    .trimStart();
+                move.commentAfter = move.commentAfter?.replace(scoreSearch[0], '').trimStart();
             } else {
                 move.userData = { score: 1 };
             }
@@ -118,9 +116,7 @@ export function getSolutionScore(
                     ...(move.userData as ExamMoveUserData),
                     isAlt: true,
                 };
-                move.commentAfter = move.commentAfter
-                    ?.replace(altSearch[0], '')
-                    .trimStart();
+                move.commentAfter = move.commentAfter?.replace(altSearch[0], '').trimStart();
             }
         }
 
@@ -257,4 +253,15 @@ export function getRegression(exam: Exam): SimpleLinearRegression | null {
         y.push(cohort);
     }
     return new SimpleLinearRegression(x, y);
+}
+
+/**
+ * Predicts an exam rating from a regression and clamps the result to the
+ * minimum allowed rating.
+ * @param regression The exam score-to-rating regression.
+ * @param score The user's score on the exam.
+ * @returns The predicted exam rating, never below 0.
+ */
+export function predictExamRating(regression: SimpleLinearRegression, score: number): number {
+    return Math.max(0, regression.predict(score));
 }

--- a/frontend/src/components/exams/ExamList.tsx
+++ b/frontend/src/components/exams/ExamList.tsx
@@ -9,7 +9,7 @@ import { useRouter } from '@/hooks/useRouter';
 import LoadingPage from '@/loading/LoadingPage';
 import UpsellDialog, { RestrictedAction } from '@/upsell/UpsellDialog';
 import { Exam, ExamType } from '@jackstenglein/chess-dojo-common/src/database/exam';
-import { getRegression } from '@jackstenglein/chess-dojo-common/src/exam/scores';
+import { getRegression, predictExamRating } from '@jackstenglein/chess-dojo-common/src/exam/scores';
 import { Check, Close, ExpandLess, ExpandMore, Help, Lock } from '@mui/icons-material';
 import {
     Alert,
@@ -55,12 +55,12 @@ function getExamInfo(e: Exam, username?: string, timezoneOverride?: string): Exa
     let userRating: number | undefined = undefined;
     if (regression) {
         const sum = Object.values(e.answers)
-            .map((a) => regression.predict(a.score))
+            .map((a) => predictExamRating(regression, a.score))
             .reduce((sum, rating) => sum + rating, 0);
         averageRating = Math.round((10 * sum) / Object.values(e.answers).length) / 10;
 
         if (answer) {
-            userRating = Math.round(10 * regression.predict(answer.score)) / 10;
+            userRating = Math.round(10 * predictExamRating(regression, answer.score)) / 10;
         }
     }
 

--- a/frontend/src/exams/view/ExamStatistics.tsx
+++ b/frontend/src/exams/view/ExamStatistics.tsx
@@ -2,7 +2,11 @@ import MultipleSelectChip from '@/components/ui/MultipleSelectChip';
 import { useLightMode } from '@/style/useLightMode';
 import { getCohortRangeInt } from '@jackstenglein/chess-dojo-common/src/database/cohort';
 import { Exam } from '@jackstenglein/chess-dojo-common/src/database/exam';
-import { getExamMaxScore, getRegression } from '@jackstenglein/chess-dojo-common/src/exam/scores';
+import {
+    getExamMaxScore,
+    getRegression,
+    predictExamRating,
+} from '@jackstenglein/chess-dojo-common/src/exam/scores';
 import { Speed } from '@mui/icons-material';
 import { CardContent, Stack, Typography } from '@mui/material';
 import {
@@ -111,7 +115,9 @@ const ExamStatistics: React.FC<ExamStatisticsProps> = ({ exam }) => {
                 id: 'best-fit',
                 type: 'line',
                 label: '',
-                data: Array.from(Array(totalScore + 1)).map((_, i) => regression.predict(i)),
+                data: Array.from(Array(totalScore + 1)).map((_, i) =>
+                    predictExamRating(regression, i),
+                ),
                 color: isLight ? '#000' : '#fff',
             },
             {
@@ -121,7 +127,7 @@ const ExamStatistics: React.FC<ExamStatisticsProps> = ({ exam }) => {
                 color: isLight ? '#000' : '#fff',
                 data: Array.from(Array(totalScore + 1)).map((_, i) => ({
                     x: i,
-                    y: Math.round(regression.predict(i)),
+                    y: Math.round(predictExamRating(regression, i)),
                     id: i,
                 })),
                 markerSize: 0,


### PR DESCRIPTION
## Summary

Very low exam scores could produce a negative rating (e.g. 8/38 showed `-1312.4`). Ratings are now capped at a minimum of 0 everywhere they're calculated or saved.

Note: this fixes new writes. Already-saved negative summaries are recomputed the next time their exam record is modified.

## Related Issues

Fixes #2317

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}
