### PR TITLE
feat(#2332): add save all variations button

### DIFF
--- a/frontend/src/board/pgn/boardTools/underboard/comments/Comments.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/Comments.tsx
@@ -16,6 +16,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
 import Comment from './Comment';
 import CommentEditor, { CommentEditorProps } from './CommentEditor';
+import { SaveAllVariationsButton } from './SaveAllVariationsButton';
 import { isSuggestedVariation } from './suggestVariation';
 
 const CommentViewKey = 'COMMENT_VIEW';
@@ -88,30 +89,34 @@ const Comments: React.FC<CommentsProps> = ({ focusEditor, setFocusEditor, isRead
         <CardContent sx={{ height: 1, p: 0 }}>
             <Stack height={1}>
                 <Stack flexGrow={1} sx={{ overflowY: 'auto', p: 2 }}>
-                    <Stack direction='row' spacing={1}>
-                        <TextField
-                            label='Show Comments From'
-                            select
-                            value={view}
-                            onChange={(e) => setView(e.target.value as View)}
-                            fullWidth
-                            size='small'
-                        >
-                            <MenuItem value={View.FullGame}>Entire Game</MenuItem>
-                            <MenuItem value={View.CurrentMove}>Current Position Only</MenuItem>
-                        </TextField>
+                    <Stack spacing={2}>
+                        <SaveAllVariationsButton />
 
-                        <TextField
-                            label='Sort By'
-                            select
-                            value={sortBy}
-                            onChange={(e) => setSortBy(e.target.value as SortBy)}
-                            fullWidth
-                            size='small'
-                        >
-                            <MenuItem value={SortBy.Newest}>Newest First</MenuItem>
-                            <MenuItem value={SortBy.Oldest}>Oldest First</MenuItem>
-                        </TextField>
+                        <Stack direction='row' spacing={1}>
+                            <TextField
+                                label='Show Comments From'
+                                select
+                                value={view}
+                                onChange={(e) => setView(e.target.value as View)}
+                                fullWidth
+                                size='small'
+                            >
+                                <MenuItem value={View.FullGame}>Entire Game</MenuItem>
+                                <MenuItem value={View.CurrentMove}>Current Position Only</MenuItem>
+                            </TextField>
+
+                            <TextField
+                                label='Sort By'
+                                select
+                                value={sortBy}
+                                onChange={(e) => setSortBy(e.target.value as SortBy)}
+                                fullWidth
+                                size='small'
+                            >
+                                <MenuItem value={SortBy.Newest}>Newest First</MenuItem>
+                                <MenuItem value={SortBy.Oldest}>Oldest First</MenuItem>
+                            </TextField>
+                        </Stack>
                     </Stack>
 
                     <Stack spacing={4} mt={3} flexGrow={1}>

--- a/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.test.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.test.tsx
@@ -78,7 +78,7 @@ describe('SaveAllVariationsButton', () => {
         expect(screen.getByRole('button', { name: 'Save All' })).toBeEnabled();
     });
 
-    it('saves all variations and updates the game', async () => {
+    it('saves all variations and updates the game without showing a success snackbar', async () => {
         const updatedGame = { ...game, positionComments: { updated: {} } } as unknown as Game;
         vi.mocked(getUnsavedSuggestedVariationRoots).mockReturnValue([{} as Move, {} as Move]);
         vi.mocked(saveAllSuggestedVariations).mockResolvedValue({
@@ -93,6 +93,6 @@ describe('SaveAllVariationsButton', () => {
             expect(saveAllSuggestedVariations).toHaveBeenCalledWith(user, game, api, chess);
         });
         expect(onUpdateGame).toHaveBeenCalledWith(updatedGame);
-        expect(await screen.findByText('Saved 2 variations as comments')).toBeInTheDocument();
+        expect(screen.queryByText('Saved 2 variations as comments')).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.test.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.test.tsx
@@ -1,0 +1,98 @@
+import { useApi } from '@/api/Api';
+import { useAuth } from '@/auth/Auth';
+import { useChess } from '@/board/pgn/PgnBoard';
+import useGame from '@/context/useGame';
+import { Game } from '@/database/game';
+import { User } from '@/database/user';
+import { Chess, Move } from '@jackstenglein/chess';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SaveAllVariationsButton } from './SaveAllVariationsButton';
+import { getUnsavedSuggestedVariationRoots, saveAllSuggestedVariations } from './suggestVariation';
+
+vi.mock('@/api/Api', () => ({ useApi: vi.fn() }));
+vi.mock('@/auth/Auth', () => ({ useAuth: vi.fn() }));
+vi.mock('@/board/pgn/PgnBoard', () => ({ useChess: vi.fn() }));
+vi.mock('@/context/useGame', () => ({ default: vi.fn() }));
+vi.mock('./suggestVariation', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./suggestVariation')>();
+    return {
+        ...actual,
+        getUnsavedSuggestedVariationRoots: vi.fn(),
+        saveAllSuggestedVariations: vi.fn(),
+    };
+});
+
+const user = {
+    username: 'dojo-user',
+    displayName: 'Dojo User',
+    dojoCohort: '1500-1600',
+    previousCohort: '1400-1500',
+} as User;
+
+const game = {
+    cohort: '1500-1600',
+    id: 'game-id',
+    pgn: '[Event "?"]\n\n1. e4 e5 *',
+    positionComments: {},
+} as Game;
+
+const chess = {
+    addObserver: vi.fn(),
+    removeObserver: vi.fn(),
+} as unknown as Chess;
+
+describe('SaveAllVariationsButton', () => {
+    const onUpdateGame = vi.fn();
+    const api = {};
+
+    beforeEach(() => {
+        vi.mocked(useAuth).mockReturnValue({ user } as ReturnType<typeof useAuth>);
+        vi.mocked(useApi).mockReturnValue(api as ReturnType<typeof useApi>);
+        vi.mocked(useChess).mockReturnValue({ chess } as ReturnType<typeof useChess>);
+        vi.mocked(useGame).mockReturnValue({
+            game,
+            onUpdateGame,
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('renders nothing when there are no unsaved variations', () => {
+        vi.mocked(getUnsavedSuggestedVariationRoots).mockReturnValue([]);
+
+        const { container } = render(<SaveAllVariationsButton />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders the unsaved variation count', () => {
+        vi.mocked(getUnsavedSuggestedVariationRoots).mockReturnValue([{} as Move, {} as Move]);
+
+        render(<SaveAllVariationsButton />);
+
+        expect(screen.getByText('2 unsaved variations')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Save All' })).toBeEnabled();
+    });
+
+    it('saves all variations and updates the game', async () => {
+        const updatedGame = { ...game, positionComments: { updated: {} } } as unknown as Game;
+        vi.mocked(getUnsavedSuggestedVariationRoots).mockReturnValue([{} as Move, {} as Move]);
+        vi.mocked(saveAllSuggestedVariations).mockResolvedValue({
+            game: updatedGame,
+            savedCount: 2,
+        });
+
+        render(<SaveAllVariationsButton />);
+        fireEvent.click(screen.getByRole('button', { name: 'Save All' }));
+
+        await waitFor(() => {
+            expect(saveAllSuggestedVariations).toHaveBeenCalledWith(user, game, api, chess);
+        });
+        expect(onUpdateGame).toHaveBeenCalledWith(updatedGame);
+        expect(await screen.findByText('Saved 2 variations as comments')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.tsx
@@ -1,0 +1,93 @@
+import { useApi } from '@/api/Api';
+import { RequestSnackbar, useRequest } from '@/api/Request';
+import { useAuth } from '@/auth/Auth';
+import { useChess } from '@/board/pgn/PgnBoard';
+import useGame from '@/context/useGame';
+import { EventType } from '@jackstenglein/chess';
+import Chat from '@mui/icons-material/Chat';
+import { Alert, Button, Typography } from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import { getUnsavedSuggestedVariationRoots, saveAllSuggestedVariations } from './suggestVariation';
+
+export function SaveAllVariationsButton() {
+    const { user } = useAuth();
+    const api = useApi();
+    const { chess } = useChess();
+    const { game, onUpdateGame } = useGame();
+    const request = useRequest<string>();
+    const [renderVersion, setRenderVersion] = useState(0);
+
+    useEffect(() => {
+        if (!chess) {
+            return;
+        }
+
+        const observer = {
+            types: [
+                EventType.NewVariation,
+                EventType.UpdateCommand,
+                EventType.DeleteMove,
+                EventType.DeleteBeforeMove,
+                EventType.PromoteVariation,
+            ],
+            handler: () => setRenderVersion((v) => v + 1),
+        };
+
+        chess.addObserver(observer);
+        return () => chess.removeObserver(observer);
+    }, [chess]);
+
+    const unsavedRoots = useMemo(
+        () => getUnsavedSuggestedVariationRoots(user, chess),
+        [user, chess, renderVersion],
+    );
+
+    if (!user || !game || !onUpdateGame || !chess || unsavedRoots.length === 0) {
+        return null;
+    }
+
+    const variationLabel =
+        unsavedRoots.length === 1
+            ? '1 unsaved variation'
+            : `${unsavedRoots.length} unsaved variations`;
+
+    const onClick = async () => {
+        request.onStart();
+        try {
+            const response = await saveAllSuggestedVariations(user, game, api, chess);
+            if (response.game) {
+                onUpdateGame(response.game);
+            }
+            const savedLabel =
+                response.savedCount === 1
+                    ? 'Saved 1 variation as a comment'
+                    : `Saved ${response.savedCount} variations as comments`;
+            request.onSuccess(savedLabel);
+        } catch (err) {
+            request.onFailure(err);
+        }
+    };
+
+    return (
+        <>
+            <Alert
+                severity='warning'
+                variant='outlined'
+                action={
+                    <Button
+                        loading={request.isLoading()}
+                        disabled={request.isLoading()}
+                        onClick={onClick}
+                        size='small'
+                        startIcon={<Chat />}
+                    >
+                        Save All
+                    </Button>
+                }
+            >
+                <Typography variant='body2'>{variationLabel}</Typography>
+            </Alert>
+            <RequestSnackbar request={request} showSuccess />
+        </>
+    );
+}

--- a/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/SaveAllVariationsButton.tsx
@@ -14,7 +14,7 @@ export function SaveAllVariationsButton() {
     const api = useApi();
     const { chess } = useChess();
     const { game, onUpdateGame } = useGame();
-    const request = useRequest<string>();
+    const request = useRequest();
     const [renderVersion, setRenderVersion] = useState(0);
 
     useEffect(() => {
@@ -58,11 +58,7 @@ export function SaveAllVariationsButton() {
             if (response.game) {
                 onUpdateGame(response.game);
             }
-            const savedLabel =
-                response.savedCount === 1
-                    ? 'Saved 1 variation as a comment'
-                    : `Saved ${response.savedCount} variations as comments`;
-            request.onSuccess(savedLabel);
+            request.onSuccess();
         } catch (err) {
             request.onFailure(err);
         }
@@ -87,7 +83,7 @@ export function SaveAllVariationsButton() {
             >
                 <Typography variant='body2'>{variationLabel}</Typography>
             </Alert>
-            <RequestSnackbar request={request} showSuccess />
+            <RequestSnackbar request={request} />
         </>
     );
 }

--- a/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.test.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.test.ts
@@ -1,5 +1,5 @@
 import { GameApiContextType } from '@/api/gameApi';
-import { Game } from '@/database/game';
+import { Game, GameResult } from '@/database/game';
 import { User } from '@/database/user';
 import { Chess, Move } from '@jackstenglein/chess';
 import { describe, expect, it, vi } from 'vitest';
@@ -25,7 +25,7 @@ function makeGame(overrides: Partial<Game> = {}): Game {
             Black: 'Black',
             Date: '2026.06.01',
             Site: 'ChessDojo',
-            Result: '*',
+            Result: GameResult.Incomplete,
         },
         createdAt: '2026-06-01T00:00:00Z',
         pgn: '[Event "?"]\n\n1. e4 e5 *',

--- a/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.test.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.test.ts
@@ -42,17 +42,23 @@ function markSaved(chess: Chess, move: Move, commentId: string) {
     chess.setCommand('dojoComment', `${user.username},${user.displayName},${commentId}`, move);
 }
 
+function requireMove(move: Move | null): Move {
+    expect(move).not.toBeNull();
+    if (!move) {
+        throw new Error('Expected move to be legal');
+    }
+    return move;
+}
+
 describe('getUnsavedSuggestedVariationRoots', () => {
     it('returns one root for a multi-move unsaved variation', () => {
         const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
         const e4 = chess.history()[0];
-        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
-        expect(c5).not.toBeNull();
-        markUnsaved(chess, c5!);
+        const c5 = requireMove(chess.move('c5', { previousMove: e4, skipSeek: true }));
+        markUnsaved(chess, c5);
 
-        const nf3 = chess.move('Nf3', { previousMove: c5, skipSeek: true });
-        expect(nf3).not.toBeNull();
-        markUnsaved(chess, nf3!);
+        const nf3 = requireMove(chess.move('Nf3', { previousMove: c5, skipSeek: true }));
+        markUnsaved(chess, nf3);
 
         const roots = getUnsavedSuggestedVariationRoots(user, chess);
 
@@ -65,13 +71,11 @@ describe('getUnsavedSuggestedVariationRoots', () => {
         const e4 = chess.history()[0];
         const e5 = chess.history()[1];
 
-        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
-        expect(c5).not.toBeNull();
-        markUnsaved(chess, c5!);
+        const c5 = requireMove(chess.move('c5', { previousMove: e4, skipSeek: true }));
+        markUnsaved(chess, c5);
 
-        const d4 = chess.move('d4', { previousMove: e5, skipSeek: true });
-        expect(d4).not.toBeNull();
-        markUnsaved(chess, d4!);
+        const d4 = requireMove(chess.move('d4', { previousMove: e5, skipSeek: true }));
+        markUnsaved(chess, d4);
 
         const roots = getUnsavedSuggestedVariationRoots(user, chess);
 
@@ -83,13 +87,11 @@ describe('getUnsavedSuggestedVariationRoots', () => {
     it('returns the saved comment root when an existing suggested variation has an unsaved extension', () => {
         const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
         const e4 = chess.history()[0];
-        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
-        expect(c5).not.toBeNull();
-        markSaved(chess, c5!, 'comment-1');
+        const c5 = requireMove(chess.move('c5', { previousMove: e4, skipSeek: true }));
+        markSaved(chess, c5, 'comment-1');
 
-        const nf3 = chess.move('Nf3', { previousMove: c5, skipSeek: true });
-        expect(nf3).not.toBeNull();
-        markUnsaved(chess, nf3!);
+        const nf3 = requireMove(chess.move('Nf3', { previousMove: c5, skipSeek: true }));
+        markUnsaved(chess, nf3);
 
         const roots = getUnsavedSuggestedVariationRoots(user, chess);
 
@@ -100,9 +102,8 @@ describe('getUnsavedSuggestedVariationRoots', () => {
     it('ignores unsaved variations from another user', () => {
         const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
         const e4 = chess.history()[0];
-        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
-        expect(c5).not.toBeNull();
-        chess.setCommand('dojoComment', 'other-user,Other User,unsaved', c5!);
+        const c5 = requireMove(chess.move('c5', { previousMove: e4, skipSeek: true }));
+        chess.setCommand('dojoComment', 'other-user,Other User,unsaved', c5);
 
         expect(getUnsavedSuggestedVariationRoots(user, chess)).toEqual([]);
     });
@@ -113,13 +114,11 @@ describe('saveAllSuggestedVariations', () => {
         const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
         const e4 = chess.history()[0];
 
-        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
-        expect(c5).not.toBeNull();
-        markUnsaved(chess, c5!);
+        const c5 = requireMove(chess.move('c5', { previousMove: e4, skipSeek: true }));
+        markUnsaved(chess, c5);
 
-        const e6 = chess.move('e6', { previousMove: e4, skipSeek: true });
-        expect(e6).not.toBeNull();
-        markUnsaved(chess, e6!);
+        const e6 = requireMove(chess.move('e6', { previousMove: e4, skipSeek: true }));
+        markUnsaved(chess, e6);
 
         const firstGame = makeGame();
         const secondGame = makeGame({
@@ -170,20 +169,18 @@ describe('saveAllSuggestedVariations', () => {
         expect(api.createComment).toHaveBeenCalledTimes(2);
         expect(result.savedCount).toBe(2);
         expect(result.game).toBe(finalGame);
-        expect(c5!.commentDiag?.dojoComment).toBe(`${user.username},${user.displayName},comment-1`);
-        expect(e6!.commentDiag?.dojoComment).toBe(`${user.username},${user.displayName},comment-2`);
+        expect(c5.commentDiag?.dojoComment).toBe(`${user.username},${user.displayName},comment-1`);
+        expect(e6.commentDiag?.dojoComment).toBe(`${user.username},${user.displayName},comment-2`);
     });
 
     it('updates an existing suggested variation when only the extension is unsaved', async () => {
         const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
         const e4 = chess.history()[0];
-        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
-        expect(c5).not.toBeNull();
-        markSaved(chess, c5!, 'comment-1');
+        const c5 = requireMove(chess.move('c5', { previousMove: e4, skipSeek: true }));
+        markSaved(chess, c5, 'comment-1');
 
-        const nf3 = chess.move('Nf3', { previousMove: c5, skipSeek: true });
-        expect(nf3).not.toBeNull();
-        markUnsaved(chess, nf3!);
+        const nf3 = requireMove(chess.move('Nf3', { previousMove: c5, skipSeek: true }));
+        markUnsaved(chess, nf3);
 
         const updatedGame = makeGame();
         const game = makeGame({
@@ -220,8 +217,6 @@ describe('saveAllSuggestedVariations', () => {
         expect(api.updateComment).toHaveBeenCalledTimes(1);
         expect(result.savedCount).toBe(1);
         expect(result.game).toBe(updatedGame);
-        expect(nf3!.commentDiag?.dojoComment).toBe(
-            `${user.username},${user.displayName},comment-1`,
-        );
+        expect(nf3.commentDiag?.dojoComment).toBe(`${user.username},${user.displayName},comment-1`);
     });
 });

--- a/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.test.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.test.ts
@@ -1,0 +1,227 @@
+import { GameApiContextType } from '@/api/gameApi';
+import { Game } from '@/database/game';
+import { User } from '@/database/user';
+import { Chess, Move } from '@jackstenglein/chess';
+import { describe, expect, it, vi } from 'vitest';
+import { getUnsavedSuggestedVariationRoots, saveAllSuggestedVariations } from './suggestVariation';
+
+const user = {
+    username: 'dojo-user',
+    displayName: 'Dojo User',
+    dojoCohort: '1500-1600',
+    previousCohort: '1400-1500',
+} as User;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+    return {
+        cohort: '1500-1600',
+        id: 'game-id',
+        date: '2026.06.01',
+        owner: 'game-owner',
+        ownerDisplayName: 'Game Owner',
+        ownerPreviousCohort: '1400-1500',
+        headers: {
+            White: 'White',
+            Black: 'Black',
+            Date: '2026.06.01',
+            Site: 'ChessDojo',
+            Result: '*',
+        },
+        createdAt: '2026-06-01T00:00:00Z',
+        pgn: '[Event "?"]\n\n1. e4 e5 *',
+        positionComments: {},
+        ...overrides,
+    };
+}
+
+function markUnsaved(chess: Chess, move: Move) {
+    chess.setCommand('dojoComment', `${user.username},${user.displayName},unsaved`, move);
+}
+
+function markSaved(chess: Chess, move: Move, commentId: string) {
+    chess.setCommand('dojoComment', `${user.username},${user.displayName},${commentId}`, move);
+}
+
+describe('getUnsavedSuggestedVariationRoots', () => {
+    it('returns one root for a multi-move unsaved variation', () => {
+        const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
+        const e4 = chess.history()[0];
+        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
+        expect(c5).not.toBeNull();
+        markUnsaved(chess, c5!);
+
+        const nf3 = chess.move('Nf3', { previousMove: c5, skipSeek: true });
+        expect(nf3).not.toBeNull();
+        markUnsaved(chess, nf3!);
+
+        const roots = getUnsavedSuggestedVariationRoots(user, chess);
+
+        expect(roots).toHaveLength(1);
+        expect(roots[0]).toBe(c5);
+    });
+
+    it('returns each independent unsaved variation root once', () => {
+        const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 2. Nf3 Nc6 *' });
+        const e4 = chess.history()[0];
+        const e5 = chess.history()[1];
+
+        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
+        expect(c5).not.toBeNull();
+        markUnsaved(chess, c5!);
+
+        const d4 = chess.move('d4', { previousMove: e5, skipSeek: true });
+        expect(d4).not.toBeNull();
+        markUnsaved(chess, d4!);
+
+        const roots = getUnsavedSuggestedVariationRoots(user, chess);
+
+        expect(roots).toHaveLength(2);
+        expect(roots).toContain(c5);
+        expect(roots).toContain(d4);
+    });
+
+    it('returns the saved comment root when an existing suggested variation has an unsaved extension', () => {
+        const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
+        const e4 = chess.history()[0];
+        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
+        expect(c5).not.toBeNull();
+        markSaved(chess, c5!, 'comment-1');
+
+        const nf3 = chess.move('Nf3', { previousMove: c5, skipSeek: true });
+        expect(nf3).not.toBeNull();
+        markUnsaved(chess, nf3!);
+
+        const roots = getUnsavedSuggestedVariationRoots(user, chess);
+
+        expect(roots).toHaveLength(1);
+        expect(roots[0]).toBe(c5);
+    });
+
+    it('ignores unsaved variations from another user', () => {
+        const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
+        const e4 = chess.history()[0];
+        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
+        expect(c5).not.toBeNull();
+        chess.setCommand('dojoComment', 'other-user,Other User,unsaved', c5!);
+
+        expect(getUnsavedSuggestedVariationRoots(user, chess)).toEqual([]);
+    });
+});
+
+describe('saveAllSuggestedVariations', () => {
+    it('creates one comment for each independent unsaved variation', async () => {
+        const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
+        const e4 = chess.history()[0];
+
+        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
+        expect(c5).not.toBeNull();
+        markUnsaved(chess, c5!);
+
+        const e6 = chess.move('e6', { previousMove: e4, skipSeek: true });
+        expect(e6).not.toBeNull();
+        markUnsaved(chess, e6!);
+
+        const firstGame = makeGame();
+        const secondGame = makeGame({
+            positionComments: {
+                [chess.normalizedFen(e4)]: {
+                    'comment-1': {
+                        id: 'comment-1',
+                        fen: chess.normalizedFen(e4),
+                        ply: e4.ply,
+                        san: e4.san,
+                        owner: {
+                            username: user.username,
+                            displayName: user.displayName,
+                            cohort: user.dojoCohort,
+                            previousCohort: user.previousCohort,
+                        },
+                        createdAt: '2026-06-01T00:00:00Z',
+                        updatedAt: '2026-06-01T00:00:00Z',
+                        content: '',
+                        parentIds: '',
+                        replies: {},
+                        suggestedVariation: '1... c5 *',
+                    },
+                },
+            },
+        });
+        const finalGame = makeGame();
+
+        const api = {
+            createComment: vi
+                .fn()
+                .mockResolvedValueOnce({
+                    data: {
+                        game: secondGame,
+                        comment: { id: 'comment-1' },
+                    },
+                })
+                .mockResolvedValueOnce({
+                    data: {
+                        game: finalGame,
+                        comment: { id: 'comment-2' },
+                    },
+                }),
+        } as unknown as GameApiContextType;
+
+        const result = await saveAllSuggestedVariations(user, firstGame, api, chess);
+
+        expect(api.createComment).toHaveBeenCalledTimes(2);
+        expect(result.savedCount).toBe(2);
+        expect(result.game).toBe(finalGame);
+        expect(c5!.commentDiag?.dojoComment).toBe(`${user.username},${user.displayName},comment-1`);
+        expect(e6!.commentDiag?.dojoComment).toBe(`${user.username},${user.displayName},comment-2`);
+    });
+
+    it('updates an existing suggested variation when only the extension is unsaved', async () => {
+        const chess = new Chess({ pgn: '[Event "?"]\n\n1. e4 e5 *' });
+        const e4 = chess.history()[0];
+        const c5 = chess.move('c5', { previousMove: e4, skipSeek: true });
+        expect(c5).not.toBeNull();
+        markSaved(chess, c5!, 'comment-1');
+
+        const nf3 = chess.move('Nf3', { previousMove: c5, skipSeek: true });
+        expect(nf3).not.toBeNull();
+        markUnsaved(chess, nf3!);
+
+        const updatedGame = makeGame();
+        const game = makeGame({
+            positionComments: {
+                [chess.normalizedFen(e4)]: {
+                    'comment-1': {
+                        id: 'comment-1',
+                        fen: chess.normalizedFen(e4),
+                        ply: e4.ply,
+                        san: e4.san,
+                        owner: {
+                            username: user.username,
+                            displayName: user.displayName,
+                            cohort: user.dojoCohort,
+                            previousCohort: user.previousCohort,
+                        },
+                        createdAt: '2026-06-01T00:00:00Z',
+                        updatedAt: '2026-06-01T00:00:00Z',
+                        content: '',
+                        parentIds: '',
+                        replies: {},
+                        suggestedVariation: '1... c5 *',
+                    },
+                },
+            },
+        });
+
+        const api = {
+            updateComment: vi.fn().mockResolvedValue({ data: updatedGame }),
+        } as unknown as GameApiContextType;
+
+        const result = await saveAllSuggestedVariations(user, game, api, chess);
+
+        expect(api.updateComment).toHaveBeenCalledTimes(1);
+        expect(result.savedCount).toBe(1);
+        expect(result.game).toBe(updatedGame);
+        expect(nf3!.commentDiag?.dojoComment).toBe(
+            `${user.username},${user.displayName},comment-1`,
+        );
+    });
+});

--- a/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/suggestVariation.ts
@@ -42,6 +42,67 @@ export function isVariationInComment(commentId: string, move: Move | null | unde
     return Boolean(move?.commentDiag?.dojoComment?.endsWith(commentId));
 }
 
+function isUserSuggestedVariation(
+    username: string | undefined,
+    move: Move | null | undefined,
+): boolean {
+    return Boolean(username && move?.commentDiag?.dojoComment?.startsWith(`${username},`));
+}
+
+function getSuggestedVariationRoot(user: User, move: Move): Move {
+    let root = move;
+    while (
+        root.previous &&
+        (isUnsavedVariation(root.previous) ||
+            isUserSuggestedVariation(user.username, root.previous))
+    ) {
+        root = root.previous;
+    }
+    return root;
+}
+
+/**
+ * Returns the unique root moves that need to be saved to persist the current user's
+ * unsaved suggested variations.
+ */
+export function getUnsavedSuggestedVariationRoots(
+    user: User | undefined,
+    chess: Chess | undefined,
+): Move[] {
+    if (!user || !chess) {
+        return [];
+    }
+
+    const roots: Move[] = [];
+    const seen = new Set<Move>();
+    const firstMove = chess.history()[0];
+    const stack = firstMove ? [firstMove] : [];
+
+    while (stack.length > 0) {
+        const move = stack.pop();
+        if (!move) {
+            continue;
+        }
+
+        if (isUnsavedVariation(move) && isUserSuggestedVariation(user.username, move)) {
+            const root = getSuggestedVariationRoot(user, move);
+            if (!seen.has(root)) {
+                roots.push(root);
+                seen.add(root);
+            }
+        }
+
+        if (move.next) {
+            stack.push(move.next);
+        }
+        for (let i = move.variations.length - 1; i >= 0; i--) {
+            stack.push(move.variations[i][0]);
+        }
+    }
+
+    return roots;
+}
+
 /**
  * Marks the dojoComment on all moves descended from the root as saved.
  * @param chess The chess instance containing the moves.
@@ -90,14 +151,7 @@ export async function saveSuggestedVariation(
         return;
     }
 
-    let root = move;
-    while (
-        root.previous &&
-        (isUnsavedVariation(root.previous) ||
-            root.previous.commentDiag?.dojoComment?.startsWith(user.username))
-    ) {
-        root = root.previous;
-    }
+    const root = getSuggestedVariationRoot(user, move);
 
     const suggestion = chess.renderFrom(root, {
         skipHeader: true,
@@ -154,4 +208,38 @@ export async function saveSuggestedVariation(
 
     markSuggestedVariationSaved(chess, root, comment.id);
     return { game: response.data };
+}
+
+export interface SaveAllSuggestedVariationsResult {
+    game?: Game;
+    savedCount: number;
+}
+
+/**
+ * Saves every unsaved suggested variation for the current user. Saves are performed
+ * sequentially so each request receives the latest returned game state.
+ */
+export async function saveAllSuggestedVariations(
+    user: User | undefined,
+    game: Game | undefined,
+    api: GameApiContextType,
+    chess: Chess | undefined,
+): Promise<SaveAllSuggestedVariationsResult> {
+    if (!user || !game || !chess) {
+        return { savedCount: 0 };
+    }
+
+    const roots = getUnsavedSuggestedVariationRoots(user, chess);
+    let latestGame = game;
+    let savedCount = 0;
+
+    for (const root of roots) {
+        const response = await saveSuggestedVariation(user, latestGame, api, chess, root);
+        if (response?.game) {
+            latestGame = response.game;
+            savedCount++;
+        }
+    }
+
+    return { game: latestGame, savedCount };
 }

--- a/frontend/src/board/pgn/pgnText/PgnText.tsx
+++ b/frontend/src/board/pgn/pgnText/PgnText.tsx
@@ -9,6 +9,7 @@ import { Resizable, ResizeCallbackData } from 'react-resizable';
 import { useLocalStorage } from 'usehooks-ts';
 import { useChess } from '../PgnBoard';
 import ResizeHandle from '../ResizeHandle';
+import { SaveAllVariationsButton } from '../boardTools/underboard/comments/SaveAllVariationsButton';
 import { HideEngine } from '../boardTools/underboard/settings/ViewerSettings';
 import { ResizableData } from '../resize';
 import GameComment from './GameComment';
@@ -41,6 +42,7 @@ const PgnText = () => {
         <Stack spacing={1} maxHeight={1}>
             {game && game.unlisted === true && isOwner && <UnpublishedGameBanner dismissable />}
             {unsaved && <UnsavedGameBanner dismissable />}
+            <SaveAllVariationsButton />
 
             <Card
                 data-testid='pgn-text'


### PR DESCRIPTION
## Summary

Adds a shared "Save All" button for the Game Analysis page so users can save all unsaved suggested variations as comments at once. The button appears above the PGN text and in the Comments tab when unsaved variations are present.

## Related Issues

Fixes item 3 of #2332

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

## Demo
<img width="2488" height="1096" alt="image" src="https://github.com/user-attachments/assets/5f5a17d3-8a69-404a-aefb-8de04fbccf9d" />