### PR TITLE
fix(#2331): allow override users to open Stripe billing portal

### DIFF
--- a/backend/paymentService/subscription/manage/main.go
+++ b/backend/paymentService/subscription/manage/main.go
@@ -14,6 +14,7 @@ import (
 )
 
 var repository database.UserGetter = database.DynamoDB
+var getBillingPortalSession = payment.GetBillingPortalSession
 
 type SubscriptionManageRequest struct {
 	Tier     database.SubscriptionTier `json:"tier"`
@@ -38,8 +39,9 @@ func handler(ctx context.Context, event api.Request) (api.Response, error) {
 		return api.Failure(err), nil
 	}
 
-	if !isValidCustomerId(user.PaymentInfo.GetCustomerId()) {
-		return api.Failure(errors.New(400, fmt.Sprintf("Invalid request: user has invalid Stripe customer ID %q", user.PaymentInfo.GetCustomerId()), "")), nil
+	paymentInfo := billingPortalPaymentInfo(user.PaymentInfo)
+	if !isValidCustomerId(paymentInfo.GetCustomerId()) {
+		return api.Failure(errors.New(400, fmt.Sprintf("Invalid request: user has invalid Stripe customer ID %q", paymentInfo.GetCustomerId()), "")), nil
 	}
 
 	var request SubscriptionManageRequest
@@ -47,11 +49,11 @@ func handler(ctx context.Context, event api.Request) (api.Response, error) {
 		return api.Failure(errors.Wrap(400, "Failed to unmarshal request body", "", err)), nil
 	}
 
-	if request.Tier != "" && user.PaymentInfo.GetSubscriptionId() == "" {
+	if request.Tier != "" && paymentInfo.GetSubscriptionId() == "" {
 		return api.Failure(errors.New(400, "Invalid request: subscription tier specified but user has no subscription ID", "")), nil
 	}
 
-	session, err := payment.GetBillingPortalSession(user.PaymentInfo, request.Tier, request.Interval)
+	session, err := getBillingPortalSession(paymentInfo, request.Tier, request.Interval)
 	if err != nil {
 		return api.Failure(err), nil
 	}
@@ -59,6 +61,21 @@ func handler(ctx context.Context, event api.Request) (api.Response, error) {
 	return api.Success(SubscriptionManageResponse{Url: session.URL}), nil
 }
 
+func billingPortalPaymentInfo(paymentInfo *database.PaymentInfo) *database.PaymentInfo {
+	if paymentInfo == nil {
+		return nil
+	}
+
+	if paymentInfo.CustomerId == database.PaymentCustomerIdOverride && database.IsStripeCustomerID(paymentInfo.PreservedCustomerId) {
+		portalPaymentInfo := *paymentInfo
+		portalPaymentInfo.CustomerId = paymentInfo.PreservedCustomerId
+		portalPaymentInfo.SubscriptionId = paymentInfo.PreservedSubscriptionId
+		return &portalPaymentInfo
+	}
+
+	return paymentInfo
+}
+
 func isValidCustomerId(customerID string) bool {
-	return customerID != "" && customerID != "WIX" && customerID != "OVERRIDE"
+	return customerID != "" && customerID != "WIX" && customerID != database.PaymentCustomerIdOverride
 }

--- a/backend/paymentService/subscription/manage/main_test.go
+++ b/backend/paymentService/subscription/manage/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	stripe "github.com/stripe/stripe-go/v81"
+)
+
+type mockUserGetter struct {
+	user *database.User
+	err  error
+}
+
+func (m *mockUserGetter) GetUser(username string) (*database.User, error) {
+	return m.user, m.err
+}
+
+func manageEvent(body string) api.Request {
+	return api.Request{
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			RequestID: "test-request",
+			Authorizer: &events.APIGatewayV2HTTPRequestContextAuthorizerDescription{
+				JWT: &events.APIGatewayV2HTTPRequestContextAuthorizerJWTDescription{
+					Claims: map[string]string{
+						"cognito:username": "test-user",
+					},
+				},
+			},
+		},
+		Body: body,
+	}
+}
+
+func resetManageDependencies(t *testing.T) func() {
+	t.Helper()
+
+	originalRepository := repository
+	originalGetBillingPortalSession := getBillingPortalSession
+
+	return func() {
+		repository = originalRepository
+		getBillingPortalSession = originalGetBillingPortalSession
+	}
+}
+
+func TestHandlerAllowsOverrideWithPreservedStripeCustomer(t *testing.T) {
+	restore := resetManageDependencies(t)
+	defer restore()
+
+	repository = &mockUserGetter{
+		user: &database.User{
+			PaymentInfo: &database.PaymentInfo{
+				CustomerId:              database.PaymentCustomerIdOverride,
+				PreservedCustomerId:     "cus_preserved123",
+				PreservedSubscriptionId: "sub_preserved123",
+			},
+		},
+	}
+
+	var gotCustomerId string
+	var gotSubscriptionId string
+	getBillingPortalSession = func(paymentInfo *database.PaymentInfo, tier database.SubscriptionTier, interval string) (*stripe.BillingPortalSession, error) {
+		gotCustomerId = paymentInfo.GetCustomerId()
+		gotSubscriptionId = paymentInfo.GetSubscriptionId()
+		return &stripe.BillingPortalSession{URL: "https://billing.stripe.test/session"}, nil
+	}
+
+	resp, err := handler(context.Background(), manageEvent(`{}`))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, resp.Body)
+	}
+	if gotCustomerId != "cus_preserved123" {
+		t.Fatalf("customer id passed to Stripe = %q, want cus_preserved123", gotCustomerId)
+	}
+	if gotSubscriptionId != "sub_preserved123" {
+		t.Fatalf("subscription id passed to Stripe = %q, want sub_preserved123", gotSubscriptionId)
+	}
+
+	var body SubscriptionManageResponse
+	if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if body.Url != "https://billing.stripe.test/session" {
+		t.Fatalf("url = %q, want billing session URL", body.Url)
+	}
+}
+
+func TestHandlerRejectsOverrideWithoutPreservedStripeCustomer(t *testing.T) {
+	restore := resetManageDependencies(t)
+	defer restore()
+
+	repository = &mockUserGetter{
+		user: &database.User{
+			PaymentInfo: &database.PaymentInfo{
+				CustomerId: database.PaymentCustomerIdOverride,
+			},
+		},
+	}
+
+	calledStripe := false
+	getBillingPortalSession = func(paymentInfo *database.PaymentInfo, tier database.SubscriptionTier, interval string) (*stripe.BillingPortalSession, error) {
+		calledStripe = true
+		return &stripe.BillingPortalSession{URL: "https://billing.stripe.test/session"}, nil
+	}
+
+	resp, err := handler(context.Background(), manageEvent(`{}`))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, resp.Body)
+	}
+	if calledStripe {
+		t.Fatal("Stripe billing portal session should not be created for OVERRIDE without preserved customer")
+	}
+}


### PR DESCRIPTION
## Summary

Allows users with admin complimentary `OVERRIDE` access to open the Stripe billing portal when their original Stripe customer was preserved. The manage subscription endpoint now uses preserved Stripe billing info only for billing portal session creation, while continuing to reject override users without a valid preserved Stripe customer.

## Related Issues

Fixes #2331

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to backend Go handler tests covering the fixed billing portal behavior