### PR TITLE
fix(#2310): prevent duplicate game review signup notifications

### DIFF
--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -1160,6 +1160,33 @@ func (repo *dynamoRepository) createDefaultDirectories(user *User) error {
 
 // UpdateUser applies the specified update to the user with the provided username.
 func (repo *dynamoRepository) UpdateUser(username string, update *UserUpdate) (*User, error) {
+	return repo.updateUser(
+		username,
+		update,
+		expression.AttributeExists(expression.Name("username")),
+	)
+}
+
+// UpdateUserIfNotGameReview applies the specified update only if the user is not currently
+// an active Game & Profile Review subscriber.
+func (repo *dynamoRepository) UpdateUserIfNotGameReview(username string, update *UserUpdate) (*User, error) {
+	notSubscribed := expression.AttributeNotExists(expression.Name("subscriptionStatus")).
+		Or(expression.Name("subscriptionStatus").NotEqual(expression.Value(SubscriptionStatus_Subscribed)))
+	notGameReviewTier := expression.AttributeNotExists(expression.Name("subscriptionTier")).
+		Or(expression.Name("subscriptionTier").NotEqual(expression.Value(SubscriptionTier_GameReview)))
+
+	return repo.updateUser(
+		username,
+		update,
+		expression.AttributeExists(expression.Name("username")).And(notSubscribed.Or(notGameReviewTier)),
+	)
+}
+
+func (repo *dynamoRepository) updateUser(
+	username string,
+	update *UserUpdate,
+	condition expression.ConditionBuilder,
+) (*User, error) {
 	if username == "STATISTICS" {
 		return nil, errors.New(403, "Invalid request: cannot update username `STATISTICS`", "")
 	}
@@ -1179,7 +1206,7 @@ func (repo *dynamoRepository) UpdateUser(username string, update *UserUpdate) (*
 		builder = builder.Set(expression.Name(k), expression.Value(v))
 	}
 
-	expr, err := expression.NewBuilder().WithUpdate(builder).Build()
+	expr, err := expression.NewBuilder().WithUpdate(builder).WithCondition(condition).Build()
 	if err != nil {
 		return nil, errors.Wrap(500, "Temporary server error", "DynamoDB expression building error", err)
 	}
@@ -1193,7 +1220,7 @@ func (repo *dynamoRepository) UpdateUser(username string, update *UserUpdate) (*
 		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),
 		UpdateExpression:          expr.Update(),
-		ConditionExpression:       aws.String("attribute_exists(username)"),
+		ConditionExpression:       expr.Condition(),
 		TableName:                 aws.String(userTable),
 		ReturnValues:              aws.String("ALL_NEW"),
 	}

--- a/backend/paymentService/webhook/game_review_signup_test.go
+++ b/backend/paymentService/webhook/game_review_signup_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+)
+
+type gameReviewSignupRepo struct {
+	updateCalls              int
+	updateIfNotReviewCalls   int
+	updateIfNotGameReviewErr error
+}
+
+func (r *gameReviewSignupRepo) UpdateUser(username string, update *database.UserUpdate) (*database.User, error) {
+	r.updateCalls++
+	return &database.User{
+		Username:           username,
+		SubscriptionStatus: database.SubscriptionStatus(*update.SubscriptionStatus),
+		SubscriptionTier:   database.SubscriptionTier(*update.SubscriptionTier),
+	}, nil
+}
+
+func (r *gameReviewSignupRepo) UpdateUserIfNotGameReview(
+	username string,
+	update *database.UserUpdate,
+) (*database.User, error) {
+	r.updateIfNotReviewCalls++
+	if r.updateIfNotGameReviewErr != nil {
+		return nil, r.updateIfNotGameReviewErr
+	}
+	return &database.User{
+		Username:           username,
+		SubscriptionStatus: database.SubscriptionStatus(*update.SubscriptionStatus),
+		SubscriptionTier:   database.SubscriptionTier(*update.SubscriptionTier),
+	}, nil
+}
+
+func TestUpdateSubscriptionAndDetectGameReviewSignup(t *testing.T) {
+	subscribed := string(database.SubscriptionStatus_Subscribed)
+	gameReview := string(database.SubscriptionTier_GameReview)
+
+	repo := &gameReviewSignupRepo{}
+	update := &database.UserUpdate{
+		SubscriptionStatus: &subscribed,
+		SubscriptionTier:   &gameReview,
+	}
+
+	user, shouldNotify, err := updateSubscriptionAndDetectGameReviewSignup(repo, "dojo_user", update)
+	if err != nil {
+		t.Fatalf("updateSubscriptionAndDetectGameReviewSignup returned error: %v", err)
+	}
+	if !shouldNotify {
+		t.Fatal("updateSubscriptionAndDetectGameReviewSignup returned shouldNotify=false, want true")
+	}
+	if user.GetSubscriptionTier() != database.SubscriptionTier_GameReview {
+		t.Fatalf("updated user tier = %q, want %q", user.GetSubscriptionTier(), database.SubscriptionTier_GameReview)
+	}
+	if repo.updateIfNotReviewCalls != 1 {
+		t.Fatalf("UpdateUserIfNotGameReview called %d times, want 1", repo.updateIfNotReviewCalls)
+	}
+	if repo.updateCalls != 0 {
+		t.Fatalf("UpdateUser called %d times, want 0", repo.updateCalls)
+	}
+}
+
+func TestUpdateSubscriptionAndDetectGameReviewSignupSkipsDuplicateNotification(t *testing.T) {
+	subscribed := string(database.SubscriptionStatus_Subscribed)
+	gameReview := string(database.SubscriptionTier_GameReview)
+	conditionalErr := errors.Wrap(
+		500,
+		"Temporary server error",
+		"DynamoDB UpdateItem failure",
+		&dynamodb.ConditionalCheckFailedException{},
+	)
+
+	repo := &gameReviewSignupRepo{updateIfNotGameReviewErr: conditionalErr}
+	update := &database.UserUpdate{
+		SubscriptionStatus: &subscribed,
+		SubscriptionTier:   &gameReview,
+	}
+
+	_, shouldNotify, err := updateSubscriptionAndDetectGameReviewSignup(repo, "dojo_user", update)
+	if err != nil {
+		t.Fatalf("updateSubscriptionAndDetectGameReviewSignup returned error: %v", err)
+	}
+	if shouldNotify {
+		t.Fatal("updateSubscriptionAndDetectGameReviewSignup returned shouldNotify=true, want false")
+	}
+	if repo.updateIfNotReviewCalls != 1 {
+		t.Fatalf("UpdateUserIfNotGameReview called %d times, want 1", repo.updateIfNotReviewCalls)
+	}
+	if repo.updateCalls != 1 {
+		t.Fatalf("UpdateUser called %d times, want 1", repo.updateCalls)
+	}
+}
+
+func TestUpdateSubscriptionAndDetectGameReviewSignupUsesNormalUpdateForOtherTiers(t *testing.T) {
+	subscribed := string(database.SubscriptionStatus_Subscribed)
+	basic := string(database.SubscriptionTier_Basic)
+
+	repo := &gameReviewSignupRepo{}
+	update := &database.UserUpdate{
+		SubscriptionStatus: &subscribed,
+		SubscriptionTier:   &basic,
+	}
+
+	_, shouldNotify, err := updateSubscriptionAndDetectGameReviewSignup(repo, "dojo_user", update)
+	if err != nil {
+		t.Fatalf("updateSubscriptionAndDetectGameReviewSignup returned error: %v", err)
+	}
+	if shouldNotify {
+		t.Fatal("updateSubscriptionAndDetectGameReviewSignup returned shouldNotify=true, want false")
+	}
+	if repo.updateIfNotReviewCalls != 0 {
+		t.Fatalf("UpdateUserIfNotGameReview called %d times, want 0", repo.updateIfNotReviewCalls)
+	}
+	if repo.updateCalls != 1 {
+		t.Fatalf("UpdateUser called %d times, want 1", repo.updateCalls)
+	}
+}

--- a/backend/paymentService/webhook/main.go
+++ b/backend/paymentService/webhook/main.go
@@ -159,7 +159,11 @@ func handleSubscriptionPurchase(checkoutSession *stripe.CheckoutSession) api.Res
 		SubscriptionTier:   stripe.String(string(tier)),
 	}
 
