### PR TITLE
feat: add browser exit pop up when suggested variations are unsaved

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1819,6 +1819,13 @@
             "saveAnalysis": "Analyse speichern",
             "analysisNotSaved": "Analyse nicht gespeichert"
         },
+        "unsavedNavigationGuard": {
+            "title": "Nicht gespeicherte Änderungen?",
+            "gameWarning": "Diese Partie hat nicht gespeicherte Änderungen. Wenn du fortnavigierst, können sie dauerhaft gelöscht werden.",
+            "suggestedVariationWarning": "Du hast nicht gespeicherte vorgeschlagene Varianten. Wenn du fortnavigierst, werden sie dauerhaft gelöscht.",
+            "cancel": "Abbrechen",
+            "leave": "Verlassen"
+        },
         "moveExtras": {
             "unsavedVariation": "Diese Variante ist nicht gespeichert. Rechtsklick zum Speichern als Kommentar.",
             "suggestedBy": "Variation vorgeschlagen von {displayName}",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1842,6 +1842,13 @@
             "saveAnalysis": "Save Analysis",
             "analysisNotSaved": "Analysis not saved"
         },
+        "unsavedNavigationGuard": {
+            "title": "Unsaved Changes?",
+            "gameWarning": "This game has unsaved changes. Navigating away may permanently delete them.",
+            "suggestedVariationWarning": "You have unsaved suggested variations. Navigating away will permanently delete them.",
+            "cancel": "Cancel",
+            "leave": "Leave"
+        },
         "moveExtras": {
             "unsavedVariation": "This variation is not saved. Right click to save as a comment.",
             "suggestedBy": "Variation suggested by {displayName}",

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -1842,6 +1842,13 @@
             "saveAnalysis": "[T] Save Analysis",
             "analysisNotSaved": "[T] Analysis not saved"
         },
