### PR TITLE
fix: use local timezone for pgn date headers

### DIFF
--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -802,16 +802,10 @@ export function parsePgnDate(pgnDate?: string): DateTime<true> | null {
  * @param date the DateTime object
  * @returns a PGN tag value suitable to use for e.g. Date
  */
-export function toPgnDate(date?: DateTime | null): string | null {
-    let pgnDate = date?.toUTC().toISO();
-    if (!pgnDate) {
-        return null;
-    }
-
-    pgnDate = pgnDate.substring(0, pgnDate.indexOf('T'));
-    pgnDate = pgnDate.replaceAll('-', '.');
-
-    return pgnDate;
+export function toPgnDate(date: DateTime | null): string | null;
+export function toPgnDate(date: DateTime | undefined): string | undefined;
+export function toPgnDate(date: DateTime | null | undefined): string | null | undefined {
+    return date?.toISODate()?.replaceAll('-', '.') ?? (date === undefined ? undefined : null);
 }
 
 /**

--- a/frontend/src/board/pgn/boardTools/underboard/tags/DateEditor.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/tags/DateEditor.tsx
@@ -1,4 +1,4 @@
-import { parsePgnDate, toLocalPgnDate } from '@/api/gameApi';
+import { parsePgnDate, toPgnDate } from '@/api/gameApi';
 import { BlockBoardKeyboardShortcuts } from '@/board/pgn/PgnBoard';
 import { PgnDate } from '@jackstenglein/chess';
 import { GridRenderEditCellParams, useGridApiContext } from '@mui/x-data-grid-pro';
@@ -14,7 +14,7 @@ export function EditDateCell(props: GridRenderEditCellParams<TagRow, PgnDate | s
         void apiRef.current.setEditCellValue({
             id,
             field,
-            value: toLocalPgnDate(newValue),
+            value: toPgnDate(newValue),
         });
     };
 


### PR DESCRIPTION
## Summary

the pgn date field was shifting backward after saving because the local DateTime object from the date picker was being converted to UTC before extracting the date string. depending on the user's local timezone offset, this conversion was pushing the time over the midnight boundary into the previous day.

updated toPgnDate in gameApi.ts to use .toISODate() instead of .toUTC(). this bypasses the timezone math entirely and strictly extracts the literal calendar date (YYYY.MM.DD) exactly as the user selected it in their local context.

edit: noticed that toLocalPgnDate already existed in the file doing this exact same thing. deleted toLocalPgnDate and updated toPgnDate with a generic type signature so it safely handles the null vs undefined return types that the different callers (game settings vs data grid) were relying on. updated all imports accordingly.

## Related Issues
Closes #2409 