-	user, err := repository.UpdateUser(checkoutSession.ClientReferenceID, &update)
+	user, shouldSendGameReviewSignup, err := updateSubscriptionAndDetectGameReviewSignup(
+		repository,
+		checkoutSession.ClientReferenceID,
+		&update,
+	)
 	if err != nil {
 		return api.Failure(err)
 	}
@@ -170,7 +174,7 @@ func handleSubscriptionPurchase(checkoutSession *stripe.CheckoutSession) api.Res
 	if err := database.SendSubscriptionCreatedEvent(user.Username); err != nil {
 		log.Errorf("Failed to send subscription created notification: %v", err)
 	}
-	if tier == database.SubscriptionTier_GameReview {
+	if shouldSendGameReviewSignup {
 		sendGameReviewSignupNotification(user.Username)
 	}
 
@@ -178,7 +182,38 @@ func handleSubscriptionPurchase(checkoutSession *stripe.CheckoutSession) api.Res
 	return api.Success(nil)
 }
 
-// Sends a notification of a Game Review subscription signup. If it fails, the error is logged.
+type gameReviewSignupSubscriptionUpdater interface {
+	UpdateUser(username string, update *database.UserUpdate) (*database.User, error)
+	UpdateUserIfNotGameReview(username string, update *database.UserUpdate) (*database.User, error)
+}
+
+func updateSubscriptionAndDetectGameReviewSignup(
+	repo gameReviewSignupSubscriptionUpdater,
+	username string,
+	update *database.UserUpdate,
+) (*database.User, bool, error) {
+	if update.SubscriptionTier == nil || database.SubscriptionTier(*update.SubscriptionTier) != database.SubscriptionTier_GameReview {
+		user, err := repo.UpdateUser(username, update)
+		return user, false, err
+	}
+
+	user, err := repo.UpdateUserIfNotGameReview(username, update)
+	if err == nil {
+		return user, true, nil
+	}
+	if !isConditionalCheckFailed(err) {
+		return nil, false, err
+	}
+
+	user, err = repo.UpdateUser(username, update)
+	return user, false, err
+}
+
+func isConditionalCheckFailed(err error) bool {
+	var conditionalErr *dynamodb.ConditionalCheckFailedException
+	return errors.As(err, &conditionalErr)
+}
+
 func sendGameReviewSignupNotification(username string) {
 	if err := database.SendGameReviewSignupEvent(username); err != nil {
 		log.Errorf("Failed to send game review signup notification: %v", err)
@@ -358,14 +393,18 @@ func handleSubscriptionUpdated(event *stripe.Event) api.Response {
 		SubscriptionTier:   stripe.String(string(tier)),
 	}
 
-	user, err := repository.UpdateUser(username, &update)
+	user, shouldSendGameReviewSignup, err := updateSubscriptionAndDetectGameReviewSignup(
+		repository,
+		username,
+		&update,
+	)
 	if err != nil {
 		return api.Failure(err)
 	}
 	if err := discord.SetCohortRole(user); err != nil {
 		log.Errorf("Failed to set Discord roles: %v", err)
 	}
-	if tier == database.SubscriptionTier_GameReview {
+	if shouldSendGameReviewSignup {
 		sendGameReviewSignupNotification(user.Username)
 	}
 


### PR DESCRIPTION
## Summary

Prevents duplicate Game & Profile Review signup notifications for users who are already subscribed. Stripe can send `customer.subscription.updated` for existing active subscriptions, so this PR restores a transition guard that only sends the Discord notification when a user was not already `SUBSCRIBED/GAME_REVIEW`.

## Related Issues

Fixes #2310

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to Go regression tests being added for the webhook guard.
