### PR TITLE
fix: add color toggle to sparring bot

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -4070,5 +4070,11 @@
         "unsubscribeSuccess": "{email} wurde abgemeldet. Bitte warte 24 Stunden, bis diese Änderung wirksam wird.",
         "emailLabel": "E-Mail",
         "unsubscribeButton": "Abmelden"
+    },
+    "PlayMaia": {
+        "title": "Gegen Dojo Sparring Bot spielen",
+        "playAsWhite": "Als Weiß spielen",
+        "playAsBlack": "Als Schwarz spielen",
+        "randomColor": "Zufällige Farbe"
     }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -4095,5 +4095,11 @@
         "unsubscribeSuccess": "{email} has been unsubscribed. Please allow 24 hours for this change to take effect.",
         "emailLabel": "Email",
         "unsubscribeButton": "Unsubscribe"
+    },
+    "PlayMaia": {
+        "title": "Play vs Dojo Sparring Bot",
+        "playAsWhite": "Play as White",
+        "playAsBlack": "Play as Black",
+        "randomColor": "Random Color"
     }
 }

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -4093,5 +4093,11 @@
         "unsubscribeSuccess": "[T] {email} has been unsubscribed. Please allow 24 hours for this change to take effect.",
         "emailLabel": "[T] Email",
         "unsubscribeButton": "[T] Unsubscribe"
+    },
+    "PlayMaia": {
+        "title": "[PlayMaia.title]",
+        "playAsWhite": "[PlayMaia.playAsWhite]",
+        "playAsBlack": "[PlayMaia.playAsBlack]",
+        "randomColor": "[PlayMaia.randomColor]"
     }
 }

--- a/frontend/src/components/playbot/PlayMaiaDialog.tsx
+++ b/frontend/src/components/playbot/PlayMaiaDialog.tsx
@@ -16,6 +16,7 @@ import {
     Stack,
     Typography,
 } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { MAIA_RATINGS, MaiaRating } from './maiaengine';
 import { RATING_DESCRIPTIONS } from './playbot';
@@ -51,7 +52,7 @@ export function PlayMaiaDialog({
     const mins = limitSeconds / 60;
     const inc = incrementSeconds;
     const isUnlimited = limitSeconds === 0 && incrementSeconds === 0;
-
+    const t = useTranslations('PlayMaia');
     const handleStart = () => {
         const params = new URLSearchParams({
             fen: fen.trim(),
@@ -68,7 +69,7 @@ export function PlayMaiaDialog({
             <DialogTitle>
                 <Stack direction='row' alignItems='center' spacing={1}>
                     <SmartToy color='primary' />
-                    <span>Play vs Dojo Sparring Bot</span>
+                    <span>{t('title')}</span>
                 </Stack>
                 {positionTitle && (
                     <Typography variant='body2' color='text.secondary' mt={0.5}>
@@ -105,7 +106,7 @@ export function PlayMaiaDialog({
                                             borderColor: 'divider',
                                         }}
                                     />
-                                    <span>Play as White</span>
+                                    <span>{t('playAsWhite')}</span>
                                 </Stack>
                             </MenuItem>
                             <MenuItem value='black'>
@@ -120,7 +121,7 @@ export function PlayMaiaDialog({
                                             borderColor: 'divider',
                                         }}
                                     />
-                                    <span>Play as Black</span>
+                                    <span>{t('playAsBlack')}</span>
                                 </Stack>
                             </MenuItem>
                         </Select>

--- a/frontend/src/components/playbot/PlayMaiaDialog.tsx
+++ b/frontend/src/components/playbot/PlayMaiaDialog.tsx
@@ -16,7 +16,7 @@ import {
     Stack,
     Typography,
 } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MAIA_RATINGS, MaiaRating } from './maiaengine';
 import { RATING_DESCRIPTIONS } from './playbot';
 
@@ -42,6 +42,11 @@ export function PlayMaiaDialog({
 }: PlayMaiaDialogProps) {
     const router = useRouter();
     const [maiaRating, setMaiaRating] = useState<MaiaRating>(1500);
+    const [selectedColor, setSelectedColor] = useState<'white' | 'black'>(playerColor);
+
+    useEffect(() => {
+        setSelectedColor(playerColor);
+    }, [playerColor]);
 
     const mins = limitSeconds / 60;
     const inc = incrementSeconds;
@@ -52,7 +57,7 @@ export function PlayMaiaDialog({
             fen: fen.trim(),
             mins: String(mins),
             inc: String(inc),
-            color: playerColor,
+            color: selectedColor,
             rating: String(maiaRating),
         });
         router.push(`/play-bot?${params.toString()}`);
@@ -80,25 +85,45 @@ export function PlayMaiaDialog({
                             size='small'
                             label={isUnlimited ? 'Unlimited' : `${mins}+${inc}`}
                             variant='outlined'
+                            sx={{ height: 32 }}
                         />
-                        <Chip
+                        <Select
                             size='small'
-                            label={`Play as ${playerColor}`}
-                            variant='outlined'
-                            icon={
-                                <Box
-                                    sx={{
-                                        width: 10,
-                                        height: 10,
-                                        borderRadius: '50%',
-                                        ml: '6px !important',
-                                        bgcolor: playerColor === 'white' ? 'white' : 'grey.700',
-                                        border: '1px solid',
-                                        borderColor: 'divider',
-                                    }}
-                                />
-                            }
-                        />
+                            value={selectedColor}
+                            onChange={(e) => setSelectedColor(e.target.value)}
+                            sx={{ height: 32 }}
+                        >
+                            <MenuItem value='white'>
+                                <Stack direction='row' alignItems='center' spacing={1}>
+                                    <Box
+                                        sx={{
+                                            width: 10,
+                                            height: 10,
+                                            borderRadius: '50%',
+                                            bgcolor: 'white',
+                                            border: '1px solid',
+                                            borderColor: 'divider',
+                                        }}
+                                    />
+                                    <span>Play as White</span>
+                                </Stack>
+                            </MenuItem>
+                            <MenuItem value='black'>
+                                <Stack direction='row' alignItems='center' spacing={1}>
+                                    <Box
+                                        sx={{
+                                            width: 10,
+                                            height: 10,
+                                            borderRadius: '50%',
+                                            bgcolor: 'grey.700',
+                                            border: '1px solid',
+                                            borderColor: 'divider',
+                                        }}
+                                    />
+                                    <span>Play as Black</span>
+                                </Stack>
+                            </MenuItem>
+                        </Select>
                     </Stack>
 
                     <Divider />


### PR DESCRIPTION
## Summary

added a color toggle to the play maia dialog for sparring positions. it defaults to the fen active turn but allows users to override it. replaced the hardcoded chip with a select dropdown to match the ui pattern of the practice menu.
tested across two different courses to confirm the fix isnt course-specific. in the KID starter course, sparring positions default to white, switched to black via the new dropdown and maia correctly responded as white first. in caro kann, positions default to black, switched to white and maia correctly responded as black first. confirmed both directions of the color override work and the bot always plays the opposite side correctly regardless of which way the user switches from the default.

## Related Issues

Closes #2413 

## Demo

<img width="552" height="442" alt="image" src="https://github.com/user-attachments/assets/df629b6a-a405-4d93-82c1-d2b210f5d1dc" />
