### PR TITLE
feat: allow users to delete moves from suggested variations

### DIFF
--- a/frontend/src/board/pgn/pgnText/MoveButton.tsx
+++ b/frontend/src/board/pgn/pgnText/MoveButton.tsx
@@ -29,6 +29,7 @@ import { useLocalStorage } from 'usehooks-ts';
 import { formatTime } from '../boardTools/underboard/clock/ClockUsage';
 import {
     isUnsavedVariation,
+    isVariationSuggestor,
     saveSuggestedVariation,
 } from '../boardTools/underboard/comments/suggestVariation';
 import { DeletePrompt, useDeletePrompt } from '../boardTools/underboard/DeletePrompt';
@@ -203,6 +204,7 @@ const MoveMenu = ({ anchor, move, onClose }: MoveMenuProps) => {
     const { user } = useAuth();
     const api = useApi();
     const saveVariationRequest = useRequest();
+    const canDeleteMove = config?.allowMoveDeletion || isVariationSuggestor(user?.username, move);
 
     if (!chess) {
         return null;
@@ -256,7 +258,6 @@ const MoveMenu = ({ anchor, move, onClose }: MoveMenuProps) => {
         <>
             <Menu anchorEl={anchor} open={Boolean(anchor)} onClose={onClose}>
                 <RequestSnackbar request={saveVariationRequest} />
-
                 <MenuList>
                     {config?.allowMoveDeletion && [
                         <MenuItem key='mainline' disabled={isInMainline} onClick={onMakeMainline}>
@@ -283,7 +284,9 @@ const MoveMenu = ({ anchor, move, onClose }: MoveMenuProps) => {
                             </ListItemIcon>
                             <ListItemText>Move variation up</ListItemText>
                         </MenuItem>,
+                    ]}
 
+                    {canDeleteMove && [
                         <MenuItem key='delete-from-here' onClick={() => onDelete(move, 'after')}>
                             <ListItemIcon>
                                 <Backspace sx={{ transform: 'rotateY(180deg)' }} />
@@ -301,7 +304,9 @@ const MoveMenu = ({ anchor, move, onClose }: MoveMenuProps) => {
                             </ListItemIcon>
                             <ListItemText>Delete before here</ListItemText>
                         </MenuItem>,
+                    ]}
 
+                    {config?.allowMoveDeletion && [
                         <MenuItem key='toggle-engine' onClick={onToggleEngineLine}>
                             <ListItemIcon>
                                 <StockfishIcon />


### PR DESCRIPTION
## Summary

exposes the delete move menu options for variations if the current user is the variation author. mainline deletion rules still apply (delete before is properly disabled for sidelines).

## Related Issues

Related to #2332 (task5)

## Demo
<img width="598" height="808" alt="image" src="https://github.com/user-attachments/assets/0b2d08c7-a23f-41a7-8ca1-6d02986d1fc6" />
