### PR TITLE
feat(#2425): Time management rating improvement

### DIFF
--- a/backend/database/games.go
+++ b/backend/database/games.go
@@ -242,6 +242,12 @@ type Game struct {
 
 	// The time management rating for black in this game.
 	TimeManagementRatingBlack int `dynamodbav:"timeManagementRatingBlack,omitempty" json:"timeManagementRatingBlack,omitempty"`
+
+	// The signed time management area for white in this game.
+	TimeManagementAreaWhite float64 `dynamodbav:"timeManagementAreaWhite,omitempty" json:"timeManagementAreaWhite,omitempty"`
+
+	// The signed time management area for black in this game.
+	TimeManagementAreaBlack float64 `dynamodbav:"timeManagementAreaBlack,omitempty" json:"timeManagementAreaBlack,omitempty"`
 }
 
 type Reviewer struct {

--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -387,6 +387,8 @@ type TimeManagementRating struct {
 	CurrentRating int `dynamodbav:"currentRating" json:"currentRating"`
 	// The number of games included in the aggregate
 	NumGames int `dynamodbav:"numGames" json:"numGames"`
+	// The average signed clock area. Positive means too fast, negative means too slow.
+	Area float64 `dynamodbav:"area,omitempty" json:"area,omitempty"`
 }
 
 type PuzzleThemeOverview struct {

--- a/backend/pgnService/game/backfillTimeManagement.ts
+++ b/backend/pgnService/game/backfillTimeManagement.ts
@@ -9,7 +9,7 @@
  *   stage=dev npx tsx pgnService/game/backfillTimeManagement.ts
  *   stage=prod npx tsx pgnService/game/backfillTimeManagement.ts
  *
- * Idempotent: skips games that already have timeManagementRatingWhite set.
+ * Idempotent: skips games that already have time management rating and area fields.
  * User aggregates are rebuilt from scratch on every run.
  */
 import { AttributeValue, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
@@ -35,6 +35,8 @@ interface GameRecord {
     pgn?: string;
     timeManagementRatingWhite?: number;
     timeManagementRatingBlack?: number;
+    timeManagementAreaWhite?: number;
+    timeManagementAreaBlack?: number;
 }
 
 async function main() {
@@ -61,14 +63,15 @@ async function main() {
                     new QueryCommand({
                         KeyConditionExpression: '#cohort = :cohort',
                         FilterExpression:
-                            'attribute_not_exists(timeManagementRatingWhite) and attribute_not_exists(timeManagementRatingBlack)',
+                            '(attribute_exists(timeManagementRatingWhite) and attribute_not_exists(timeManagementAreaWhite)) or (attribute_exists(timeManagementRatingBlack) and attribute_not_exists(timeManagementAreaBlack)) or (attribute_not_exists(timeManagementRatingWhite) and attribute_not_exists(timeManagementRatingBlack))',
                         ExpressionAttributeNames: {
                             '#cohort': 'cohort',
                             '#id': 'id',
                             '#owner': 'owner',
                         },
                         ExpressionAttributeValues: { ':cohort': { S: cohort } },
-                        ProjectionExpression: '#cohort, #id, #owner, orientation, pgn',
+                        ProjectionExpression:
+                            '#cohort, #id, #owner, orientation, pgn, timeManagementRatingWhite, timeManagementRatingBlack, timeManagementAreaWhite, timeManagementAreaBlack',
                         ExclusiveStartKey: startKey,
                         TableName: gamesTable,
                     }),
@@ -85,10 +88,12 @@ async function main() {
                         owners.add(game.owner);
                     }
 
-                    // Skip games that already have TM ratings (idempotent)
+                    // Skip games that already have TM ratings and areas (idempotent)
                     if (
-                        game.timeManagementRatingWhite !== undefined ||
-                        game.timeManagementRatingBlack !== undefined
+                        game.timeManagementRatingWhite !== undefined &&
+                        game.timeManagementRatingBlack !== undefined &&
+                        game.timeManagementAreaWhite !== undefined &&
+                        game.timeManagementAreaBlack !== undefined
                     ) {
                         gamesSkipped++;
                         continue;
@@ -160,12 +165,18 @@ async function main() {
 /**
  * Writes per-game TM ratings to the game record.
  */
-async function updateGameRatings(game: GameRecord, white?: number, black?: number): Promise<void> {
+async function updateGameRatings(
+    game: GameRecord,
+    white?: { rating: number; area: number },
+    black?: { rating: number; area: number },
+): Promise<void> {
     await new UpdateItemBuilder()
         .key('cohort', game.cohort)
         .key('id', game.id)
-        .set('timeManagementRatingWhite', white)
-        .set('timeManagementRatingBlack', black)
+        .set('timeManagementRatingWhite', white?.rating)
+        .set('timeManagementRatingBlack', black?.rating)
+        .set('timeManagementAreaWhite', white?.area)
+        .set('timeManagementAreaBlack', black?.area)
         .table(gamesTable)
         .send();
 }

--- a/backend/pgnService/game/create.ts
+++ b/backend/pgnService/game/create.ts
@@ -329,8 +329,10 @@ export function getGame(
             positionComments: {},
             unlisted: !publish,
             directories: directory ? [directory] : undefined,
-            timeManagementRatingWhite: tmRatings.white,
-            timeManagementRatingBlack: tmRatings.black,
+            timeManagementRatingWhite: tmRatings.white?.rating,
+            timeManagementRatingBlack: tmRatings.black?.rating,
+            timeManagementAreaWhite: tmRatings.white?.area,
+            timeManagementAreaBlack: tmRatings.black?.area,
         };
 
         if (publish) {
@@ -492,7 +494,7 @@ export async function createTimelineEntry(game: Game) {
  * @param games The newly created games.
  */
 async function updateUserTimeManagementRating(user: User, games: Game[]): Promise<void> {
-    const newRatings: number[] = [];
+    const newRatings: { rating: number; area: number }[] = [];
     games.sort((lhs, rhs) => (lhs.date || lhs.createdAt).localeCompare(rhs.date || rhs.createdAt));
 
     for (const game of games) {
@@ -500,9 +502,13 @@ async function updateUserTimeManagementRating(user: User, games: Game[]): Promis
             game.orientation === 'black'
                 ? game.timeManagementRatingBlack
                 : game.timeManagementRatingWhite;
+        const ownerArea =
+            game.orientation === 'black'
+                ? game.timeManagementAreaBlack
+                : game.timeManagementAreaWhite;
 
         if (ownerRating !== undefined) {
-            newRatings.push(ownerRating);
+            newRatings.push({ rating: ownerRating, area: ownerArea ?? 0 });
         }
     }
 
@@ -513,7 +519,7 @@ async function updateUserTimeManagementRating(user: User, games: Game[]): Promis
     try {
         let rating = user.timeManagementRating;
         for (const gameRating of newRatings) {
-            rating = newTimeManagementRating(rating, gameRating);
+            rating = newTimeManagementRating(rating, gameRating.rating, gameRating.area);
         }
 
         if (rating) {

--- a/backend/pgnService/game/timeManagement.test.ts
+++ b/backend/pgnService/game/timeManagement.test.ts
@@ -38,8 +38,10 @@ test('returns exact ratings for Fang vs Kraai (US Masters 2025)', () => {
     const chess = new Chess({ pgn: classicalPgnWithClocks });
     const ratings = rateGameTimeManagement(chess);
 
-    assert.equal(ratings.white, 2478);
-    assert.equal(ratings.black, 2456);
+    assert.equal(ratings.white?.rating, 2478);
+    assert.equal(ratings.black?.rating, 2456);
+    assert.isNumber(ratings.white?.area);
+    assert.isNumber(ratings.black?.area);
 });
 
 test('returns undefined for blitz game (time control < 30 min)', () => {
@@ -84,6 +86,8 @@ test('getGame populates exact TM rating fields for classical game with clocks', 
 
     assert.equal(game.timeManagementRatingWhite, 2478);
     assert.equal(game.timeManagementRatingBlack, 2456);
+    assert.isNumber(game.timeManagementAreaWhite);
+    assert.isNumber(game.timeManagementAreaBlack);
 });
 
 test('getGame does not populate TM rating fields for blitz game', async () => {

--- a/backend/pgnService/game/timeManagement.ts
+++ b/backend/pgnService/game/timeManagement.ts
@@ -19,9 +19,14 @@ import {
 import { GetItemBuilder, UpdateItemBuilder } from '../../directoryService/database';
 import { directoriesTable, dynamo, gamesTable, usersTable } from './database';
 
+interface TimeManagementGameRating {
+    rating: number;
+    area: number;
+}
+
 export interface TimeManagementRatings {
-    white?: number;
-    black?: number;
+    white?: TimeManagementGameRating;
+    black?: TimeManagementGameRating;
 }
 
 /**
@@ -69,8 +74,8 @@ export function rateGameTimeManagement(chess: Chess): TimeManagementRatings {
     const blackResult = calculateTimeRating(timeControls, blackClock);
 
     return {
-        white: whiteResult?.rating,
-        black: blackResult?.rating,
+        white: whiteResult,
+        black: blackResult,
     };
 }
 
@@ -142,7 +147,13 @@ async function getGameKeys(owner: string): Promise<GameKey[]> {
 
 type PartialGame = Pick<
     Game,
-    'date' | 'createdAt' | 'orientation' | 'timeManagementRatingWhite' | 'timeManagementRatingBlack'
+    | 'date'
+    | 'createdAt'
+    | 'orientation'
+    | 'timeManagementRatingWhite'
+    | 'timeManagementRatingBlack'
+    | 'timeManagementAreaWhite'
+    | 'timeManagementAreaBlack'
 >;
 
 /**
@@ -165,7 +176,7 @@ async function rateAllGamesTimeManagement(gameKeys: GameKey[]): Promise<TimeMana
                         [gamesTable]: {
                             Keys: keys,
                             ProjectionExpression:
-                                '#date, createdAt, orientation, timeManagementRatingWhite, timeManagementRatingBlack',
+                                '#date, createdAt, orientation, timeManagementRatingWhite, timeManagementRatingBlack, timeManagementAreaWhite, timeManagementAreaBlack',
                             ExpressionAttributeNames: { '#date': 'date' },
                         },
                     },
@@ -186,9 +197,13 @@ async function rateAllGamesTimeManagement(gameKeys: GameKey[]): Promise<TimeMana
             game.orientation === 'black'
                 ? game.timeManagementRatingBlack
                 : game.timeManagementRatingWhite;
+        const ownerArea =
+            game.orientation === 'black'
+                ? game.timeManagementAreaBlack
+                : game.timeManagementAreaWhite;
 
         if (ownerRating !== undefined && ownerRating >= 0) {
-            aggregate = newTimeManagementRating(aggregate, ownerRating);
+            aggregate = newTimeManagementRating(aggregate, ownerRating, ownerArea ?? 0);
         }
     }
 

--- a/backend/pgnService/game/types.ts
+++ b/backend/pgnService/game/types.ts
@@ -70,6 +70,12 @@ export interface Game {
 
     /** The time management rating for black in this game. */
     timeManagementRatingBlack?: number;
+
+    /** The signed time management area for white in this game. */
+    timeManagementAreaWhite?: number;
+
+    /** The signed time management area for black in this game. */
+    timeManagementAreaBlack?: number;
 }
 
 export interface GameUpdate {
@@ -108,6 +114,12 @@ export interface GameUpdate {
 
     /** The time management rating for black in this game. */
     timeManagementRatingBlack?: number;
+
+    /** The signed time management area for white in this game. */
+    timeManagementAreaWhite?: number;
+
+    /** The signed time management area for black in this game. */
+    timeManagementAreaBlack?: number;
 }
 
 export interface GameImportHeaders {
@@ -136,12 +148,7 @@ function stripPlayerNameHeader(value?: string): string {
  * @param game The game to check for publishability
  * @returns An error message if the update is missing data.
  */
-export function isMissingData({
-    white,
-    black,
-    result,
-    date,
-}: Partial<GameImportHeaders>): string {
+export function isMissingData({ white, black, result, date }: Partial<GameImportHeaders>): string {
     const strippedWhite = stripPlayerNameHeader(white);
     if (!strippedWhite) {
         return `invalid White header: '${white}'`;

--- a/backend/pgnService/game/update.ts
+++ b/backend/pgnService/game/update.ts
@@ -67,6 +67,8 @@ async function updateGame(event: APIGatewayProxyEventV2): Promise<APIGatewayProx
     if (
         result.old.timeManagementRatingWhite !== result.new.timeManagementRatingWhite ||
         result.old.timeManagementRatingBlack !== result.new.timeManagementRatingBlack ||
+        result.old.timeManagementAreaWhite !== result.new.timeManagementAreaWhite ||
+        result.old.timeManagementAreaBlack !== result.new.timeManagementAreaBlack ||
         result.old.orientation !== result.new.orientation ||
         result.old.directories !== result.new.directories
     ) {
@@ -115,6 +117,8 @@ async function getGameUpdate(request: UpdateGameRequest): Promise<GameUpdate> {
         update.headers = game.headers;
         update.timeManagementRatingWhite = game.timeManagementRatingWhite ?? -1;
         update.timeManagementRatingBlack = game.timeManagementRatingBlack ?? -1;
+        update.timeManagementAreaWhite = game.timeManagementAreaWhite ?? 0;
+        update.timeManagementAreaBlack = game.timeManagementAreaBlack ?? 0;
 
         const result = game.headers['Result'];
         const missingDataErr = isMissingData({ ...update, result });

--- a/common/src/database/game.ts
+++ b/common/src/database/game.ts
@@ -315,6 +315,12 @@ export interface GameInfo extends GameKey {
 
     /** The time management rating for black in this game. */
     timeManagementRatingBlack?: number;
+
+    /** The signed time management area for white in this game. */
+    timeManagementAreaWhite?: number;
+
+    /** The signed time management area for black in this game. */
+    timeManagementAreaBlack?: number;
 }
 
 export interface CommentOwner {

--- a/common/src/ratings/timeManagement.test.ts
+++ b/common/src/ratings/timeManagement.test.ts
@@ -16,6 +16,14 @@ describe('newTimeManagementRating', () => {
         assert.equal(result.numGames, 1);
     });
 
+    test('stores first game signed area', () => {
+        const result = newTimeManagementRating(undefined, 2000, 125);
+
+        assert.equal(result.currentRating, 2000);
+        assert.equal(result.numGames, 1);
+        assert.equal(result.area, 125);
+    });
+
     test('computes running average for < 10 games', () => {
         let agg = newTimeManagementRating(undefined, 2000);
         agg = newTimeManagementRating(agg, 2100);
@@ -23,6 +31,24 @@ describe('newTimeManagementRating', () => {
 
         assert.equal(agg.numGames, 3);
         assert.equal(agg.currentRating, Math.round((2000 + 2100 + 1900) / 3));
+    });
+
+    test('computes running average signed area', () => {
+        let agg = newTimeManagementRating(undefined, 2000, 100);
+        agg = newTimeManagementRating(agg, 2100, -40);
+        agg = newTimeManagementRating(agg, 1900, 30);
+
+        assert.equal(agg.numGames, 3);
+        assert.equal(agg.currentRating, Math.round((2000 + 2100 + 1900) / 3));
+        assert.closeTo(agg.area ?? 0, 30, 0.000001);
+    });
+
+    test('treats missing legacy area as neutral', () => {
+        const result = newTimeManagementRating({ currentRating: 2000, numGames: 1 }, 2200);
+
+        assert.equal(result.numGames, 2);
+        assert.equal(result.currentRating, 2100);
+        assert.equal(result.area, 0);
     });
 
     test('is provisional for < 10 games', () => {

--- a/common/src/ratings/timeManagement.ts
+++ b/common/src/ratings/timeManagement.ts
@@ -13,6 +13,8 @@ export interface TimeManagementRating {
     currentRating: number;
     /** The number of games included in the aggregate. */
     numGames: number;
+    /** The average signed clock area. Positive means too fast, negative means too slow. */
+    area?: number;
 }
 
 /**
@@ -37,6 +39,15 @@ function calculateRating(currentRating: number, gameRating: number): number {
     return Math.round(currentRating + K_FACTOR * (DRAW_SCORE - expected));
 }
 
+function calculateAverageArea(
+    current: TimeManagementRating | undefined,
+    gameArea: number,
+    newCount: number,
+): number {
+    const currentArea = current?.area ?? 0;
+    return currentArea + (gameArea - currentArea) / newCount;
+}
+
 /**
  * Incrementally updates the time management aggregate with a new game rating
  * and returns the new rating. The current rating is left unchanged.
@@ -45,29 +56,33 @@ function calculateRating(currentRating: number, gameRating: number): number {
  *
  * @param current The current aggregate, or undefined if this is the user's first game.
  * @param gameRating The time management rating from the new game.
+ * @param gameArea The signed clock area from the new game.
  * @returns The new aggregate rating.
  */
 export function newTimeManagementRating(
     current: TimeManagementRating | undefined,
     gameRating: number,
+    gameArea = 0,
 ): TimeManagementRating {
-    if (!current) {
-        return { currentRating: gameRating, numGames: 1 };
+    if (!current || current.numGames <= 0) {
+        return { currentRating: gameRating, numGames: 1, area: gameArea };
     }
 
     const newCount = current.numGames + 1;
+    const area = calculateAverageArea(current, gameArea, newCount);
 
     if (newCount <= MIN_GAMES_FOR_ELO) {
         // Running average: newAvg = oldAvg + (gameRating - oldAvg) / newCount
         const newRating = Math.round(
             current.currentRating + (gameRating - current.currentRating) / newCount,
         );
-        return { currentRating: newRating, numGames: newCount };
+        return { currentRating: newRating, numGames: newCount, area };
     }
 
     // Elo draw adjustment
     return {
         currentRating: calculateRating(current.currentRating, gameRating),
         numGames: newCount,
+        area,
     };
 }

--- a/frontend/src/components/profile/info/DojoScoreCard.tsx
+++ b/frontend/src/components/profile/info/DojoScoreCard.tsx
@@ -22,13 +22,12 @@ import { CrossedSwordIcon } from '@/style/CrossedSwordIcon';
 import { RatingSystemIcon } from '@/style/RatingSystemIcons';
 import { CategoryColors } from '@/style/ThemeProvider';
 import { isCustom } from '@jackstenglein/chess-dojo-common/src/ratings/ratings';
-import { MIN_GAMES_FOR_ELO } from '@jackstenglein/chess-dojo-common/src/ratings/timeManagement';
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
-import { Card, CardContent, Grid, Stack, Tooltip, Typography } from '@mui/material';
+import { Card, CardContent, Grid, Stack, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import React from 'react';
 import { useTimelineContext } from '../activity/useTimeline';
 import { CLASSICAL_GAMES_TASK_ID } from '../trainingPlan/suggestedTasks';
+import { TimeManagementRatingRow } from './TimeManagementRatingRow';
 
 const categories = [
     RequirementCategory.Games,
@@ -232,31 +231,7 @@ const DojoScoreCard: React.FC<DojoScoreCardProps> = ({ user, cohort }) => {
                     })}
 
                     {timeManagementRating && timeManagementRating.currentRating > 0 && (
-                        <Grid size={12}>
-                            <Tooltip title='Time Management Rating is calculated from the classical games in your My Games folder (and subfolders).'>
-                                <Stack direction='row' alignItems='center' gap={0.5}>
-                                    <AccessTimeIcon
-                                        sx={{ fontSize: 15, color: 'text.secondary' }}
-                                    />
-                                    <Typography
-                                        variant='body2'
-                                        color='text.secondary'
-                                        sx={{ fontWeight: 'bold' }}
-                                    >
-                                        Time Management
-                                    </Typography>
-                                    <Typography
-                                        variant='body2'
-                                        color='text.secondary'
-                                        sx={{ ml: 'auto', fontWeight: 'bold' }}
-                                    >
-                                        {timeManagementRating.currentRating}
-                                        {(timeManagementRating.numGames ?? 0) < MIN_GAMES_FOR_ELO &&
-                                            '?'}
-                                    </Typography>
-                                </Stack>
-                            </Tooltip>
-                        </Grid>
+                        <TimeManagementRatingRow timeManagementRating={timeManagementRating} />
                     )}
                 </Grid>
             </CardContent>

--- a/frontend/src/components/profile/info/TimeManagementRatingRow.test.tsx
+++ b/frontend/src/components/profile/info/TimeManagementRatingRow.test.tsx
@@ -17,6 +17,9 @@ describe('TimeManagementRatingRow', () => {
         expect(screen.getByText('2100')).toBeInTheDocument();
         expect(screen.getByText('(12 games)')).toBeInTheDocument();
         expect(screen.getByTestId('time-management-fast-icon')).toBeInTheDocument();
+        expect(
+            screen.getByLabelText('You tend to play faster than the ideal clock curve on average.'),
+        ).toBeInTheDocument();
     });
 
     it('shows a sloth for negative average area', () => {
@@ -27,6 +30,9 @@ describe('TimeManagementRatingRow', () => {
         );
 
         expect(screen.getByTestId('time-management-slow-icon')).toBeInTheDocument();
+        expect(
+            screen.getByLabelText('You tend to play slower than the ideal clock curve on average.'),
+        ).toBeInTheDocument();
     });
 
     it('shows no direction icon for neutral or missing area', () => {

--- a/frontend/src/components/profile/info/TimeManagementRatingRow.test.tsx
+++ b/frontend/src/components/profile/info/TimeManagementRatingRow.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TimeManagementRatingRow } from './TimeManagementRatingRow';
+
+afterEach(() => {
+    cleanup();
+});
+
+describe('TimeManagementRatingRow', () => {
+    it('shows a bunny for positive average area', () => {
+        render(
+            <TimeManagementRatingRow
+                timeManagementRating={{ currentRating: 2100, numGames: 12, area: 25 }}
+            />,
+        );
+
+        expect(screen.getByText('2100')).toBeInTheDocument();
+        expect(screen.getByText('(12 games)')).toBeInTheDocument();
+        expect(screen.getByTestId('time-management-fast-icon')).toBeInTheDocument();
+    });
+
+    it('shows a sloth for negative average area', () => {
+        render(
+            <TimeManagementRatingRow
+                timeManagementRating={{ currentRating: 1800, numGames: 11, area: -40 }}
+            />,
+        );
+
+        expect(screen.getByTestId('time-management-slow-icon')).toBeInTheDocument();
+    });
+
+    it('shows no direction icon for neutral or missing area', () => {
+        render(
+            <TimeManagementRatingRow
+                timeManagementRating={{ currentRating: 2000, numGames: 10 }}
+            />,
+        );
+
+        expect(screen.queryByTestId('time-management-fast-icon')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('time-management-slow-icon')).not.toBeInTheDocument();
+    });
+
+    it('marks ratings with fewer than 10 games as provisional', () => {
+        render(
+            <TimeManagementRatingRow
+                timeManagementRating={{ currentRating: 1900, numGames: 4, area: 10 }}
+            />,
+        );
+
+        expect(screen.getByText('1900?')).toBeInTheDocument();
+        expect(screen.getByText('(4 games)')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/profile/info/TimeManagementRatingRow.tsx
+++ b/frontend/src/components/profile/info/TimeManagementRatingRow.tsx
@@ -1,0 +1,70 @@
+import { RabbitIcon } from '@/style/RabbitIcon';
+import { SlothIcon } from '@/style/SlothIcon';
+import {
+    MIN_GAMES_FOR_ELO,
+    TimeManagementRating,
+} from '@jackstenglein/chess-dojo-common/src/ratings/timeManagement';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import { Grid, Stack, Tooltip, Typography } from '@mui/material';
+
+function gameCountLabel(numGames: number): string {
+    return `(${numGames} ${numGames === 1 ? 'game' : 'games'})`;
+}
+
+function TimeManagementDirectionIcon({ area }: { area?: number }) {
+    if (!area) {
+        return null;
+    }
+
+    if (area > 0) {
+        return (
+            <RabbitIcon
+                data-testid='time-management-fast-icon'
+                sx={{ fontSize: 17, color: 'text.secondary' }}
+            />
+        );
+    }
+
+    return (
+        <SlothIcon
+            data-testid='time-management-slow-icon'
+            sx={{ fontSize: 17, color: 'text.secondary' }}
+        />
+    );
+}
+
+export function TimeManagementRatingRow({
+    timeManagementRating,
+}: {
+    timeManagementRating: TimeManagementRating;
+}) {
+    const numGames = timeManagementRating.numGames ?? 0;
+    const provisional = numGames < MIN_GAMES_FOR_ELO;
+
+    return (
+        <Grid size={12}>
+            <Tooltip title='Time Management Rating is calculated from the classical games in your My Games folder (and subfolders).'>
+                <Stack direction='row' alignItems='center' gap={0.5}>
+                    <AccessTimeIcon sx={{ fontSize: 15, color: 'text.secondary' }} />
+                    <Typography variant='body2' color='text.secondary' sx={{ fontWeight: 'bold' }}>
+                        Time Management
+                    </Typography>
+                    <Stack direction='row' alignItems='center' gap={0.5} sx={{ ml: 'auto' }}>
+                        <TimeManagementDirectionIcon area={timeManagementRating.area} />
+                        <Typography
+                            variant='body2'
+                            color='text.secondary'
+                            sx={{ fontWeight: 'bold' }}
+                        >
+                            {timeManagementRating.currentRating}
+                            {provisional && '?'}
+                        </Typography>
+                        <Typography variant='body2' color='text.secondary'>
+                            {gameCountLabel(numGames)}
+                        </Typography>
+                    </Stack>
+                </Stack>
+            </Tooltip>
+        </Grid>
+    );
+}

--- a/frontend/src/components/profile/info/TimeManagementRatingRow.tsx
+++ b/frontend/src/components/profile/info/TimeManagementRatingRow.tsx
@@ -11,6 +11,9 @@ function gameCountLabel(numGames: number): string {
     return `(${numGames} ${numGames === 1 ? 'game' : 'games'})`;
 }
 
+const fastTooltip = 'You tend to play faster than the ideal clock curve on average.';
+const slowTooltip = 'You tend to play slower than the ideal clock curve on average.';
+
 function TimeManagementDirectionIcon({ area }: { area?: number }) {
     if (!area) {
         return null;
@@ -18,18 +21,26 @@ function TimeManagementDirectionIcon({ area }: { area?: number }) {
 
     if (area > 0) {
         return (
-            <RabbitIcon
-                data-testid='time-management-fast-icon'
-                sx={{ fontSize: 17, color: 'text.secondary' }}
-            />
+            <Tooltip title={fastTooltip}>
+                <span>
+                    <RabbitIcon
+                        data-testid='time-management-fast-icon'
+                        sx={{ fontSize: 17, color: 'text.secondary' }}
+                    />
+                </span>
+            </Tooltip>
         );
     }
 
     return (
-        <SlothIcon
-            data-testid='time-management-slow-icon'
-            sx={{ fontSize: 17, color: 'text.secondary' }}
-        />
+        <Tooltip title={slowTooltip}>
+            <span>
+                <SlothIcon
+                    data-testid='time-management-slow-icon'
+                    sx={{ fontSize: 17, color: 'text.secondary' }}
+                />
+            </span>
+        </Tooltip>
     );
 }
 


### PR DESCRIPTION
## Summary

Adds time-management direction to profile ratings by tracking signed clock area, showing a bunny/sloth icon with the rated game count, and updating the backfill script so existing games can be populated after deployment.

## Related Issues

Fixes #2425

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}
