### PR TITLE
feat(#1218): add metadata to public landing pages

### DIFF
--- a/frontend/src/app/(scoreboard)/clubs/page.tsx
+++ b/frontend/src/app/(scoreboard)/clubs/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { ListClubsPage } from './ListClubsPage';
+
+export const metadata: Metadata = {
+    title: 'ChessDojo Clubs',
+    description: 'Find or create chess clubs within the ChessDojo community.',
+};
 
 export default function Page() {
     return (

--- a/frontend/src/app/(scoreboard)/coaching/page.tsx
+++ b/frontend/src/app/(scoreboard)/coaching/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import CoachingPage from './CoachingPage';
+
+export const metadata: Metadata = {
+    title: 'ChessDojo Coaching',
+    description: 'Work with titled coaches from the ChessDojo to accelerate your improvement.',
+};
 
 export default function Page() {
     return (

--- a/frontend/src/app/(scoreboard)/courses/(list)/page.tsx
+++ b/frontend/src/app/(scoreboard)/courses/(list)/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next';
 import ListCoursesPage from './ListCoursesPage';
+
+export const metadata: Metadata = {
+    title: 'ChessDojo Courses',
+    description: 'Browse structured chess courses created by the ChessDojo senseis.',
+};
 
 export default function Page() {
     return <ListCoursesPage />;

--- a/frontend/src/app/(scoreboard)/live-classes/page.tsx
+++ b/frontend/src/app/(scoreboard)/live-classes/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import LiveClassesPage from './LiveClassesPage';
+
+export const metadata: Metadata = {
+    title: 'ChessDojo Live Classes',
+    description: 'Live chess classes streamed weekly by the ChessDojo senseis.',
+};
 
 export default function Page() {
     return (

--- a/frontend/src/app/(scoreboard)/prices/page.tsx
+++ b/frontend/src/app/(scoreboard)/prices/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import PricingPage from './PricingPage';
+
+export const metadata: Metadata = {
+    title: 'ChessDojo Pricing',
+    description:
+        'Membership plans for ChessDojo — train with the structure used by titled players.',
+};
 
 export default function Page() {
     return (


### PR DESCRIPTION
## Summary

- Adds static `Metadata` exports to 5 public landing pages: /coaching, /courses, /prices, /live-classes, /clubs. So shared links render with a page-specific title and description.
- Follows a static-per-route approach as a first implementation.
- Mirrors the pattern already used in /tournaments.
- Profile pages (/profile/[username]) are deliberately excluded — they are currently auth-gated by the middleware in src/proxy.ts, so scraper requests would never reach generateMetadata. Making them public is a separate decision and a follow-up.

## Related Issues
Part of #1218  

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to: Just verified server-rendered `<title>`, `og:title`, and `og:description` for all 5 routes via curl against "npm run dev".

## Demo
