### PR TITLE
feat(#2332): Viewer setting for inline comments in PGN

### DIFF
--- a/frontend/src/board/pgn/boardTools/underboard/comments/Comment.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/Comment.tsx
@@ -145,6 +145,7 @@ const BaseComment: React.FC<BaseCommentProps> = ({
                                         lines={[suggestedVariation]}
                                         handleScroll={() => null}
                                         forceShowSuggestedVariations
+                                        showInlinePositionComments={false}
                                         slotProps={{
                                             moveButton: { hideSuggestedVariationOwner: true },
                                         }}

--- a/frontend/src/board/pgn/boardTools/underboard/comments/Comments.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/Comments.tsx
@@ -16,8 +16,11 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
 import Comment from './Comment';
 import CommentEditor, { CommentEditorProps } from './CommentEditor';
+import { getCommentsForFen, SortBy } from './positionComments';
 import { SaveAllVariationsButton } from './SaveAllVariationsButton';
 import { isSuggestedVariation } from './suggestVariation';
+
+export { SortBy } from './positionComments';
 
 const CommentViewKey = 'COMMENT_VIEW';
 const CommentSortByKey = 'COMMENT_SORT_BY';
@@ -25,11 +28,6 @@ const CommentSortByKey = 'COMMENT_SORT_BY';
 enum View {
     FullGame = 'FULL_GAME',
     CurrentMove = 'CURRENT_MOVE',
-}
-
-export enum SortBy {
-    Newest = 'NEWEST',
-    Oldest = 'OLDEST',
 }
 
 interface PositionCommentSortContextType {
@@ -192,31 +190,6 @@ function getFenSections(game: Game, chess: Chess, view: View, sort: SortBy) {
     }
 
     return fenSections;
-}
-
-function getCommentsForFen(
-    game: Game,
-    fen: string,
-    move: Move | null,
-    sort: SortBy,
-): PositionComment[] {
-    const fenComments = game.positionComments[fen] || {};
-    const selectedComments: PositionComment[] = [];
-
-    for (const comment of Object.values(fenComments)) {
-        if (comment.ply === (move?.ply || 0) && comment.san === move?.san) {
-            selectedComments.push(comment);
-        }
-    }
-
-    selectedComments.sort((lhs, rhs) => {
-        if (sort === SortBy.Newest) {
-            return rhs.createdAt.localeCompare(lhs.createdAt);
-        }
-        return lhs.createdAt.localeCompare(rhs.createdAt);
-    });
-
-    return selectedComments;
 }
 
 interface CommentSectionProps {

--- a/frontend/src/board/pgn/boardTools/underboard/comments/Replies.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/Replies.tsx
@@ -1,7 +1,8 @@
 import { PositionComment } from '@/database/game';
 import { Stack } from '@mui/material';
 import Comment from './Comment';
-import { SortBy, usePositionCommentSort } from './Comments';
+import { usePositionCommentSort } from './Comments';
+import { SortBy } from './positionComments';
 
 interface RepliesProps {
     comment: PositionComment;

--- a/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.test.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.test.ts
@@ -1,0 +1,141 @@
+import { Game, PositionComment } from '@/database/game';
+import { Chess } from '@jackstenglein/chess';
+import { describe, expect, it } from 'vitest';
+import { getCommentsForFen, getInlineCommentsForMove, SortBy } from './positionComments';
+
+function makeComment(overrides: Partial<PositionComment> = {}): PositionComment {
+    return {
+        id: 'comment-id',
+        fen: '',
+        ply: 1,
+        san: 'e4',
+        owner: {
+            username: 'commenter',
+            displayName: 'Commenter',
+            cohort: '1500-1600',
+            previousCohort: '1400-1500',
+        },
+        createdAt: '2026-06-01T10:00:00Z',
+        updatedAt: '2026-06-01T10:00:00Z',
+        content: 'Interesting move',
+        parentIds: '',
+        replies: {},
+        ...overrides,
+    };
+}
+
+function makeGame(comments: Record<string, Record<string, PositionComment>>): Game {
+    return {
+        cohort: '1500-1600',
+        id: 'game-id',
+        owner: 'owner',
+        ownerDisplayName: 'Owner',
+        headers: {},
+        createdAt: '2026-06-01T00:00:00Z',
+        updatedAt: '2026-06-01T00:00:00Z',
+        unlisted: false,
+        pgn: '1. e4 e5 2. Nf3',
+        positionComments: comments,
+    } as Game;
+}
+
+describe('position comment helpers', () => {
+    it('matches comments by FEN, ply, and SAN', () => {
+        const chess = new Chess({ pgn: '1. e4 e5 2. Nf3' });
+        const move = chess.history()[0];
+        const fen = chess.normalizedFen(move);
+        const matching = makeComment({ id: 'matching', fen, ply: move.ply, san: move.san });
+        const wrongSan = makeComment({ id: 'wrong-san', fen, ply: move.ply, san: 'd4' });
+        const wrongPly = makeComment({ id: 'wrong-ply', fen, ply: 3, san: move.san });
+        const game = makeGame({ [fen]: { matching, wrongSan, wrongPly } });
+
+        expect(getCommentsForFen(game, fen, move, SortBy.Oldest).map((c) => c.id)).toEqual([
+            'matching',
+        ]);
+    });
+
+    it('sorts matched comments newest or oldest first', () => {
+        const chess = new Chess({ pgn: '1. e4 e5 2. Nf3' });
+        const move = chess.history()[0];
+        const fen = chess.normalizedFen(move);
+        const older = makeComment({
+            id: 'older',
+            fen,
+            ply: move.ply,
+            san: move.san,
+            createdAt: '2026-06-01T10:00:00Z',
+        });
+        const newer = makeComment({
+            id: 'newer',
+            fen,
+            ply: move.ply,
+            san: move.san,
+            createdAt: '2026-06-01T11:00:00Z',
+        });
+        const game = makeGame({ [fen]: { older, newer } });
+
+        expect(getCommentsForFen(game, fen, move, SortBy.Newest).map((c) => c.id)).toEqual([
+            'newer',
+            'older',
+        ]);
+        expect(getCommentsForFen(game, fen, move, SortBy.Oldest).map((c) => c.id)).toEqual([
+            'older',
+            'newer',
+        ]);
+    });
+
+    it('returns only top-level non-empty content comments for inline PGN display', () => {
+        const chess = new Chess({ pgn: '1. e4 e5 2. Nf3' });
+        const move = chess.history()[0];
+        const fen = chess.normalizedFen(move);
+        const older = makeComment({
+            id: 'older',
+            fen,
+            ply: move.ply,
+            san: move.san,
+            content: 'First comment',
+            createdAt: '2026-06-01T10:00:00Z',
+        });
+        const newer = makeComment({
+            id: 'newer',
+            fen,
+            ply: move.ply,
+            san: move.san,
+            content: 'Second comment',
+            createdAt: '2026-06-01T11:00:00Z',
+        });
+        const reply = makeComment({
+            id: 'reply',
+            fen,
+            ply: move.ply,
+            san: move.san,
+            content: 'Reply text',
+            parentIds: 'older',
+        });
+        const suggestionOnly = makeComment({
+            id: 'suggestion-only',
+            fen,
+            ply: move.ply,
+            san: move.san,
+            content: '   ',
+            suggestedVariation: '1. d4',
+        });
+        const game = makeGame({ [fen]: { newer, reply, suggestionOnly, older } });
+
+        expect(getInlineCommentsForMove(game, chess, move).map((c) => c.id)).toEqual([
+            'older',
+            'newer',
+        ]);
+    });
+
+    it('returns an empty list without game or chess context', () => {
+        const chess = new Chess({ pgn: '1. e4' });
+        const move = chess.history()[0];
+
+        expect(getInlineCommentsForMove(undefined, chess, move)).toEqual([]);
+        expect(getInlineCommentsForMove({ positionComments: {} } as Game, undefined, move)).toEqual(
+            [],
+        );
+        expect(getInlineCommentsForMove({ positionComments: {} } as Game, chess, null)).toEqual([]);
+    });
+});

--- a/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.test.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.test.ts
@@ -1,7 +1,12 @@
 import { Game, PositionComment } from '@/database/game';
 import { Chess } from '@jackstenglein/chess';
 import { describe, expect, it } from 'vitest';
-import { getCommentsForFen, getInlineCommentsForMove, SortBy } from './positionComments';
+import {
+    getCommentsForFen,
+    getInlineCommentsForMove,
+    getInlineCommentsForStartingPosition,
+    SortBy,
+} from './positionComments';
 
 function makeComment(overrides: Partial<PositionComment> = {}): PositionComment {
     return {
@@ -137,5 +142,47 @@ describe('position comment helpers', () => {
             [],
         );
         expect(getInlineCommentsForMove({ positionComments: {} } as Game, chess, null)).toEqual([]);
+    });
+
+    it('returns top-level non-empty starting position comments oldest first', () => {
+        const chess = new Chess({ pgn: '1. e4' });
+        const fen = chess.setUpFen();
+        const older = makeComment({
+            id: 'older',
+            fen,
+            ply: 0,
+            san: undefined,
+            content: 'First starting position comment',
+            createdAt: '2026-06-01T10:00:00Z',
+        });
+        const newer = makeComment({
+            id: 'newer',
+            fen,
+            ply: 0,
+            san: undefined,
+            content: 'Second starting position comment',
+            createdAt: '2026-06-01T11:00:00Z',
+        });
+        const reply = makeComment({
+            id: 'reply',
+            fen,
+            ply: 0,
+            san: undefined,
+            parentIds: 'older',
+            content: 'Reply text',
+        });
+        const empty = makeComment({
+            id: 'empty',
+            fen,
+            ply: 0,
+            san: undefined,
+            content: '   ',
+        });
+        const game = makeGame({ [fen]: { newer, reply, empty, older } });
+
+        expect(getInlineCommentsForStartingPosition(game, chess).map((c) => c.id)).toEqual([
+            'older',
+            'newer',
+        ]);
     });
 });

--- a/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.ts
@@ -41,6 +41,21 @@ export function getInlineCommentsForMove(
     }
 
     return getCommentsForFen(game, chess.normalizedFen(move), move, SortBy.Oldest).filter(
-        (comment) => !comment.parentIds?.trim() && comment.content.trim().length > 0,
+        isInlineComment,
     );
+}
+
+export function getInlineCommentsForStartingPosition(
+    game: Game | undefined,
+    chess: Chess | undefined,
+): PositionComment[] {
+    if (!game || !chess) {
+        return [];
+    }
+
+    return getCommentsForFen(game, chess.setUpFen(), null, SortBy.Oldest).filter(isInlineComment);
+}
+
+function isInlineComment(comment: PositionComment): boolean {
+    return !comment.parentIds?.trim() && comment.content.trim().length > 0;
 }

--- a/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.ts
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/positionComments.ts
@@ -1,0 +1,46 @@
+import { Game, PositionComment } from '@/database/game';
+import { Chess, Move } from '@jackstenglein/chess';
+
+export enum SortBy {
+    Newest = 'NEWEST',
+    Oldest = 'OLDEST',
+}
+
+export function getCommentsForFen(
+    game: Game,
+    fen: string,
+    move: Move | null,
+    sort: SortBy,
+): PositionComment[] {
+    const fenComments = game.positionComments?.[fen] || {};
+    const selectedComments: PositionComment[] = [];
+
+    for (const comment of Object.values(fenComments)) {
+        if (comment.ply === (move?.ply || 0) && comment.san === move?.san) {
+            selectedComments.push(comment);
+        }
+    }
+
+    selectedComments.sort((lhs, rhs) => {
+        if (sort === SortBy.Newest) {
+            return rhs.createdAt.localeCompare(lhs.createdAt);
+        }
+        return lhs.createdAt.localeCompare(rhs.createdAt);
+    });
+
+    return selectedComments;
+}
+
+export function getInlineCommentsForMove(
+    game: Game | undefined,
+    chess: Chess | undefined,
+    move: Move | null | undefined,
+): PositionComment[] {
+    if (!game || !chess || !move) {
+        return [];
+    }
+
+    return getCommentsForFen(game, chess.normalizedFen(move), move, SortBy.Oldest).filter(
+        (comment) => !comment.parentIds?.trim() && comment.content.trim().length > 0,
+    );
+}

--- a/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.test.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.test.tsx
@@ -1,6 +1,11 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import ViewerSettings, { CoordinateSize, CoordinateSizeKey, ViewerSetting } from './ViewerSettings';
+import ViewerSettings, {
+    CoordinateSize,
+    CoordinateSizeKey,
+    ShowInlineCommentsInPgn,
+    ViewerSetting,
+} from './ViewerSettings';
 
 vi.mock('./KeyboardShortcuts', () => ({
     default: () => null,
@@ -40,5 +45,41 @@ describe('ViewerSettings coordinate size', () => {
         render(<ViewerSettings enabledSettings={{ [ViewerSetting.CoordinateSize]: true }} />);
 
         expect(screen.getByRole('combobox', { name: 'Coordinate Size' })).toBeInTheDocument();
+    });
+});
+
+describe('ViewerSettings inline comments in PGN', () => {
+    it('shows inline comments in PGN by default', () => {
+        render(<ViewerSettings />);
+
+        expect(
+            screen.getByRole('checkbox', { name: 'Display comments in PGN text' }),
+        ).toBeChecked();
+    });
+
+    it('persists the inline comments in PGN selection', () => {
+        render(<ViewerSettings />);
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Display comments in PGN text' }));
+
+        expect(localStorage.getItem(ShowInlineCommentsInPgn.key)).toBe(JSON.stringify(false));
+    });
+
+    it('can hide the inline comments in PGN setting with enabledSettings', () => {
+        render(<ViewerSettings enabledSettings={{ [ViewerSetting.CoordinateStyle]: true }} />);
+
+        expect(
+            screen.queryByRole('checkbox', { name: 'Display comments in PGN text' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('can show the inline comments in PGN setting with enabledSettings', () => {
+        render(
+            <ViewerSettings enabledSettings={{ [ViewerSetting.DisplayInlineComments]: true }} />,
+        );
+
+        expect(
+            screen.getByRole('checkbox', { name: 'Display comments in PGN text' }),
+        ).toBeInTheDocument();
     });
 });

--- a/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
@@ -43,6 +43,12 @@ export const ShowSuggestedVariations = {
     default: true,
 } as const;
 
+/** Whether to show position comments in the PGN text. */
+export const ShowInlineCommentsInPgn = {
+    key: 'showInlineCommentsInPgn',
+    default: true,
+} as const;
+
 /** Whether to automatically save variations as comments on other users games. */
 export const AutoSaveVariations = {
     key: 'autoSaveVariations',
@@ -123,6 +129,7 @@ export enum ViewerSetting {
     HighlightEngineLines,
     PersistEngineLines,
     DisplaySuggestedVariations,
+    DisplayInlineComments,
     ScrollOnBoardToMove,
     PieceSounds,
     CorrectSolitaireMoveSound,
@@ -180,6 +187,10 @@ const ViewerSettings = ({
     const [showSuggestedVariations, setShowSuggestedVariations] = useLocalStorage<boolean>(
         ShowSuggestedVariations.key,
         ShowSuggestedVariations.default,
+    );
+    const [showInlineCommentsInPgn, setShowInlineCommentsInPgn] = useLocalStorage<boolean>(
+        ShowInlineCommentsInPgn.key,
+        ShowInlineCommentsInPgn.default,
     );
     const [autoSaveVariations, setAutoSaveVariations] = useLocalStorage<boolean>(
         AutoSaveVariations.key,
@@ -375,6 +386,18 @@ const ViewerSettings = ({
                             />
                         }
                         label="Display other users' suggested variations in PGN text"
+                    />
+                )}
+
+                {(!enabledSettings || enabledSettings[ViewerSetting.DisplayInlineComments]) && (
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={showInlineCommentsInPgn}
+                                onChange={(e) => setShowInlineCommentsInPgn(e.target.checked)}
+                            />
+                        }
+                        label='Display comments in PGN text'
                     />
                 )}
 

--- a/frontend/src/board/pgn/pgnText/Comments.tsx
+++ b/frontend/src/board/pgn/pgnText/Comments.tsx
@@ -1,15 +1,19 @@
+import { PositionComment } from '@/database/game';
 import { CommentType, Event, EventType, Move } from '@jackstenglein/chess';
+import { Divider } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useChess } from '../PgnBoard';
+import InlinePositionComments from './InlinePositionComments';
 import Markdown from './Markdown';
 
-interface CommentProps {
+interface CommentsProps {
     move: Move;
     type?: CommentType;
     inline?: boolean;
+    inlineComments: PositionComment[];
 }
 
-const Comment: React.FC<CommentProps> = ({ move, type, inline }) => {
+export function Comments({ move, type, inline, inlineComments }: CommentsProps) {
     const { chess } = useChess();
     const [, setForceRender] = useState(0);
 
@@ -31,11 +35,15 @@ const Comment: React.FC<CommentProps> = ({ move, type, inline }) => {
 
     const text = type === CommentType.Before ? move.commentMove : move.commentAfter;
 
-    if (!text) {
+    if (!text && inlineComments.length === 0) {
         return null;
     }
 
-    return <Markdown text={text} inline={inline} move={move} />;
-};
-
-export default Comment;
+    return (
+        <>
+            {text && <Markdown text={text} inline={inline} move={move} />}
+            {text && inlineComments.length > 0 && !inline && <Divider />}
+            <InlinePositionComments comments={inlineComments} inline={inline} />
+        </>
+    );
+}

--- a/frontend/src/board/pgn/pgnText/InlinePositionComments.test.tsx
+++ b/frontend/src/board/pgn/pgnText/InlinePositionComments.test.tsx
@@ -1,0 +1,60 @@
+import { PositionComment } from '@/database/game';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import InlinePositionComments from './InlinePositionComments';
+
+vi.mock('@/profile/Avatar', () => ({
+    default: ({ displayName }: { displayName?: string }) => (
+        <span data-testid='inline-comment-avatar'>{displayName}</span>
+    ),
+}));
+
+afterEach(() => {
+    cleanup();
+});
+
+function makeComment(overrides: Partial<PositionComment> = {}): PositionComment {
+    return {
+        id: 'comment-id',
+        fen: 'fen',
+        ply: 1,
+        san: 'e4',
+        owner: {
+            username: 'commenter',
+            displayName: 'Commenter',
+            cohort: '1500-1600',
+            previousCohort: '1400-1500',
+        },
+        createdAt: '2026-06-01T10:00:00Z',
+        updatedAt: '2026-06-01T10:00:00Z',
+        content: 'Interesting move',
+        parentIds: '',
+        replies: {},
+        ...overrides,
+    };
+}
+
+describe('InlinePositionComments', () => {
+    it('renders the commenter avatar and comment text', () => {
+        render(<InlinePositionComments comments={[makeComment()]} />);
+
+        expect(screen.getByTestId('inline-comment-avatar')).toHaveTextContent('Commenter');
+        expect(screen.getByText('Interesting move')).toBeInTheDocument();
+    });
+
+    it('preserves multi-line comment text', () => {
+        render(
+            <InlinePositionComments comments={[makeComment({ content: 'Line one\nLine two' })]} />,
+        );
+
+        expect(
+            screen.getByText('Line one\nLine two', { normalizer: (text) => text }),
+        ).toBeInTheDocument();
+    });
+
+    it('renders nothing for empty comments', () => {
+        const { container } = render(<InlinePositionComments comments={[]} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/frontend/src/board/pgn/pgnText/InlinePositionComments.tsx
+++ b/frontend/src/board/pgn/pgnText/InlinePositionComments.tsx
@@ -4,15 +4,16 @@ import { Stack, Tooltip, Typography } from '@mui/material';
 
 interface InlinePositionCommentsProps {
     comments: PositionComment[];
+    inline?: boolean;
 }
 
-export default function InlinePositionComments({ comments }: InlinePositionCommentsProps) {
+export default function InlinePositionComments({ comments, inline }: InlinePositionCommentsProps) {
     if (comments.length === 0) {
         return null;
     }
 
     return (
-        <Stack spacing={0.75} px={1} py={0.75}>
+        <Stack spacing={1.5} px={1} py={0.75}>
             {comments.map((comment) => (
                 <Stack
                     key={comment.id}
@@ -31,10 +32,10 @@ export default function InlinePositionComments({ comments }: InlinePositionComme
                         </span>
                     </Tooltip>
                     <Typography
-                        variant='body2'
-                        color='text.primary'
+                        variant={inline ? 'caption' : 'body2'}
+                        color='text.secondary'
                         whiteSpace='pre-line'
-                        sx={{ minWidth: 0, wordBreak: 'break-word' }}
+                        sx={{ minWidth: 0, wordBreak: 'break-word', paddingTop: '2px' }}
                     >
                         {comment.content.trim()}
                     </Typography>

--- a/frontend/src/board/pgn/pgnText/InlinePositionComments.tsx
+++ b/frontend/src/board/pgn/pgnText/InlinePositionComments.tsx
@@ -1,0 +1,45 @@
+import { PositionComment } from '@/database/game';
+import Avatar from '@/profile/Avatar';
+import { Stack, Tooltip, Typography } from '@mui/material';
+
+interface InlinePositionCommentsProps {
+    comments: PositionComment[];
+}
+
+export default function InlinePositionComments({ comments }: InlinePositionCommentsProps) {
+    if (comments.length === 0) {
+        return null;
+    }
+
+    return (
+        <Stack spacing={0.75} px={1} py={0.75}>
+            {comments.map((comment) => (
+                <Stack
+                    key={comment.id}
+                    data-testid='inline-position-comment'
+                    direction='row'
+                    alignItems='flex-start'
+                    spacing={0.75}
+                >
+                    <Tooltip title={`Comment by ${comment.owner.displayName}`}>
+                        <span>
+                            <Avatar
+                                username={comment.owner.username}
+                                displayName={comment.owner.displayName}
+                                size={24}
+                            />
+                        </span>
+                    </Tooltip>
+                    <Typography
+                        variant='body2'
+                        color='text.primary'
+                        whiteSpace='pre-line'
+                        sx={{ minWidth: 0, wordBreak: 'break-word' }}
+                    >
+                        {comment.content.trim()}
+                    </Typography>
+                </Stack>
+            ))}
+        </Stack>
+    );
+}

--- a/frontend/src/board/pgn/pgnText/Interrupt.test.tsx
+++ b/frontend/src/board/pgn/pgnText/Interrupt.test.tsx
@@ -1,0 +1,110 @@
+import { GameContext } from '@/context/useGame';
+import { Game, PositionComment } from '@/database/game';
+import { Chess } from '@jackstenglein/chess';
+import { Grid } from '@mui/material';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ShowInlineCommentsInPgn } from '../boardTools/underboard/settings/ViewerSettings';
+import Interrupt from './Interrupt';
+
+const mockChessContext = vi.hoisted(() => ({ chess: undefined as unknown }));
+
+vi.mock('@/auth/Auth', () => ({
+    useAuth: () => ({ user: { username: 'viewer' } }),
+}));
+
+vi.mock('../PgnBoard', () => ({
+    useChess: () => ({ chess: mockChessContext.chess }),
+}));
+
+vi.mock('../boardTools/underboard/settings/ViewerSettings', () => ({
+    ShowInlineCommentsInPgn: {
+        key: 'showInlineCommentsInPgn',
+        default: true,
+    },
+    ShowSuggestedVariations: {
+        key: 'showSuggestedVariations',
+        default: true,
+    },
+}));
+
+vi.mock('@/profile/Avatar', () => ({
+    default: ({ displayName }: { displayName?: string }) => (
+        <span data-testid='inline-comment-avatar'>{displayName}</span>
+    ),
+}));
+
+vi.mock('./Comment', () => ({
+    default: () => null,
+}));
+
+vi.mock('./Ellipsis', () => ({
+    Ellipsis: () => null,
+}));
+
+vi.mock('./Lines', () => ({
+    default: () => null,
+}));
+
+afterEach(() => {
+    cleanup();
+    localStorage.clear();
+});
+
+function makeComment(overrides: Partial<PositionComment> = {}): PositionComment {
+    return {
+        id: 'comment-id',
+        fen: '',
+        ply: 1,
+        san: 'e4',
+        owner: {
+            username: 'commenter',
+            displayName: 'Commenter',
+            cohort: '1500-1600',
+            previousCohort: '1400-1500',
+        },
+        createdAt: '2026-06-01T10:00:00Z',
+        updatedAt: '2026-06-01T10:00:00Z',
+        content: 'Nice pawn push',
+        parentIds: '',
+        replies: {},
+        ...overrides,
+    };
+}
+
+function renderInterrupt(enabled: boolean) {
+    localStorage.setItem(ShowInlineCommentsInPgn.key, JSON.stringify(enabled));
+
+    const chess = new Chess({ pgn: '1. e4 e5' });
+    const move = chess.history()[0];
+    mockChessContext.chess = chess;
+    const fen = chess.normalizedFen(move);
+    const comment = makeComment({ fen, ply: move.ply, san: move.san });
+    const game = {
+        pgn: '1. e4 e5',
+        positionComments: { [fen]: { [comment.id]: comment } },
+    } as Game;
+
+    return render(
+        <GameContext.Provider value={{ game }}>
+            <Grid container>
+                <Interrupt move={move} handleScroll={() => null} />
+            </Grid>
+        </GameContext.Provider>,
+    );
+}
+
+describe('Interrupt inline position comments', () => {
+    it('renders position comments when the setting is enabled', () => {
+        renderInterrupt(true);
+
+        expect(screen.getByText('Nice pawn push')).toBeInTheDocument();
+        expect(screen.getByTestId('inline-comment-avatar')).toHaveTextContent('Commenter');
+    });
+
+    it('does not render position comments when the setting is disabled', () => {
+        renderInterrupt(false);
+
+        expect(screen.queryByText('Nice pawn push')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/board/pgn/pgnText/Interrupt.tsx
+++ b/frontend/src/board/pgn/pgnText/Interrupt.tsx
@@ -1,22 +1,31 @@
 import { useAuth } from '@/auth/Auth';
+import useGame from '@/context/useGame';
 import { Move } from '@jackstenglein/chess';
 import { Divider, Grid, Paper } from '@mui/material';
 import { useLocalStorage } from 'usehooks-ts';
+import { getInlineCommentsForMove } from '../boardTools/underboard/comments/positionComments';
 import {
     isSuggestedVariation,
     isVariationSuggestor,
 } from '../boardTools/underboard/comments/suggestVariation';
-import { ShowSuggestedVariations } from '../boardTools/underboard/settings/ViewerSettings';
+import {
+    ShowInlineCommentsInPgn,
+    ShowSuggestedVariations,
+} from '../boardTools/underboard/settings/ViewerSettings';
+import { useChess } from '../PgnBoard';
 import Comment from './Comment';
 import { Ellipsis } from './Ellipsis';
+import InlinePositionComments from './InlinePositionComments';
 import Lines from './Lines';
 
 export function hasInterrupt(
     move: Move,
     showSuggestedVariations: boolean,
     username: string | undefined,
+    hasInlineComments = false,
 ): boolean {
     return (
+        hasInlineComments ||
         (move.commentAfter?.trim().length || 0) > 0 ||
         move.variations.some(
             (v) =>
@@ -35,12 +44,21 @@ interface InterruptProps {
 
 const Interrupt: React.FC<InterruptProps> = ({ move, handleScroll }) => {
     const { user } = useAuth();
+    const { chess } = useChess();
+    const { game } = useGame();
     const [showSuggestedVariations] = useLocalStorage<boolean>(
         ShowSuggestedVariations.key,
         ShowSuggestedVariations.default,
     );
+    const [showInlineCommentsInPgn] = useLocalStorage<boolean>(
+        ShowInlineCommentsInPgn.key,
+        ShowInlineCommentsInPgn.default,
+    );
+    const inlineComments = showInlineCommentsInPgn
+        ? getInlineCommentsForMove(game, chess, move)
+        : [];
 
-    if (!hasInterrupt(move, showSuggestedVariations, user?.username)) {
+    if (!hasInterrupt(move, showSuggestedVariations, user?.username, inlineComments.length > 0)) {
         return null;
     }
 
@@ -79,6 +97,7 @@ const Interrupt: React.FC<InterruptProps> = ({ move, handleScroll }) => {
                     />
 
                     <Comment move={move} />
+                    <InlinePositionComments comments={inlineComments} />
 
                     <Lines lines={move.variations} handleScroll={handleScroll} />
 

--- a/frontend/src/board/pgn/pgnText/Interrupt.tsx
+++ b/frontend/src/board/pgn/pgnText/Interrupt.tsx
@@ -13,9 +13,8 @@ import {
     ShowSuggestedVariations,
 } from '../boardTools/underboard/settings/ViewerSettings';
 import { useChess } from '../PgnBoard';
-import Comment from './Comment';
+import { Comments } from './Comments';
 import { Ellipsis } from './Ellipsis';
-import InlinePositionComments from './InlinePositionComments';
 import Lines from './Lines';
 
 export function hasInterrupt(
@@ -96,8 +95,7 @@ const Interrupt: React.FC<InterruptProps> = ({ move, handleScroll }) => {
                         }}
                     />
 
-                    <Comment move={move} />
-                    <InlinePositionComments comments={inlineComments} />
+                    <Comments move={move} inlineComments={inlineComments} />
 
                     <Lines lines={move.variations} handleScroll={handleScroll} />
 

--- a/frontend/src/board/pgn/pgnText/Lines.test.tsx
+++ b/frontend/src/board/pgn/pgnText/Lines.test.tsx
@@ -69,7 +69,7 @@ function makeComment(overrides: Partial<PositionComment> = {}): PositionComment 
     };
 }
 
-function renderVariationLine(enabled: boolean) {
+function renderVariationLine(enabled: boolean, showInlinePositionComments = true) {
     localStorage.setItem(ShowInlineCommentsInPgn.key, JSON.stringify(enabled));
 
     const chess = new Chess({ pgn: '1. e4 (1. d4 d5) e5' });
@@ -85,7 +85,13 @@ function renderVariationLine(enabled: boolean) {
 
     return render(
         <GameContext.Provider value={{ game }}>
-            <Line line={line} depth={0} handleScroll={() => null} onExpand={() => null} />
+            <Line
+                line={line}
+                depth={0}
+                handleScroll={() => null}
+                onExpand={() => null}
+                showInlinePositionComments={showInlinePositionComments}
+            />
         </GameContext.Provider>,
     );
 }
@@ -100,6 +106,12 @@ describe('Line inline position comments', () => {
 
     it('does not render comments attached to variation moves when the setting is disabled', () => {
         renderVariationLine(false);
+
+        expect(screen.queryByText('Variation position note')).not.toBeInTheDocument();
+    });
+
+    it('does not render comments when the line consumer disables inline position comments', () => {
+        renderVariationLine(true, false);
 
         expect(screen.queryByText('Variation position note')).not.toBeInTheDocument();
     });

--- a/frontend/src/board/pgn/pgnText/Lines.test.tsx
+++ b/frontend/src/board/pgn/pgnText/Lines.test.tsx
@@ -1,0 +1,106 @@
+import { GameContext } from '@/context/useGame';
+import { Game, PositionComment } from '@/database/game';
+import { Chess } from '@jackstenglein/chess';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ShowInlineCommentsInPgn } from '../boardTools/underboard/settings/ViewerSettings';
+import { Line } from './Lines';
+
+const mockChessContext = vi.hoisted(() => ({ chess: undefined as unknown }));
+
+vi.mock('@/auth/Auth', () => ({
+    useAuth: () => ({ user: { username: 'viewer' } }),
+}));
+
+vi.mock('../PgnBoard', () => ({
+    useChess: () => ({ chess: mockChessContext.chess }),
+}));
+
+vi.mock('../boardTools/underboard/settings/ViewerSettings', () => ({
+    ShowInlineCommentsInPgn: {
+        key: 'showInlineCommentsInPgn',
+        default: true,
+    },
+    ShowSuggestedVariations: {
+        key: 'showSuggestedVariations',
+        default: true,
+    },
+}));
+
+vi.mock('@/profile/Avatar', () => ({
+    default: ({ displayName }: { displayName?: string }) => (
+        <span data-testid='inline-comment-avatar'>{displayName}</span>
+    ),
+}));
+
+vi.mock('./Comment', () => ({
+    default: () => null,
+}));
+
+vi.mock('./MoveButton', () => ({
+    default: ({ move }: { move: { san: string } }) => (
+        <span data-testid='variation-move'>{move.san}</span>
+    ),
+}));
+
+afterEach(() => {
+    cleanup();
+    localStorage.clear();
+});
+
+function makeComment(overrides: Partial<PositionComment> = {}): PositionComment {
+    return {
+        id: 'comment-id',
+        fen: '',
+        ply: 1,
+        san: 'd4',
+        owner: {
+            username: 'commenter',
+            displayName: 'Commenter',
+            cohort: '1500-1600',
+            previousCohort: '1400-1500',
+        },
+        createdAt: '2026-06-01T10:00:00Z',
+        updatedAt: '2026-06-01T10:00:00Z',
+        content: 'Variation position note',
+        parentIds: '',
+        replies: {},
+        ...overrides,
+    };
+}
+
+function renderVariationLine(enabled: boolean) {
+    localStorage.setItem(ShowInlineCommentsInPgn.key, JSON.stringify(enabled));
+
+    const chess = new Chess({ pgn: '1. e4 (1. d4 d5) e5' });
+    mockChessContext.chess = chess;
+    const line = chess.history()[0].variations[0];
+    const move = line[0];
+    const fen = chess.normalizedFen(move);
+    const comment = makeComment({ fen, ply: move.ply, san: move.san });
+    const game = {
+        pgn: '1. e4 (1. d4 d5) e5',
+        positionComments: { [fen]: { [comment.id]: comment } },
+    } as Game;
+
+    return render(
+        <GameContext.Provider value={{ game }}>
+            <Line line={line} depth={0} handleScroll={() => null} onExpand={() => null} />
+        </GameContext.Provider>,
+    );
+}
+
+describe('Line inline position comments', () => {
+    it('renders comments attached to variation moves when the setting is enabled', () => {
+        renderVariationLine(true);
+
+        expect(screen.getByText('Variation position note')).toBeInTheDocument();
+        expect(screen.getByTestId('inline-comment-avatar')).toHaveTextContent('Commenter');
+    });
+
+    it('does not render comments attached to variation moves when the setting is disabled', () => {
+        renderVariationLine(false);
+
+        expect(screen.queryByText('Variation position note')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/board/pgn/pgnText/Lines.tsx
+++ b/frontend/src/board/pgn/pgnText/Lines.tsx
@@ -27,6 +27,7 @@ interface LineProps {
     handleScroll: (child: HTMLElement | null) => void;
     onExpand: () => void;
     forceShowSuggestedVariations?: boolean;
+    showInlinePositionComments?: boolean;
     slotProps?: {
         moveButton?: MoveButtonSlotProps;
     };
@@ -38,6 +39,7 @@ export const Line: React.FC<LineProps> = ({
     handleScroll,
     onExpand,
     forceShowSuggestedVariations,
+    showInlinePositionComments = true,
     slotProps,
 }) => {
     const { user } = useAuth();
@@ -91,6 +93,7 @@ export const Line: React.FC<LineProps> = ({
                     handleScroll={handleScroll}
                     expandParent={onExpand}
                     forceShowSuggestedVariations={forceShowSuggestedVariations}
+                    showInlinePositionComments={showInlinePositionComments}
                     slotProps={slotProps}
                 />,
             );
@@ -110,7 +113,9 @@ export const Line: React.FC<LineProps> = ({
                 <Comment move={move} inline />
                 <InlinePositionComments
                     comments={
-                        showInlineCommentsInPgn ? getInlineCommentsForMove(game, chess, move) : []
+                        showInlinePositionComments && showInlineCommentsInPgn
+                            ? getInlineCommentsForMove(game, chess, move)
+                            : []
                     }
                 />
             </Fragment>,
@@ -143,6 +148,7 @@ interface LinesProps {
     handleScroll: (child: HTMLElement | null) => void;
     expandParent?: () => void;
     forceShowSuggestedVariations?: boolean;
+    showInlinePositionComments?: boolean;
     slotProps?: {
         moveButton?: MoveButtonSlotProps;
     };
@@ -154,6 +160,7 @@ const Lines: React.FC<LinesProps> = ({
     handleScroll,
     expandParent,
     forceShowSuggestedVariations,
+    showInlinePositionComments = true,
     slotProps,
 }) => {
     const { chess } = useChess();
@@ -292,6 +299,7 @@ const Lines: React.FC<LinesProps> = ({
                             expandParent?.();
                         }}
                         forceShowSuggestedVariations={forceShowSuggestedVariations}
+                        showInlinePositionComments={showInlinePositionComments}
                         slotProps={slotProps}
                     />
                 ))}

--- a/frontend/src/board/pgn/pgnText/Lines.tsx
+++ b/frontend/src/board/pgn/pgnText/Lines.tsx
@@ -1,15 +1,21 @@
 import { useAuth } from '@/auth/Auth';
+import useGame from '@/context/useGame';
 import { CommentType, Event, EventType, Move } from '@jackstenglein/chess';
 import { Box, Collapse, Divider, Stack, Tooltip, Typography } from '@mui/material';
 import { Fragment, useEffect, useMemo, useRef, useState, type JSX } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
+import { getInlineCommentsForMove } from '../boardTools/underboard/comments/positionComments';
 import {
     isSuggestedVariation,
     isVariationSuggestor,
 } from '../boardTools/underboard/comments/suggestVariation';
-import { ShowSuggestedVariations } from '../boardTools/underboard/settings/ViewerSettings';
+import {
+    ShowInlineCommentsInPgn,
+    ShowSuggestedVariations,
+} from '../boardTools/underboard/settings/ViewerSettings';
 import { useChess } from '../PgnBoard';
 import Comment from './Comment';
+import InlinePositionComments from './InlinePositionComments';
 import MoveButton, { MoveButtonSlotProps } from './MoveButton';
 
 const borderWidth = 1.5; // px
@@ -36,10 +42,15 @@ export const Line: React.FC<LineProps> = ({
 }) => {
     const { user } = useAuth();
     const { chess } = useChess();
+    const { game } = useGame();
     const [, setForceRender] = useState(0);
     const [showSuggestedVariations] = useLocalStorage<boolean>(
         ShowSuggestedVariations.key,
         ShowSuggestedVariations.default,
+    );
+    const [showInlineCommentsInPgn] = useLocalStorage<boolean>(
+        ShowInlineCommentsInPgn.key,
+        ShowInlineCommentsInPgn.default,
     );
 
     useEffect(() => {
@@ -97,6 +108,11 @@ export const Line: React.FC<LineProps> = ({
                     slotProps={slotProps?.moveButton}
                 />
                 <Comment move={move} inline />
+                <InlinePositionComments
+                    comments={
+                        showInlineCommentsInPgn ? getInlineCommentsForMove(game, chess, move) : []
+                    }
+                />
             </Fragment>,
         );
     }

--- a/frontend/src/board/pgn/pgnText/Lines.tsx
+++ b/frontend/src/board/pgn/pgnText/Lines.tsx
@@ -14,8 +14,7 @@ import {
     ShowSuggestedVariations,
 } from '../boardTools/underboard/settings/ViewerSettings';
 import { useChess } from '../PgnBoard';
-import Comment from './Comment';
-import InlinePositionComments from './InlinePositionComments';
+import { Comments } from './Comments';
 import MoveButton, { MoveButtonSlotProps } from './MoveButton';
 
 const borderWidth = 1.5; // px
@@ -102,7 +101,7 @@ export const Line: React.FC<LineProps> = ({
 
         result.push(
             <Fragment key={`fragment-${i}`}>
-                <Comment move={move} type={CommentType.Before} inline />
+                <Comments move={move} type={CommentType.Before} inline inlineComments={[]} />
                 <MoveButton
                     inline
                     forceShowPly={i === 0}
@@ -110,9 +109,10 @@ export const Line: React.FC<LineProps> = ({
                     handleScroll={handleScroll}
                     slotProps={slotProps?.moveButton}
                 />
-                <Comment move={move} inline />
-                <InlinePositionComments
-                    comments={
+                <Comments
+                    move={move}
+                    inline
+                    inlineComments={
                         showInlinePositionComments && showInlineCommentsInPgn
                             ? getInlineCommentsForMove(game, chess, move)
                             : []

--- a/frontend/src/board/pgn/pgnText/MoveDisplay.tsx
+++ b/frontend/src/board/pgn/pgnText/MoveDisplay.tsx
@@ -1,8 +1,13 @@
 import { useAuth } from '@/auth/Auth';
+import useGame from '@/context/useGame';
 import { Event, EventType, Move } from '@jackstenglein/chess';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
-import { ShowSuggestedVariations } from '../boardTools/underboard/settings/ViewerSettings';
+import { getInlineCommentsForMove } from '../boardTools/underboard/comments/positionComments';
+import {
+    ShowInlineCommentsInPgn,
+    ShowSuggestedVariations,
+} from '../boardTools/underboard/settings/ViewerSettings';
 import { useChess } from '../PgnBoard';
 import { Ellipsis } from './Ellipsis';
 import Interrupt, { hasInterrupt } from './Interrupt';
@@ -18,14 +23,36 @@ const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll }) => {
     const { user } = useAuth();
     const username = user?.username;
     const { chess } = useChess();
+    const { game } = useGame();
     const [, setForceRender] = useState(0);
     const [, setHasComment] = useState(move.commentAfter && move.commentAfter !== '');
     const [showSuggestedVariations] = useLocalStorage<boolean>(
         ShowSuggestedVariations.key,
         ShowSuggestedVariations.default,
     );
+    const [showInlineCommentsInPgn] = useLocalStorage<boolean>(
+        ShowInlineCommentsInPgn.key,
+        ShowInlineCommentsInPgn.default,
+    );
+    const hasMoveInterrupt = useCallback(
+        (target: Move | null | undefined) => {
+            if (!target) {
+                return false;
+            }
+            const inlineComments = showInlineCommentsInPgn
+                ? getInlineCommentsForMove(game, chess, target)
+                : [];
+            return hasInterrupt(
+                target,
+                showSuggestedVariations,
+                username,
+                inlineComments.length > 0,
+            );
+        },
+        [chess, game, showInlineCommentsInPgn, showSuggestedVariations, username],
+    );
     const [needReminder, setNeedReminder] = useState(
-        move.previous === null || hasInterrupt(move.previous, showSuggestedVariations, username),
+        move.previous === null || hasMoveInterrupt(move.previous),
     );
 
     useEffect(() => {
@@ -62,9 +89,7 @@ const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll }) => {
                     }
 
                     if (event.type === EventType.UpdateComment && move === event.move?.next) {
-                        setNeedReminder(
-                            hasInterrupt(event.move, showSuggestedVariations, username),
-                        );
+                        setNeedReminder(hasMoveInterrupt(event.move));
                     }
                     if (
                         event.type === EventType.NewVariation &&
@@ -74,9 +99,7 @@ const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll }) => {
                         setNeedReminder(true);
                     }
                     if (event.type === EventType.DeleteMove && move === event.mainlineMove?.next) {
-                        setNeedReminder(
-                            hasInterrupt(event.mainlineMove, showSuggestedVariations, username),
-                        );
+                        setNeedReminder(hasMoveInterrupt(event.mainlineMove));
                     }
                 },
             };
@@ -84,14 +107,11 @@ const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll }) => {
             chess.addObserver(observer);
             return () => chess.removeObserver(observer);
         }
-    }, [chess, move, setForceRender, setNeedReminder, showSuggestedVariations, username]);
+    }, [chess, move, setForceRender, setNeedReminder, hasMoveInterrupt]);
 
     useEffect(() => {
-        setNeedReminder(
-            move.previous === null ||
-                hasInterrupt(move.previous, showSuggestedVariations, username),
-        );
-    }, [setNeedReminder, move, showSuggestedVariations, username]);
+        setNeedReminder(move.previous === null || hasMoveInterrupt(move.previous));
+    }, [setNeedReminder, move, hasMoveInterrupt]);
 
     return (
         <>

--- a/frontend/src/board/pgn/pgnText/PgnText.tsx
+++ b/frontend/src/board/pgn/pgnText/PgnText.tsx
@@ -14,6 +14,7 @@ import { HideEngine } from '../boardTools/underboard/settings/ViewerSettings';
 import { ResizableData } from '../resize';
 import GameComment from './GameComment';
 import Result from './Result';
+import StartingPositionComments from './StartingPositionComments';
 import Variation from './Variation';
 import EngineSection from './engine/EngineSection';
 
@@ -55,6 +56,7 @@ const PgnText = () => {
                     sx={{ overflowY: 'scroll', overflowX: 'clip', flexGrow: 1, width: 1 }}
                 >
                     <GameComment />
+                    <StartingPositionComments />
                     <Variation handleScroll={handleScroll} />
                     {!slotProps?.pgnText?.hideResult && !solitaire?.enabled && <Result />}
 

--- a/frontend/src/board/pgn/pgnText/StartingPositionComments.test.tsx
+++ b/frontend/src/board/pgn/pgnText/StartingPositionComments.test.tsx
@@ -1,0 +1,85 @@
+import { GameContext } from '@/context/useGame';
+import { Game, PositionComment } from '@/database/game';
+import { Chess } from '@jackstenglein/chess';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ShowInlineCommentsInPgn } from '../boardTools/underboard/settings/ViewerSettings';
+import StartingPositionComments from './StartingPositionComments';
+
+const mockChessContext = vi.hoisted(() => ({ chess: undefined as unknown }));
+
+vi.mock('../PgnBoard', () => ({
+    useChess: () => ({ chess: mockChessContext.chess }),
+}));
+
+vi.mock('../boardTools/underboard/settings/ViewerSettings', () => ({
+    ShowInlineCommentsInPgn: {
+        key: 'showInlineCommentsInPgn',
+        default: true,
+    },
+}));
+
+vi.mock('@/profile/Avatar', () => ({
+    default: ({ displayName }: { displayName?: string }) => (
+        <span data-testid='inline-comment-avatar'>{displayName}</span>
+    ),
+}));
+
+afterEach(() => {
+    cleanup();
+    localStorage.clear();
+});
+
+function makeComment(overrides: Partial<PositionComment> = {}): PositionComment {
+    return {
+        id: 'comment-id',
+        fen: '',
+        ply: 0,
+        owner: {
+            username: 'commenter',
+            displayName: 'Commenter',
+            cohort: '1500-1600',
+            previousCohort: '1400-1500',
+        },
+        createdAt: '2026-06-01T10:00:00Z',
+        updatedAt: '2026-06-01T10:00:00Z',
+        content: 'Starting position note',
+        parentIds: '',
+        replies: {},
+        ...overrides,
+    };
+}
+
+function renderStartingPositionComments(enabled: boolean) {
+    localStorage.setItem(ShowInlineCommentsInPgn.key, JSON.stringify(enabled));
+
+    const chess = new Chess({ pgn: '1. e4 e5' });
+    mockChessContext.chess = chess;
+    const fen = chess.setUpFen();
+    const comment = makeComment({ fen });
+    const game = {
+        pgn: '1. e4 e5',
+        positionComments: { [fen]: { [comment.id]: comment } },
+    } as Game;
+
+    return render(
+        <GameContext.Provider value={{ game }}>
+            <StartingPositionComments />
+        </GameContext.Provider>,
+    );
+}
+
+describe('StartingPositionComments', () => {
+    it('renders starting position comments when the setting is enabled', () => {
+        renderStartingPositionComments(true);
+
+        expect(screen.getByText('Starting position note')).toBeInTheDocument();
+        expect(screen.getByTestId('inline-comment-avatar')).toHaveTextContent('Commenter');
+    });
+
+    it('does not render starting position comments when the setting is disabled', () => {
+        renderStartingPositionComments(false);
+
+        expect(screen.queryByText('Starting position note')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/board/pgn/pgnText/StartingPositionComments.tsx
+++ b/frontend/src/board/pgn/pgnText/StartingPositionComments.tsx
@@ -1,0 +1,29 @@
+import useGame from '@/context/useGame';
+import { Paper } from '@mui/material';
+import { useLocalStorage } from 'usehooks-ts';
+import { getInlineCommentsForStartingPosition } from '../boardTools/underboard/comments/positionComments';
+import { ShowInlineCommentsInPgn } from '../boardTools/underboard/settings/ViewerSettings';
+import { useChess } from '../PgnBoard';
+import InlinePositionComments from './InlinePositionComments';
+
+export default function StartingPositionComments() {
+    const { chess } = useChess();
+    const { game } = useGame();
+    const [showInlineCommentsInPgn] = useLocalStorage<boolean>(
+        ShowInlineCommentsInPgn.key,
+        ShowInlineCommentsInPgn.default,
+    );
+    const comments = showInlineCommentsInPgn
+        ? getInlineCommentsForStartingPosition(game, chess)
+        : [];
+
+    if (comments.length === 0) {
+        return null;
+    }
+
+    return (
+        <Paper elevation={3} sx={{ boxShadow: 'none', color: 'text.secondary' }}>
+            <InlinePositionComments comments={comments} />
+        </Paper>
+    );
+}

--- a/frontend/src/board/pgn/pgnText/StartingPositionComments.tsx
+++ b/frontend/src/board/pgn/pgnText/StartingPositionComments.tsx
@@ -1,5 +1,5 @@
 import useGame from '@/context/useGame';
-import { Paper } from '@mui/material';
+import { Divider, Paper } from '@mui/material';
 import { useLocalStorage } from 'usehooks-ts';
 import { getInlineCommentsForStartingPosition } from '../boardTools/underboard/comments/positionComments';
 import { ShowInlineCommentsInPgn } from '../boardTools/underboard/settings/ViewerSettings';
@@ -24,6 +24,7 @@ export default function StartingPositionComments() {
     return (
         <Paper elevation={3} sx={{ boxShadow: 'none', color: 'text.secondary' }}>
             <InlinePositionComments comments={comments} />
+            <Divider />
         </Paper>
     );
 }


### PR DESCRIPTION
## Summary

Adds a viewer setting to display position comments inline within PGN text.

Comments are shown with the author's avatar and support mainline moves, variations, and the starting position. Replies and empty comments are excluded.

## Related Issues

Item 4 of #2332

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests

## Demo

**Inline comment**
<img width="2481" height="835" alt="image" src="https://github.com/user-attachments/assets/0d2b044f-4c79-4e30-ab19-a0a16e0b2591" />

**Viewer setting**
<img width="711" height="252" alt="image" src="https://github.com/user-attachments/assets/3bf78dfa-929a-4d03-b1f6-8f1a70405ef5" />
