### PR TITLE
feat: add toggle for inline pgn notation

### DIFF
--- a/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/ViewerSettings.tsx
@@ -38,6 +38,11 @@ export const HideEngine = {
     Default: false,
 } as const;
 
+export const InlineNotationSetting = {
+    key: 'pgn-editor/inline-notation',
+    default: false,
+} as const;
+
 /** Whether to show suggested variations in the PGN text. */
 export const ShowSuggestedVariations = {
     key: 'showSuggestedVariations',
@@ -135,6 +140,7 @@ export enum ViewerSetting {
     PieceSounds,
     CorrectSolitaireMoveSound,
     IncorrectSolitaireMoveSound,
+    InlineNotation,
 }
 
 const ViewerSettings = ({
@@ -205,6 +211,10 @@ const ViewerSettings = ({
     const [pieceSounds, setPieceSounds] = useLocalStorage<boolean>(
         PieceSounds.key,
         PieceSounds.default,
+    );
+    const [inlineNotation, setInlineNotation] = useLocalStorage<boolean>(
+        InlineNotationSetting.key,
+        InlineNotationSetting.default,
     );
 
     const [correctSound, setCorrectSound] = useLocalStorage(CORRECT_SOUND_KEY, true);
@@ -382,6 +392,17 @@ const ViewerSettings = ({
                     <Typography variant='h6' mt={1}>
                         {t('pgnTextSectionHeader')}
                     </Typography>
+                )}
+                {(!enabledSettings || enabledSettings[ViewerSetting.InlineNotation]) && (
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={inlineNotation}
+                                onChange={(e) => setInlineNotation(e.target.checked)}
+                            />
+                        }
+                        label='Enable Inline PGN notation'
+                    />
                 )}
 
                 {(!enabledSettings || enabledSettings[ViewerSetting.ShowElapsedTimeNextToMove]) && (

--- a/frontend/src/board/pgn/pgnText/Interrupt.tsx
+++ b/frontend/src/board/pgn/pgnText/Interrupt.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '@/auth/Auth';
 import useGame from '@/context/useGame';
 import { Move } from '@jackstenglein/chess';
-import { Divider, Grid, Paper } from '@mui/material';
+import { Box, Divider, Grid, Paper } from '@mui/material';
 import { useLocalStorage } from 'usehooks-ts';
 import { getInlineCommentsForMove } from '../boardTools/underboard/comments/positionComments';
 import {
@@ -39,9 +39,10 @@ export function hasInterrupt(
 interface InterruptProps {
     move: Move;
     handleScroll: (child: HTMLElement | null) => void;
+    forceInline?: boolean;
 }
 
-const Interrupt: React.FC<InterruptProps> = ({ move, handleScroll }) => {
+const Interrupt: React.FC<InterruptProps> = ({ move, handleScroll, forceInline }) => {
     const { user } = useAuth();
     const { chess } = useChess();
     const { game } = useGame();
@@ -59,6 +60,15 @@ const Interrupt: React.FC<InterruptProps> = ({ move, handleScroll }) => {
 
     if (!hasInterrupt(move, showSuggestedVariations, user?.username, inlineComments.length > 0)) {
         return null;
+    }
+
+    if (forceInline) {
+        return (
+            <Box component='span'>
+                <Comments inline={forceInline} move={move} inlineComments={inlineComments} />
+                <Lines lines={move.variations} handleScroll={handleScroll} />
+            </Box>
+        );
     }
 
     return (

--- a/frontend/src/board/pgn/pgnText/Lines.tsx
+++ b/frontend/src/board/pgn/pgnText/Lines.tsx
@@ -157,7 +157,7 @@ interface LinesProps {
 
 const Lines: React.FC<LinesProps> = ({
     lines,
-    depth,
+    depth = 0,
     handleScroll,
     expandParent,
     forceShowSuggestedVariations,
@@ -182,7 +182,6 @@ const Lines: React.FC<LinesProps> = ({
         return false;
     }, [chess, lines]);
 
-    depth = depth ?? 0;
     const [expanded, setExpanded] = useState(forceExpansion || depth < 3 || depth % 2 === 0);
     const expandRef = useRef<HTMLHRElement>(null);
 

--- a/frontend/src/board/pgn/pgnText/MoveButton.tsx
+++ b/frontend/src/board/pgn/pgnText/MoveButton.tsx
@@ -59,6 +59,13 @@ export function getTextColor(move: Move, inline?: boolean, highlightEngineLines?
     return 'text.primary';
 }
 
+function getFontWeight(chess: Chess | undefined, move: Move, inline?: boolean): string {
+    if (inline && chess?.isInMainline(move)) {
+        return 'bold';
+    }
+    return 'inherit';
+}
+
 export interface MoveButtonSlotProps {
     hideSuggestedVariationOwner?: boolean;
 }
@@ -77,6 +84,7 @@ export interface ButtonProps {
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+    const { chess } = useChess();
     const { isCurrentMove, inline, move, onClickMove, onRightClick, text, time } = props;
     const { slots } = useChess();
     const t = useTranslations('analysisBoard.pgnText');
@@ -127,7 +135,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
             disableElevation
             sx={{
                 textTransform: 'none',
-                fontWeight: isCurrentMove ? 'bold' : 'inherit',
+                fontWeight: isCurrentMove ? 'bold' : getFontWeight(chess, move, inline),
                 color: isCurrentMove ? undefined : getTextColor(move, inline, highlightEngineLines),
                 backgroundColor: isCurrentMove ? 'primary' : undefined,
                 paddingRight: inline ? undefined : 2,

--- a/frontend/src/board/pgn/pgnText/MoveDisplay.tsx
+++ b/frontend/src/board/pgn/pgnText/MoveDisplay.tsx
@@ -17,9 +17,10 @@ import MoveNumber from './MoveNumber';
 interface MoveProps {
     move: Move;
     handleScroll: (child: HTMLElement | null) => void;
+    forceInline?: boolean;
 }
 
-const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll }) => {
+const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll, forceInline }) => {
     const { user } = useAuth();
     const username = user?.username;
     const { chess } = useChess();
@@ -115,7 +116,7 @@ const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll }) => {
 
     return (
         <>
-            {(move.ply % 2 === 1 || needReminder) && (
+            {!forceInline && (move.ply % 2 === 1 || needReminder) && (
                 <>
                     <MoveNumber key={`move-number-${move.ply}`} ply={move.ply} />
 
@@ -134,9 +135,15 @@ const MoveDisplay: React.FC<MoveProps> = ({ move, handleScroll }) => {
                 move={move}
                 handleScroll={handleScroll}
                 firstMove={move.previous === null}
+                inline={forceInline}
             />
 
-            <Interrupt key={`interrupt-${move.ply}`} move={move} handleScroll={handleScroll} />
+            <Interrupt
+                key={`interrupt-${move.ply}`}
+                move={move}
+                handleScroll={handleScroll}
+                forceInline={forceInline}
+            />
         </>
     );
 };

--- a/frontend/src/board/pgn/pgnText/Variation.tsx
+++ b/frontend/src/board/pgn/pgnText/Variation.tsx
@@ -1,7 +1,9 @@
 import { Chess, Event, EventType } from '@jackstenglein/chess';
-import { Grid, Paper } from '@mui/material';
+import { Box, Grid, Paper } from '@mui/material';
 import { useEffect, useState } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
 import { useChess } from '../PgnBoard';
+import { InlineNotationSetting } from '../boardTools/underboard/settings/ViewerSettings';
 import MoveDisplay from './MoveDisplay';
 
 interface VariationProps {
@@ -11,6 +13,10 @@ interface VariationProps {
 const Variation: React.FC<VariationProps> = ({ handleScroll }) => {
     const { chess, solitaire } = useChess();
     const [, setForceRender] = useState(0);
+    const [inlineNotation] = useLocalStorage<boolean>(
+        InlineNotationSetting.key,
+        InlineNotationSetting.default,
+    );
 
     useEffect(() => {
         if (chess) {
@@ -48,11 +54,28 @@ const Variation: React.FC<VariationProps> = ({ handleScroll }) => {
 
     return (
         <Paper sx={{ boxShadow: 'none' }}>
-            <Grid container>
-                {moves?.map((move) => {
-                    return <MoveDisplay move={move} handleScroll={handleScroll} key={move.ply} />;
-                })}
-            </Grid>
+            {inlineNotation ? (
+                <Box sx={{ p: 1, lineHeight: 1.8 }}>
+                    {moves?.map((move) => {
+                        return (
+                            <MoveDisplay
+                                move={move}
+                                handleScroll={handleScroll}
+                                key={move.ply}
+                                forceInline={true}
+                            />
+                        );
+                    })}
+                </Box>
+            ) : (
+                <Grid container>
+                    {moves?.map((move) => {
+                        return (
+                            <MoveDisplay move={move} handleScroll={handleScroll} key={move.ply} />
+                        );
+                    })}
+                </Grid>
+            )}
         </Paper>
     );
 };


### PR DESCRIPTION
## Summary

added a toggle in viewer settings for inline pgn notation. refactored the pgn rendering components (variation, movedisplay, interrupt) to conditionally strip the tabular grid wrappers and use a continuous flowing box layout when enabled. hooked the prop drilling to local storage state at the top level to avoid memory bloat. disabled by default to preserve standard tabular view for existing users.

## Related Issues

Closes #1591 

## Demo

<img width="1917" height="971" alt="image" src="https://github.com/user-attachments/assets/678f3c20-acb3-4b0a-a1b5-a7a5daa88b66" />
