### PR TITLE
feat(#2389): add Repertoire Spy sparring mode

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -3426,7 +3426,15 @@
                 "hideSourceTooltip": "Quelle aus Ergebnissen ausblenden",
                 "removeSourceTooltip": "Quelle entfernen",
                 "clearDataButton": "Daten löschen",
-                "addSourceButton": "Quelle hinzufügen"
+                "addSourceButton": "Quelle hinzufügen",
+                "playModeTitle": "Gegen Repertoire spielen",
+                "playModeDescription": "Nutze die gefilterte Datenbank dieses Spielers, bis die Stichprobe klein wird, dann setzt Maia die Partie fort.",
+                "playAsLabel": "Spiele als",
+                "databasePlaysLabel": "Datenbank spielt {color}",
+                "minimumGamesLabel": "Mindestens Datenbankpartien",
+                "maiaFallbackRatingLabel": "Maia-Fallback-Wertung",
+                "startPlayModeButton": "Sparring starten",
+                "stopPlayModeButton": "Sparring stoppen"
             }
         },
         "boardButtons": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3449,7 +3449,15 @@
                 "hideSourceTooltip": "Hide source from results",
                 "removeSourceTooltip": "Remove source",
                 "clearDataButton": "Clear Data",
-                "addSourceButton": "Add Source"
+                "addSourceButton": "Add Source",
+                "playModeTitle": "Play vs Repertoire",
+                "playModeDescription": "Use this player's filtered database until the sample gets small, then let Maia continue the game.",
+                "playAsLabel": "Play as",
+                "databasePlaysLabel": "Database plays {color}",
+                "minimumGamesLabel": "Minimum database games",
+                "maiaFallbackRatingLabel": "Maia fallback rating",
+                "startPlayModeButton": "Start Sparring",
+                "stopPlayModeButton": "Stop Sparring"
             }
         },
         "boardButtons": {

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -3449,7 +3449,15 @@
                 "hideSourceTooltip": "[T] Hide source from results",
                 "removeSourceTooltip": "[T] Remove source",
                 "clearDataButton": "[T] Clear Data",
-                "addSourceButton": "[T] Add Source"
+                "addSourceButton": "[T] Add Source",
+                "playModeTitle": "[T] Play vs Repertoire",
+                "playModeDescription": "[T] Use this player's filtered database until the sample gets small, then let Maia continue the game.",
+                "playAsLabel": "[T] Play as",
+                "databasePlaysLabel": "[T] Database plays {color}",
+                "minimumGamesLabel": "[T] Minimum database games",
+                "maiaFallbackRatingLabel": "[T] Maia fallback rating",
+                "startPlayModeButton": "[T] Start Sparring",
+                "stopPlayModeButton": "[T] Stop Sparring"
             }
         },
         "boardButtons": {

--- a/frontend/playwright/tests/e2e/games/view/player-explorer.spec.ts
+++ b/frontend/playwright/tests/e2e/games/view/player-explorer.spec.ts
@@ -64,6 +64,12 @@ async function openPlayerTab(page: import('@playwright/test').Page) {
     await expect(page.getByRole('tab', { name: 'Repertoire Spy', selected: true })).toBeVisible();
 }
 
+/** Navigate to the analysis board and open the Player explorer tab. */
+async function openAnalysisPlayerTab(page: import('@playwright/test').Page) {
+    await page.goto('/games/analysis?explorer=player');
+    await expect(page.getByRole('tab', { name: 'Repertoire Spy', selected: true })).toBeVisible();
+}
+
 test.describe('Player Opening Explorer', () => {
     test.beforeEach(async ({ page }) => {
         // Clear localStorage to reset filter state
@@ -90,6 +96,26 @@ test.describe('Player Opening Explorer', () => {
         await expect(playerTree.getByRole('gridcell', { name: /e4/ })).toBeVisible({
             timeout: 10000,
         });
+    });
+
+    test('starts Repertoire Spy play mode after loading a player tree', async ({ page }) => {
+        await mockChesscomRoutes(page);
+        await openAnalysisPlayerTab(page);
+
+        await page.getByPlaceholder('Chess.com Username').fill('testuser');
+        await page.getByRole('button', { name: 'Load Games' }).click();
+
+        const playerTree = page.getByTestId('explorer-tab-player');
+        await expect(playerTree).toBeVisible({ timeout: 15000 });
+        await expect(playerTree.getByRole('gridcell', { name: /e4/ })).toBeVisible({
+            timeout: 10000,
+        });
+
+        await expect(page.getByRole('button', { name: 'Start Sparring' })).toBeVisible();
+        await page.getByRole('button', { name: 'Start Sparring' }).click();
+        await expect(page.getByRole('button', { name: 'Stop Sparring' })).toBeVisible();
+        await page.getByRole('button', { name: 'Stop Sparring' }).click();
+        await expect(page.getByRole('button', { name: 'Start Sparring' })).toBeVisible();
     });
 
     test('loads Lichess games and displays opening tree', async ({ page }) => {

--- a/frontend/src/app/[locale]/(scoreboard)/games/analysis/AnalysisBoard.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/games/analysis/AnalysisBoard.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import { AuthStatus, useAuth } from '@/auth/Auth';
+import { BoardApi, PrimitiveMove, reconcile } from '@/board/Board';
 import { DefaultUnderboardTab } from '@/board/pgn/boardTools/underboard/underboardTabs';
+import {
+    RepertoireSpyPlayProvider,
+    RepertoireSpyStartOpts,
+} from '@/board/pgn/explorer/player/RepertoireSpyPlayContext';
 import PgnBoard from '@/board/pgn/PgnBoard';
 import { getInitialSidePanelTab, useSidePanelTabs } from '@/board/pgn/sidePanelTabs';
 import SaveGameDialog, { SaveGameDialogType } from '@/components/games/edit/SaveGameDialog';
 import { GameMoveButtonExtras } from '@/components/games/view/GameMoveButtonExtras';
+import { useMaiaGame } from '@/components/playbot/useMaiaGame';
 import { GameContext } from '@/context/useGame';
 import { User } from '@/database/user';
 import PgnErrorBoundary from '@/games/view/PgnErrorBoundary';
@@ -22,7 +28,7 @@ import {
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useNavigationGuard } from 'next-navigation-guard';
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const gameUrlRegex = /^\/games\/.*\/.*/;
 
@@ -55,6 +61,12 @@ export default function AnalysisBoard() {
         },
     });
     const [chess, setChess] = useState<Chess>();
+    const maiaGame = useMaiaGame();
+    const [playInitKey, setPlayInitKey] = useState(0);
+    const [playFen, setPlayFen] = useState<string | null>(null);
+    const [playOrientation, setPlayOrientation] = useState<GameOrientation>(GameOrientations.white);
+    const [isRepertoireSpyPlaying, setIsRepertoireSpyPlaying] = useState(false);
+    const latestChessRef = useRef<Chess | undefined>(undefined);
     const {
         showDialog: showSaveDialog,
         setShowDialog: setShowSaveDialog,
@@ -62,6 +74,79 @@ export default function AnalysisBoard() {
         request,
     } = useUnsavedGame(chess);
     const { leftTabs, rightTabs } = useSidePanelTabs(analysisTabs);
+
+    const onInitialize = useCallback(
+        (board: BoardApi, c: Chess) => {
+            setChess(c);
+            latestChessRef.current = c;
+            maiaGame.onBoardInit(board, c);
+        },
+        [maiaGame],
+    );
+
+    const startRepertoireSpyGame = useCallback(
+        (opts: RepertoireSpyStartOpts) => {
+            setPlayFen(opts.startFen || FEN.start);
+            setPlayOrientation(opts.playerColor);
+            setIsRepertoireSpyPlaying(true);
+            maiaGame.startGame({
+                playerColor: opts.playerColor,
+                maiaRating: opts.maiaRating,
+                startFen: opts.startFen || FEN.start,
+                timeControl: opts.timeControl,
+                botMoveProvider: opts.botMoveProvider,
+            });
+            setPlayInitKey((value) => value + 1);
+        },
+        [maiaGame],
+    );
+
+    const stopRepertoireSpyGame = useCallback(() => {
+        setIsRepertoireSpyPlaying(false);
+        maiaGame.resign();
+    }, [maiaGame]);
+
+    useEffect(() => {
+        if (maiaGame.result !== null) {
+            setIsRepertoireSpyPlaying(false);
+        }
+    }, [maiaGame.result]);
+
+    const repertoireSpyPlayContext = useMemo(
+        () => ({
+            isAvailable: true,
+            isPlaying: isRepertoireSpyPlaying,
+            startRepertoireSpyGame,
+            stopRepertoireSpyGame,
+        }),
+        [isRepertoireSpyPlaying, startRepertoireSpyGame, stopRepertoireSpyGame],
+    );
+
+    const onPlayModeMove = useCallback(
+        (board: BoardApi, c: Chess, primitive: PrimitiveMove) => {
+            if (!isRepertoireSpyPlaying) {
+                return;
+            }
+            if (maiaGame.result !== null) {
+                return;
+            }
+            if (!maiaGame.playerToMove) {
+                return;
+            }
+            if (c.currentMove() !== c.lastMove()) {
+                return;
+            }
+
+            const uci = primitive.orig + primitive.dest + (primitive.promotion ?? '');
+            const moved = c.move(uci);
+            if (!moved) {
+                return;
+            }
+            reconcile(c, board);
+            maiaGame.onPlayerMoved(uci);
+        },
+        [isRepertoireSpyPlaying, maiaGame],
+    );
 
     if (status === AuthStatus.Loading) {
         return <LoadingPage />;
@@ -75,31 +160,41 @@ export default function AnalysisBoard() {
                     unsaved: true,
                 }}
             >
-                <PgnBoard
-                    pgn={pgn}
-                    fen={searchParams.get('fen') || fen}
-                    startOrientation={getDefaultOrientation(pgn, user)}
-                    underboardTabs={leftTabs}
-                    rightTabs={rightTabs}
-                    sidePanelTabs={analysisTabs}
-                    initialUnderboardTab={getInitialSidePanelTab(
-                        leftTabs,
-                        DefaultUnderboardTab.Explorer,
-                    )}
-                    initialRightTab={getInitialSidePanelTab(
-                        rightTabs,
-                        DefaultUnderboardTab.PgnText,
-                    )}
-                    tabStorageKeyPrefix='analysis'
-                    allowMoveDeletion={true}
-                    allowDeleteBefore={true}
-                    showElapsedMoveTimes
-                    slots={{
-                        moveButtonExtras: GameMoveButtonExtras,
-                    }}
-                    disableNullMoves={false}
-                    onInitialize={(_, c) => setChess(c)}
-                />
+                <RepertoireSpyPlayProvider value={repertoireSpyPlayContext}>
+                    <PgnBoard
+                        pgn={pgn}
+                        fen={playFen || searchParams.get('fen') || fen}
+                        startOrientation={
+                            playFen ? playOrientation : getDefaultOrientation(pgn, user)
+                        }
+                        underboardTabs={leftTabs}
+                        rightTabs={rightTabs}
+                        sidePanelTabs={analysisTabs}
+                        initialUnderboardTab={getInitialSidePanelTab(
+                            leftTabs,
+                            DefaultUnderboardTab.Explorer,
+                        )}
+                        initialRightTab={getInitialSidePanelTab(
+                            rightTabs,
+                            DefaultUnderboardTab.PgnText,
+                        )}
+                        tabStorageKeyPrefix='analysis'
+                        allowMoveDeletion={!isRepertoireSpyPlaying}
+                        allowDeleteBefore={!isRepertoireSpyPlaying}
+                        showElapsedMoveTimes
+                        slots={{
+                            moveButtonExtras: GameMoveButtonExtras,
+                        }}
+                        slotProps={{
+                            board: {
+                                onMove: isRepertoireSpyPlaying ? onPlayModeMove : undefined,
+                            },
+                        }}
+                        disableNullMoves={false}
+                        initKey={playFen ? `repertoire-spy-${playInitKey}` : undefined}
+                        onInitialize={onInitialize}
+                    />
+                </RepertoireSpyPlayProvider>
             </GameContext.Provider>
 
             <Dialog

--- a/frontend/src/board/pgn/explorer/player/PlayerTab.tsx
+++ b/frontend/src/board/pgn/explorer/player/PlayerTab.tsx
@@ -18,7 +18,11 @@ import Database from '../Database';
 import { ExplorerDatabaseType } from '../Explorer';
 import { Filters } from './Filters';
 import { usePlayerOpeningTree } from './PlayerOpeningTree';
+import { Color } from './PlayerSource';
 import { PlayerSources } from './PlayerSources';
+import { createRepertoireSpyMoveProvider } from './repertoireSpyMoveProvider';
+import { DEFAULT_REPERTOIRE_SPY_START_FEN, useRepertoireSpyPlay } from './RepertoireSpyPlayContext';
+import { RepertoireSpyPlayControls } from './RepertoireSpyPlayControls';
 import { usePlayerGames } from './usePlayerGames';
 
 function onClickGame(game: GameInfo) {
@@ -41,6 +45,7 @@ export function PlayerTab({ fen }: { fen: string }) {
     const isFreeTier = useFreeTier();
     const pagination = usePlayerGames(fen, openingTree, readonlyFilters);
     const [filtersOpen, setFiltersOpen] = useState(false);
+    const { isAvailable, startRepertoireSpyGame } = useRepertoireSpyPlay();
 
     if (isFreeTier) {
         return (
@@ -54,6 +59,8 @@ export function PlayerTab({ fen }: { fen: string }) {
         setFiltersOpen(false);
         void parentOnLoad();
     };
+
+    const position = openingTree.current?.getPosition(fen, readonlyFilters);
 
     return (
         <Stack>
@@ -97,10 +104,36 @@ export function PlayerTab({ fen }: { fen: string }) {
                 <Database
                     type={ExplorerDatabaseType.Player}
                     fen={fen}
-                    position={openingTree.current?.getPosition(fen, readonlyFilters)}
+                    position={position}
                     isLoading={false}
                     pagination={pagination}
                     onClickGame={onClickGame}
+                />
+            )}
+
+            {isAvailable && openingTree.current && (
+                <RepertoireSpyPlayControls
+                    filters={readonlyFilters}
+                    performanceRating={position?.performanceData?.performanceRating}
+                    onStart={({ playerColor, maiaRating, minGames, timeControl }) => {
+                        if (!openingTree.current) {
+                            return;
+                        }
+                        const databaseColor = playerColor === 'white' ? Color.Black : Color.White;
+                        startRepertoireSpyGame({
+                            playerColor,
+                            maiaRating,
+                            minGames,
+                            timeControl,
+                            startFen: fen || DEFAULT_REPERTOIRE_SPY_START_FEN,
+                            botMoveProvider: createRepertoireSpyMoveProvider({
+                                openingTree: openingTree.current,
+                                filters: readonlyFilters,
+                                databaseColor,
+                                minGames,
+                            }),
+                        });
+                    }}
                 />
             )}
 

--- a/frontend/src/board/pgn/explorer/player/RepertoireSpyPlayContext.tsx
+++ b/frontend/src/board/pgn/explorer/player/RepertoireSpyPlayContext.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { BotMoveProvider } from '@/components/playbot/botMoveProvider';
+import { MaiaRating } from '@/components/playbot/maiaengine';
+import { TimeControl } from '@/components/playbot/PlayBotSetup';
+import { PlayerColor } from '@/components/playbot/useMaiaGame';
+import { FEN } from '@jackstenglein/chess';
+import { createContext, ReactNode, useContext } from 'react';
+
+export interface RepertoireSpyStartOpts {
+    playerColor: PlayerColor;
+    maiaRating: MaiaRating;
+    minGames: number;
+    timeControl: TimeControl;
+    botMoveProvider: BotMoveProvider;
+    startFen?: string;
+}
+
+export interface RepertoireSpyPlayContextValue {
+    isAvailable: boolean;
+    isPlaying: boolean;
+    startRepertoireSpyGame: (opts: RepertoireSpyStartOpts) => void;
+    stopRepertoireSpyGame: () => void;
+}
+
+const defaultValue: RepertoireSpyPlayContextValue = {
+    isAvailable: false,
+    isPlaying: false,
+    startRepertoireSpyGame: () => undefined,
+    stopRepertoireSpyGame: () => undefined,
+};
+
+const RepertoireSpyPlayContext = createContext<RepertoireSpyPlayContextValue>(defaultValue);
+
+export function RepertoireSpyPlayProvider({
+    value,
+    children,
+}: {
+    value: RepertoireSpyPlayContextValue;
+    children: ReactNode;
+}) {
+    return (
+        <RepertoireSpyPlayContext.Provider value={value}>
+            {children}
+        </RepertoireSpyPlayContext.Provider>
+    );
+}
+
+export function useRepertoireSpyPlay() {
+    return useContext(RepertoireSpyPlayContext);
+}
+
+export const DEFAULT_REPERTOIRE_SPY_START_FEN = FEN.start;
+export const DEFAULT_REPERTOIRE_SPY_MIN_GAMES = 3;

--- a/frontend/src/board/pgn/explorer/player/RepertoireSpyPlayControls.test.ts
+++ b/frontend/src/board/pgn/explorer/player/RepertoireSpyPlayControls.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getNearestMaiaRating } from './maiaRating';
+
+describe('getNearestMaiaRating', () => {
+    it('defaults to 1500 when no performance rating is available', () => {
+        expect(getNearestMaiaRating()).toBe(1500);
+    });
+
+    it('returns the nearest supported Maia rating', () => {
+        expect(getNearestMaiaRating(1549)).toBe(1500);
+        expect(getNearestMaiaRating(1551)).toBe(1600);
+        expect(getNearestMaiaRating(580)).toBe(600);
+        expect(getNearestMaiaRating(2630)).toBe(2600);
+    });
+});

--- a/frontend/src/board/pgn/explorer/player/RepertoireSpyPlayControls.tsx
+++ b/frontend/src/board/pgn/explorer/player/RepertoireSpyPlayControls.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { MAIA_RATINGS, MaiaRating } from '@/components/playbot/maiaengine';
+import { TimeControl } from '@/components/playbot/PlayBotSetup';
+import { PlayerColor } from '@/components/playbot/useMaiaGame';
+import { PlayArrow, Stop } from '@mui/icons-material';
+import {
+    Button,
+    Divider,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+import { useTranslations } from 'next-intl';
+import { useEffect, useMemo, useState } from 'react';
+import { getNearestMaiaRating } from './maiaRating';
+import { Color, GameFilters } from './PlayerSource';
+import { DEFAULT_REPERTOIRE_SPY_MIN_GAMES, useRepertoireSpyPlay } from './RepertoireSpyPlayContext';
+
+export interface RepertoireSpyPlayControlsProps {
+    filters: GameFilters;
+    performanceRating?: number;
+    onStart: (opts: {
+        playerColor: PlayerColor;
+        maiaRating: MaiaRating;
+        minGames: number;
+        timeControl: TimeControl;
+    }) => void;
+}
+
+function getDatabaseColor(filters: GameFilters): PlayerColor {
+    if (filters.color === Color.White) {
+        return 'white';
+    }
+    return 'black';
+}
+
+function opposite(color: PlayerColor): PlayerColor {
+    return color === 'white' ? 'black' : 'white';
+}
+
+function parseMaiaRating(value: unknown): MaiaRating {
+    const rating = Number(value);
+    return MAIA_RATINGS.find((candidate) => candidate === rating) ?? 1500;
+}
+
+export function RepertoireSpyPlayControls({
+    filters,
+    performanceRating,
+    onStart,
+}: RepertoireSpyPlayControlsProps) {
+    const t = useTranslations('analysisBoard.explorer.player');
+    const { isPlaying, stopRepertoireSpyGame } = useRepertoireSpyPlay();
+    const defaultMaiaRating = useMemo(
+        () => getNearestMaiaRating(performanceRating),
+        [performanceRating],
+    );
+    const [maiaRating, setMaiaRating] = useState<MaiaRating>(defaultMaiaRating);
+    const [minGames, setMinGames] = useState(DEFAULT_REPERTOIRE_SPY_MIN_GAMES);
+
+    const databaseColor = useMemo(() => getDatabaseColor(filters), [filters]);
+    const playerColor = opposite(databaseColor);
+
+    useEffect(() => {
+        setMaiaRating(defaultMaiaRating);
+    }, [defaultMaiaRating]);
+
+    return (
+        <Stack spacing={1.5} mt={2}>
+            <Divider />
+            <Stack spacing={0.5}>
+                <Typography variant='subtitle2' fontWeight='bold'>
+                    {t('playModeTitle')}
+                </Typography>
+                <Typography variant='caption' color='text.secondary'>
+                    {t('playModeDescription')}
+                </Typography>
+                <Typography variant='caption' color='text.secondary'>
+                    {t('databasePlaysLabel', { color: databaseColor })}
+                </Typography>
+            </Stack>
+
+            <TextField
+                type='number'
+                size='small'
+                label={t('minimumGamesLabel')}
+                value={minGames}
+                onChange={(event) => setMinGames(Math.max(1, Number(event.target.value) || 1))}
+                slotProps={{ htmlInput: { min: 1, step: 1 } }}
+            />
+
+            <FormControl size='small'>
+                <InputLabel>{t('maiaFallbackRatingLabel')}</InputLabel>
+                <Select
+                    label={t('maiaFallbackRatingLabel')}
+                    value={maiaRating}
+                    onChange={(event) => setMaiaRating(parseMaiaRating(event.target.value))}
+                >
+                    {MAIA_RATINGS.map((rating) => (
+                        <MenuItem key={rating} value={rating}>
+                            {rating}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+
+            {isPlaying ? (
+                <Button
+                    variant='outlined'
+                    color='error'
+                    startIcon={<Stop />}
+                    onClick={stopRepertoireSpyGame}
+                >
+                    {t('stopPlayModeButton')}
+                </Button>
+            ) : (
+                <Button
+                    variant='contained'
+                    color='dojoOrange'
+                    startIcon={<PlayArrow />}
+                    onClick={() =>
+                        onStart({
+                            playerColor,
+                            maiaRating,
+                            minGames,
+                            timeControl: { initialMs: null, incrementMs: 0 },
+                        })
+                    }
+                >
+                    {t('startPlayModeButton')}
+                </Button>
+            )}
+        </Stack>
+    );
+}

--- a/frontend/src/board/pgn/explorer/player/maiaRating.ts
+++ b/frontend/src/board/pgn/explorer/player/maiaRating.ts
@@ -1,0 +1,13 @@
+import { MAIA_RATINGS, MaiaRating } from '@/components/playbot/maiaengine';
+
+export function getNearestMaiaRating(rating?: number): MaiaRating {
+    if (rating === undefined || Number.isNaN(rating)) {
+        return 1500;
+    }
+
+    return MAIA_RATINGS.reduce<MaiaRating>((nearest, candidate) => {
+        const nearestDistance = Math.abs(nearest - rating);
+        const candidateDistance = Math.abs(candidate - rating);
+        return candidateDistance < nearestDistance ? candidate : nearest;
+    }, 1500);
+}

--- a/frontend/src/board/pgn/explorer/player/repertoireSpyMoveProvider.test.ts
+++ b/frontend/src/board/pgn/explorer/player/repertoireSpyMoveProvider.test.ts
@@ -1,0 +1,147 @@
+import { GameData } from '@/database/explorer';
+import { GameResult } from '@/database/game';
+import { Chess, FEN } from '@jackstenglein/chess';
+import { describe, expect, it } from 'vitest';
+import { OpeningTree } from './OpeningTree';
+import { Color, GameFilters, MAX_DOWNLOAD_LIMIT, MAX_PLY_COUNT, SourceType } from './PlayerSource';
+import { createRepertoireSpyMoveProvider } from './repertoireSpyMoveProvider';
+
+const filters: GameFilters = {
+    color: Color.Both,
+    win: true,
+    draw: true,
+    loss: true,
+    rated: true,
+    casual: true,
+    bullet: true,
+    blitz: true,
+    rapid: true,
+    classical: true,
+    daily: true,
+    opponentRating: [0, 4000],
+    downloadLimit: MAX_DOWNLOAD_LIMIT,
+    dateRange: ['', ''],
+    plyCount: [0, MAX_PLY_COUNT],
+    hiddenSources: [],
+};
+
+function game(url: string, playerColor = Color.White): GameData {
+    const targetIsWhite = playerColor === Color.White;
+
+    return {
+        source: { type: SourceType.Chesscom, username: 'target' },
+        playerColor,
+        white: targetIsWhite ? 'target' : 'opponent',
+        black: targetIsWhite ? 'opponent' : 'target',
+        whiteElo: 1500,
+        normalizedWhiteElo: 1500,
+        blackElo: 1500,
+        normalizedBlackElo: 1500,
+        result: targetIsWhite ? GameResult.White : GameResult.Black,
+        plyCount: 20,
+        rated: true,
+        url,
+        headers: { Date: '2026.01.01', Site: url },
+        timeClass: 'blitz',
+    } as GameData;
+}
+
+function treeWithStartingMoves(): OpeningTree {
+    const tree = new OpeningTree();
+    tree.setGame(game('g1'));
+    tree.setGame(game('g2'));
+    tree.setGame(game('g3'));
+    tree.setPosition(FEN.start, {
+        white: 3,
+        black: 0,
+        draws: 0,
+        games: new Set(['g1', 'g2', 'g3']),
+        moves: [
+            { san: 'e4', white: 2, black: 0, draws: 0, games: new Set(['g1', 'g2']) },
+            { san: 'd4', white: 1, black: 0, draws: 0, games: new Set(['g3']) },
+        ],
+    });
+    return tree;
+}
+
+function treeWithTargetAndOpponentBlackMoves(fen: string): OpeningTree {
+    const tree = new OpeningTree();
+    tree.setGame(game('target-as-white', Color.White));
+    tree.setGame(game('target-as-black', Color.Black));
+    tree.setPosition(fen, {
+        white: 1,
+        black: 1,
+        draws: 0,
+        games: new Set(['target-as-white', 'target-as-black']),
+        moves: [
+            { san: 'e5', white: 1, black: 0, draws: 0, games: new Set(['target-as-white']) },
+            { san: 'c5', white: 0, black: 1, draws: 0, games: new Set(['target-as-black']) },
+        ],
+    });
+    return tree;
+}
+
+describe('createRepertoireSpyMoveProvider', () => {
+    it('returns null when the filtered position is below the minimum game threshold', async () => {
+        const provider = createRepertoireSpyMoveProvider({
+            openingTree: treeWithStartingMoves(),
+            filters,
+            minGames: 4,
+            random: () => 0,
+        });
+
+        expect(
+            await provider({
+                fen: FEN.start,
+                maiaRating: 1500,
+                plyCount: 0,
+            }),
+        ).toBeNull();
+    });
+
+    it('returns a deterministic weighted legal UCI move from the player tree', async () => {
+        const provider = createRepertoireSpyMoveProvider({
+            openingTree: treeWithStartingMoves(),
+            filters,
+            minGames: 3,
+            random: () => 0,
+        });
+
+        expect(
+            await provider({
+                fen: FEN.start,
+                maiaRating: 1500,
+                plyCount: 0,
+            }),
+        ).toEqual({
+            uci: 'e2e4',
+            san: 'e4',
+            source: 'repertoire-spy',
+        });
+    });
+
+    it('uses only the chosen database color when the source filters include both colors', async () => {
+        const chess = new Chess();
+        chess.move('e4');
+        const fen = chess.fen();
+        const provider = createRepertoireSpyMoveProvider({
+            openingTree: treeWithTargetAndOpponentBlackMoves(fen),
+            filters,
+            databaseColor: Color.Black,
+            minGames: 1,
+            random: () => 0,
+        });
+
+        expect(
+            await provider({
+                fen,
+                maiaRating: 1500,
+                plyCount: 1,
+            }),
+        ).toEqual({
+            uci: 'c7c5',
+            san: 'c5',
+            source: 'repertoire-spy',
+        });
+    });
+});

--- a/frontend/src/board/pgn/explorer/player/repertoireSpyMoveProvider.ts
+++ b/frontend/src/board/pgn/explorer/player/repertoireSpyMoveProvider.ts
@@ -1,0 +1,77 @@
+import { BotMoveProvider, BotMoveResult } from '@/components/playbot/botMoveProvider';
+import { Chess } from '@jackstenglein/chess';
+import { OpeningTree } from './OpeningTree';
+import { Color, GameFilters } from './PlayerSource';
+
+interface RepertoireSpyMoveProviderOptions {
+    openingTree: OpeningTree;
+    filters: GameFilters;
+    databaseColor?: Color.White | Color.Black;
+    minGames: number;
+    random?: () => number;
+}
+
+function moveGameCount(move: { white: number; black: number; draws: number }): number {
+    return move.white + move.black + move.draws;
+}
+
+function toUci(fen: string, san: string): string | null {
+    try {
+        const chess = new Chess({ fen });
+        const move = chess.move(san);
+        if (!move) {
+            return null;
+        }
+        return move.uci ?? `${move.from}${move.to}${move.promotion ?? ''}`;
+    } catch {
+        return null;
+    }
+}
+
+export function createRepertoireSpyMoveProvider({
+    openingTree,
+    filters,
+    databaseColor,
+    minGames,
+    random = Math.random,
+}: RepertoireSpyMoveProviderOptions): BotMoveProvider {
+    const playFilters = databaseColor ? { ...filters, color: databaseColor } : filters;
+
+    return ({ fen }): BotMoveResult | null => {
+        const position = openingTree.getPosition(fen, playFilters);
+        if (!position) {
+            return null;
+        }
+
+        const totalGames = position.white + position.black + position.draws;
+        if (totalGames < minGames) {
+            return null;
+        }
+
+        const candidates = position.moves
+            .map((move) => ({
+                san: move.san,
+                count: moveGameCount(move),
+                uci: toUci(fen, move.san),
+            }))
+            .filter((move): move is { san: string; count: number; uci: string } =>
+                Boolean(move.uci && move.count > 0),
+            );
+
+        if (candidates.length === 0) {
+            return null;
+        }
+
+        const totalWeight = candidates.reduce((sum, move) => sum + move.count, 0);
+        let target = random() * totalWeight;
+        for (const move of candidates) {
+            target -= move.count;
+            if (target <= 0) {
+                return { uci: move.uci, san: move.san, source: 'repertoire-spy' };
+            }
+        }
+
+        const fallback = candidates[candidates.length - 1];
+        return { uci: fallback.uci, san: fallback.san, source: 'repertoire-spy' };
+    };
+}

--- a/frontend/src/components/playbot/botMoveProvider.test.ts
+++ b/frontend/src/components/playbot/botMoveProvider.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveBotMove, type BotMoveContext } from './botMoveProvider';
+
+const context: BotMoveContext = {
+    fen: 'rn1qkbnr/pppbpppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 1 3',
+    maiaRating: 1500,
+    plyCount: 4,
+};
+
+describe('resolveBotMove', () => {
+    it('uses a custom provider result before the Maia fallback', async () => {
+        const provider = vi.fn().mockResolvedValue({
+            uci: 'c2c4',
+            san: 'c4',
+            source: 'repertoire-spy' as const,
+        });
+        const getDefaultOpeningBookMove = vi.fn();
+        const callMaia = vi.fn();
+
+        await expect(
+            resolveBotMove(context, {
+                provider,
+                getDefaultOpeningBookMove,
+                callMaia,
+            }),
+        ).resolves.toEqual({
+            uci: 'c2c4',
+            san: 'c4',
+            source: 'repertoire-spy',
+        });
+
+        expect(provider).toHaveBeenCalledWith(context);
+        expect(getDefaultOpeningBookMove).not.toHaveBeenCalled();
+        expect(callMaia).not.toHaveBeenCalled();
+    });
+
+    it('falls back to Maia when the custom provider and opening book return null', async () => {
+        const provider = vi.fn().mockResolvedValue(null);
+        const getDefaultOpeningBookMove = vi.fn().mockResolvedValue(null);
+        const callMaia = vi.fn().mockResolvedValue({
+            bestMove: 'g1f3',
+            value: 0.54,
+            policy: {},
+        });
+
+        await expect(
+            resolveBotMove(context, {
+                provider,
+                getDefaultOpeningBookMove,
+                callMaia,
+            }),
+        ).resolves.toEqual({
+            uci: 'g1f3',
+            san: undefined,
+            source: 'maia',
+            winProbability: 0.54,
+        });
+    });
+});

--- a/frontend/src/components/playbot/botMoveProvider.ts
+++ b/frontend/src/components/playbot/botMoveProvider.ts
@@ -1,0 +1,57 @@
+import { MaiaEvalResult, MaiaRating, callMaiaApi } from './maiaengine';
+import { getOpeningBookMove } from './openingBook';
+
+export type BotMoveSource = 'book' | 'maia' | 'repertoire-spy';
+
+export interface BotMoveContext {
+    fen: string;
+    maiaRating: MaiaRating;
+    plyCount: number;
+}
+
+export interface BotMoveResult {
+    uci: string;
+    san?: string;
+    source: BotMoveSource;
+    winProbability?: number;
+}
+
+export type BotMoveProvider = (
+    context: BotMoveContext,
+) => BotMoveResult | null | Promise<BotMoveResult | null>;
+
+interface ResolveBotMoveDeps {
+    provider?: BotMoveProvider | null;
+    getDefaultOpeningBookMove?: typeof getOpeningBookMove;
+    callMaia?: typeof callMaiaApi;
+}
+
+export async function resolveBotMove(
+    context: BotMoveContext,
+    {
+        provider,
+        getDefaultOpeningBookMove = getOpeningBookMove,
+        callMaia = callMaiaApi,
+    }: ResolveBotMoveDeps = {},
+): Promise<BotMoveResult | null> {
+    const customMove = await provider?.(context);
+    if (customMove) {
+        return customMove;
+    }
+
+    const bookMove = await getDefaultOpeningBookMove(
+        context.fen,
+        context.maiaRating,
+        context.plyCount,
+    );
+    if (bookMove) {
+        return { ...bookMove, source: 'book' };
+    }
+
+    const evalResult: MaiaEvalResult = await callMaia(context.fen, context.maiaRating);
+    return {
+        uci: evalResult.bestMove,
+        source: 'maia',
+        winProbability: evalResult.value,
+    };
+}

--- a/frontend/src/components/playbot/useMaiaGame.ts
+++ b/frontend/src/components/playbot/useMaiaGame.ts
@@ -5,8 +5,9 @@ import { logger } from '@/logging/logger';
 import { Chess, FEN } from '@jackstenglein/chess';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TimeControl } from './PlayBotSetup';
-import { callMaiaApi, MaiaRating } from './maiaengine';
-import { getOpeningBookMove, OPENING_PLY_LIMIT } from './openingBook';
+import { BotMoveProvider, resolveBotMove } from './botMoveProvider';
+import { MaiaRating } from './maiaengine';
+import { OPENING_PLY_LIMIT } from './openingBook';
 
 export type PlayerColor = 'white' | 'black';
 
@@ -33,6 +34,7 @@ export interface StartOpts {
     maiaRating: MaiaRating;
     startFen?: string;
     timeControl: TimeControl;
+    botMoveProvider?: BotMoveProvider | null;
 }
 
 export interface ClockState {
@@ -118,6 +120,7 @@ export function useMaiaGame(): UseMaiaGameResult {
     const cancelBotRef = useRef(false);
     const moveStartRef = useRef(Date.now());
     const timeControlRef = useRef<TimeControl>(UNLIMITED_TC);
+    const botMoveProviderRef = useRef<BotMoveProvider | null>(null);
     // Track last tick timestamp for accurate countdown
     const clockTickRef = useRef<number>(Date.now());
     const clockIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -234,19 +237,23 @@ export function useMaiaGame(): UseMaiaGameResult {
             const rating = maiaRatingRef.current;
             const plyCount = chess.plyCount();
 
-            // Opening book (Posira API) for the first OPENING_PLY_LIMIT half-moves.
-            // Falls back to Maia silently if no book move is found.
-            let bestMove: string | null = null;
+            const botMove = await resolveBotMove(
+                {
+                    fen,
+                    maiaRating: rating,
+                    plyCount,
+                },
+                {
+                    provider: botMoveProviderRef.current,
+                },
+            );
 
-            const bookMove = await getOpeningBookMove(fen, rating, plyCount);
-            if (bookMove) {
-                bestMove = bookMove.uci;
-            } else if (!cancelBotRef.current) {
-                const evalResult = await callMaiaApi(fen, rating);
+            if (botMove?.winProbability !== undefined) {
                 const isBlack = fen.split(' ')[1] === 'b';
-                setMaiaWinProb(isBlack ? 1 - evalResult.value : evalResult.value);
-                bestMove = evalResult.bestMove || null;
+                setMaiaWinProb(isBlack ? 1 - botMove.winProbability : botMove.winProbability);
             }
+
+            const bestMove = botMove?.uci ?? null;
 
             await new Promise<void>((res) => setTimeout(res, botDelay(plyCount)));
             if (cancelBotRef.current) return;
@@ -359,6 +366,7 @@ export function useMaiaGame(): UseMaiaGameResult {
             playerColorRef.current = opts.playerColor;
             setMaiaRating(opts.maiaRating);
             maiaRatingRef.current = opts.maiaRating;
+            botMoveProviderRef.current = opts.botMoveProvider ?? null;
             setStartFen(opts.startFen || FEN.start);
             setTimeControl(opts.timeControl);
             timeControlRef.current = opts.timeControl;
@@ -403,6 +411,7 @@ export function useMaiaGame(): UseMaiaGameResult {
     const resign = useCallback(() => {
         if (resultRef.current !== null) return;
         cancelBotRef.current = true;
+        botMoveProviderRef.current = null;
         if (clockIntervalRef.current) clearInterval(clockIntervalRef.current);
         clockIntervalRef.current = null;
         setBotThinking(false);


### PR DESCRIPTION
## Summary

Adds a Repertoire Spy sparring mode to the analysis board. After loading a player database, users can start a sparring game where the loaded repertoire plays one side until the filtered sample drops below the configured minimum, then normal Maia fallback continues the game.

## Related Issues

Fixes #2389

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [x] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}

## Demo

**Play vs Repertoire controls**
<img width="1803" height="1084" alt="image" src="https://github.com/user-attachments/assets/9c790538-3048-4865-8c06-2f9b5a5451b8" />