### PR TITLE
fix(#2315): force hard reload on cross-COEP navigation

### DIFF
--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import { MetaPixel } from '@/components/analytics/MetaPixel';
 import { WebVitals } from '@/components/analytics/WebVitals';
+import { CoepBoundaryGuard } from '@/components/navigation/CoepBoundaryGuard';
 import { getConfig } from '@/config';
 import { DEFAULT_LOCALE, LOCALE_CODES } from '@/i18n/locales';
 import { routing } from '@/i18n/routing';
@@ -77,6 +78,7 @@ export default async function LocaleLayout({
             </head>
             <body>
                 <NavigationGuardProvider>
+                    <CoepBoundaryGuard />
                     <MetaPixel />
                     <WebVitals />
                     <div id='root'>

--- a/frontend/src/components/navigation/CoepBoundaryGuard.tsx
+++ b/frontend/src/components/navigation/CoepBoundaryGuard.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { pagesWithVideos } from '@/hooks/useRouter';
+import { LOCALE_CODES } from '@/i18n/locales';
+// next/navigation, not @/i18n/navigation, so this can mount above the intl provider.
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+const LOCALE_PREFIX_REGEX = new RegExp(`^/(${LOCALE_CODES.join('|')})(?=/|$)`);
+
+function canonicalPath(input: string): string {
+    const noQuery = input.split('?')[0].split('#')[0];
+    return noQuery.replace(LOCALE_PREFIX_REGEX, '') || '/';
+}
+
+function isVideoPage(pathname: string): boolean {
+    return pagesWithVideos.some((page) => pathname.match(page));
+}
+
+/**
+ * Reloads the page when its cross-origin-isolation state doesn't match the
+ * route. Engine pages need isolation (COEP require-corp) for Stockfish; video
+ * pages need it off (unsafe-none) for cross-origin iframes. A soft navigation
+ * across that boundary keeps the previous page's headers, breaking videos on
+ * `/profile` etc. (#2315). We let navigation proceed — preserving page-level
+ * unsaved-changes prompts — then hard reload to fetch the correct headers.
+ */
+export function CoepBoundaryGuard() {
+    const pathname = usePathname();
+
+    useEffect(() => {
+        const needsVideo = isVideoPage(canonicalPath(pathname));
+        const key = `coep-reloaded:${pathname}`;
+
+        if (window.crossOriginIsolated !== needsVideo) {
+            sessionStorage.removeItem(key);
+            return;
+        }
+
+        // Reload once per path: a stuck marker means the server headers disagree
+        // with pagesWithVideos, where reloading again would never converge.
+        if (!sessionStorage.getItem(key)) {
+            sessionStorage.setItem(key, '1');
+            window.location.reload();
+        }
+    }, [pathname]);
+
+    return null;
+}


### PR DESCRIPTION
## Summary

Navigating between an engine-isolated page ("/games/analysis", "/play-bot", …) and a video-embedding page ("/profile", "/learn/sparring", …) left the destination with the source page's COEP/COOP headers. On Firefox this surfaces as a "security configuration error" and videos fail to load.

This fix adds a small "CoepBoundaryGuard" mounted in the root layout. On each client navigation it compares the landed-on document's isolation state ("window.crossOriginIsolated") against what the route needs (per "pagesWithVideos") and forces a one-time hard reload when they mismatch, so the server can send the correct headers. A sessionStorage marker prevents reload loops in case the client/server page lists ever drift.

## Related Issues

Link to any relevant issues or tickets to provide context.
Fixes #2315

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to: manual testing

## Demo

not applicable