+        "unsavedNavigationGuard": {
+            "title": "[T] Unsaved Changes?",
+            "gameWarning": "[T] This game has unsaved changes. Navigating away may permanently delete them.",
+            "suggestedVariationWarning": "[T] You have unsaved suggested variations. Navigating away will permanently delete them.",
+            "cancel": "[T] Cancel",
+            "leave": "[T] Leave"
+        },
         "moveExtras": {
             "unsavedVariation": "[T] This variation is not saved. Right click to save as a comment.",
             "suggestedBy": "[T] Variation suggested by {displayName}",

--- a/frontend/src/board/pgn/PgnBoard.tsx
+++ b/frontend/src/board/pgn/PgnBoard.tsx
@@ -1,11 +1,13 @@
 import { useApi } from '@/api/Api';
 import { RequestSnackbar, useRequest } from '@/api/Request';
 import { useAuth } from '@/auth/Auth';
-import useGame from '@/context/useGame';
+import useGame, { GameContext } from '@/context/useGame';
 import LoadingPage from '@/loading/LoadingPage';
 import { Chess, Event, EventType, Move, Observer } from '@jackstenglein/chess';
-import { Box } from '@mui/material';
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 import { Color } from 'chessground/types';
+import { useTranslations } from 'next-intl';
+import { useNavigationGuard } from 'next-navigation-guard';
 import React, {
     createContext,
     forwardRef,
@@ -22,7 +24,10 @@ import React, {
 import { useLocalStorage } from 'usehooks-ts';
 import { BoardApi, onMoveFunc } from '../Board';
 import ResizableContainer from './ResizableContainer';
-import { saveSuggestedVariation } from './boardTools/underboard/comments/suggestVariation';
+import {
+    getUnsavedSuggestedVariationRoots,
+    saveSuggestedVariation,
+} from './boardTools/underboard/comments/suggestVariation';
 import { AutoSaveVariations } from './boardTools/underboard/settings/ViewerSettings';
 import { DefaultUnderboardTab, UnderboardTab } from './boardTools/underboard/underboardTabs';
 import { ButtonProps as MoveButtonProps } from './pgnText/MoveButton';
@@ -131,7 +136,9 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
         },
         ref,
     ) => {
-        const { game, onUpdateGame } = useGame();
+        const t = useTranslations('games.unsavedNavigationGuard');
+        const gameContext = useGame();
+        const { game, onUpdateGame } = gameContext;
         const { user } = useAuth();
         const api = useApi();
         const [autoSaveVariations] = useLocalStorage<boolean>(
@@ -145,10 +152,77 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
 
         const disableNullMoves = disableNullMovesProp ?? !game;
         const [chess] = useState<Chess>(new Chess({ disableNullMoves }));
+        const [hasUnsavedGameChanges, setHasUnsavedGameChanges] = useState(false);
+        const [pendingGameNavigation, setPendingGameNavigation] = useState<{
+            cohort: string;
+            id: string;
+        }>();
         const [orientation, setOrientation] = useState(game?.orientation || startOrientation);
         const keydownMap = useRef<Record<string, boolean>>({});
         const solitaire = useSolitaireChess(chess, board);
         const addEngineMoveRef = useRef<(() => void) | null>(null);
+
+        const hasUnsavedSuggestedVariations = useCallback(() => {
+            if (!game || !user || game.owner === user.username) {
+                return false;
+            }
+            return getUnsavedSuggestedVariationRoots(user, chess).length > 0;
+        }, [chess, game, user]);
+
+        const hasUnsavedBoardChanges = useCallback(() => {
+            return hasUnsavedGameChanges || hasUnsavedSuggestedVariations();
+        }, [hasUnsavedGameChanges, hasUnsavedSuggestedVariations]);
+
+        const navGuard = useNavigationGuard({
+            enabled: hasUnsavedBoardChanges,
+        });
+
+        useEffect(() => {
+            const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+                if (hasUnsavedBoardChanges()) {
+                    e.preventDefault();
+                }
+            };
+
+            window.addEventListener('beforeunload', handleBeforeUnload);
+            return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+        }, [hasUnsavedBoardChanges]);
+
+        const rejectNavigation = useCallback(() => {
+            if (navGuard.active) {
+                navGuard.reject();
+            }
+            setPendingGameNavigation(undefined);
+        }, [navGuard]);
+
+        const acceptNavigation = useCallback(() => {
+            if (pendingGameNavigation) {
+                const { cohort, id } = pendingGameNavigation;
+                setPendingGameNavigation(undefined);
+                gameContext.onNavigateToGame?.(cohort, id);
+                return;
+            }
+
+            navGuard.accept();
+        }, [gameContext, navGuard, pendingGameNavigation]);
+
+        const guardedGameContext = useMemo(
+            () => ({
+                ...gameContext,
+                hasUnsavedGameChanges,
+                setHasUnsavedGameChanges,
+                onNavigateToGame: gameContext.onNavigateToGame
+                    ? (cohort: string, id: string) => {
+                          if (hasUnsavedBoardChanges()) {
+                              setPendingGameNavigation({ cohort, id });
+                              return;
+                          }
+                          gameContext.onNavigateToGame?.(cohort, id);
+                      }
+                    : undefined,
+            }),
+            [gameContext, hasUnsavedBoardChanges, hasUnsavedGameChanges],
+        );
 
         const toggleOrientation = useCallback(() => {
             if (board) {
@@ -290,23 +364,42 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
                 {(pgn || fen) && (
                     <ChessContext.Provider value={chessContext}>
                         <RequestSnackbar request={autoSaveRequest} />
-                        <ResizableContainer
-                            {...{
-                                underboardTabs,
-                                initialUnderboardTab,
-                                rightTabs,
-                                initialRightTab,
-                                tabStorageKeyPrefix,
-                                sidePanelTabs,
-                                showPlayerHeaders,
-                                pgn,
-                                fen,
-                                startOrientation,
-                                onInitialize,
-                            }}
-                        />
+                        <GameContext.Provider value={guardedGameContext}>
+                            <ResizableContainer
+                                {...{
+                                    underboardTabs,
+                                    initialUnderboardTab,
+                                    rightTabs,
+                                    initialRightTab,
+                                    tabStorageKeyPrefix,
+                                    sidePanelTabs,
+                                    showPlayerHeaders,
+                                    pgn,
+                                    fen,
+                                    startOrientation,
+                                    onInitialize,
+                                }}
+                            />
+                        </GameContext.Provider>
                     </ChessContext.Provider>
                 )}
+
+                <Dialog
+                    data-testid='unsaved-board-nav-guard'
+                    open={navGuard.active || Boolean(pendingGameNavigation)}
+                    onClose={rejectNavigation}
+                >
+                    <DialogTitle>{t('title')}</DialogTitle>
+                    <DialogContent>
+                        {hasUnsavedGameChanges ? t('gameWarning') : t('suggestedVariationWarning')}
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={rejectNavigation}>{t('cancel')}</Button>
+                        <Button color='error' onClick={acceptNavigation}>
+                            {t('leave')}
+                        </Button>
+                    </DialogActions>
+                </Dialog>
             </Box>
         );
     },

--- a/frontend/src/board/pgn/boardTools/boardButtons/StatusIcon.tsx
+++ b/frontend/src/board/pgn/boardTools/boardButtons/StatusIcon.tsx
@@ -5,6 +5,7 @@ import { RequestSnackbar, useRequest } from '@/api/Request';
 import { useAuth } from '@/auth/Auth';
 import { useReconcile } from '@/board/Board';
 import { toDojoDateString, toDojoTimeString } from '@/components/calendar/displayDate';
+import useGame from '@/context/useGame';
 import { Game } from '@/database/game';
 import { EventType as ChessEventType, Event } from '@jackstenglein/chess';
 import { GameImportTypes } from '@jackstenglein/chess-dojo-common/src/database/game';
@@ -53,6 +54,7 @@ const StatusIcon: React.FC<StatusIconProps> = ({ game }) => {
     const [undoLog, setUndoLog] = useState<UndoLog[]>([]);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const { user } = useAuth();
+    const { setHasUnsavedGameChanges } = useGame();
     const reconcile = useReconcile();
 
     const onSave = (cohort: string, id: string, pgnText: string, isUndo?: boolean) => {
@@ -124,6 +126,11 @@ const StatusIcon: React.FC<StatusIconProps> = ({ game }) => {
             return () => chess.removeObserver(observer);
         }
     }, [chess, game, initialPgn, setInitialPgn, debouncedOnSave, setHasChanges]);
+
+    useEffect(() => {
+        setHasUnsavedGameChanges?.(hasChanges);
+        return () => setHasUnsavedGameChanges?.(false);
+    }, [hasChanges, setHasUnsavedGameChanges]);
 
     const onRestore = () => {
         setAnchorEl(null);

--- a/frontend/src/context/useGame.ts
+++ b/frontend/src/context/useGame.ts
@@ -6,6 +6,8 @@ export interface GameContextType {
     onUpdateGame?: (g: Game) => void;
     isOwner?: boolean;
     unsaved?: boolean;
+    hasUnsavedGameChanges?: boolean;
+    setHasUnsavedGameChanges?: (hasChanges: boolean) => void;
     /** If defined, the Directories tab calls this instead of router.push when clicking a game. */
     onNavigateToGame?: (cohort: string, id: string) => void;
 }


### PR DESCRIPTION
## Summary

adds a native browser beforeunload listener directly to PgnBoard.tsx. it taps into the existing getUnsavedSuggestedVariationRoots logic.

now, if a user has "Auto Save Variations" turned off and attempts to close the tab with unsaved variations, the browser will natively block them with a "Leave site? Changes you made may not be saved" warning.

## Related Issues

Closes #2426 

## Demo

<img width="1918" height="962" alt="Screenshot 2026-06-19 150056" src="https://github.com/user-attachments/assets/281b0597-75b1-464a-86c6-6ab4bc11d690" />
