### PR TITLE
fix(#2442): improve progress history dialog performance

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -261,7 +261,7 @@
                 "fillInDetails": "Trag die Details unten ein",
                 "cohort": "Kohorte",
                 "deleteEntry": "Eintrag löschen",
-                "totalCount": "Gesamt {label} : {total}. Aktuelle Kohorte: {cohortCount}",
+                "totalCount": "Gesamt {label}: {total}. Aktuelle Kohorte: {cohortCount}",
                 "totalTime": "Gesamtzeit: {totalHours}h {totalMinutes}m. Aktuelle Kohorte: {cohortHours}h {cohortMinutes}m",
                 "deleteAriaLabel": "Löschen"
             },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -284,7 +284,7 @@
                 "fillInDetails": "Fill in the details below",
                 "cohort": "Cohort",
                 "deleteEntry": "Delete entry",
-                "totalCount": "Total {label} : {total}. Current Cohort: {cohortCount}",
+                "totalCount": "Total {label}: {total}. Current Cohort: {cohortCount}",
                 "totalTime": "Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
                 "deleteAriaLabel": "delete"
             },

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -261,7 +261,7 @@
                 "fillInDetails": "Compila i dettagli qui sotto",
                 "cohort": "Coorte",
                 "deleteEntry": "Elimina voce",
-                "totalCount": "Totale {label} : {total}. Coorte attuale: {cohortCount}",
+                "totalCount": "Totale {label}: {total}. Coorte attuale: {cohortCount}",
                 "totalTime": "Tempo totale: {totalHours}h {totalMinutes}m. Coorte attuale: {cohortHours}h {cohortMinutes}m",
                 "deleteAriaLabel": "elimina"
             },

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -284,7 +284,7 @@
                 "fillInDetails": "[T] Fill in the details below",
                 "cohort": "[T] Cohort",
                 "deleteEntry": "[T] Delete entry",
-                "totalCount": "[T] Total {label} : {total}. Current Cohort: {cohortCount}",
+                "totalCount": "[T] Total {label}: {total}. Current Cohort: {cohortCount}",
                 "totalTime": "[T] Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
                 "deleteAriaLabel": "[T] delete"
             },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,6 +58,7 @@
                 "react-markdown": "^10.1.0",
                 "react-minimal-pie-chart": "^9.1.2",
                 "react-resizable": "^3.1.3",
+                "react-virtuoso": "^4.18.10",
                 "remark-gfm": "^4.0.1",
                 "rrule": "^2.8.1",
                 "sharp": "^0.34.5",
@@ -14435,6 +14436,16 @@
             "peerDependencies": {
                 "react": ">= 16.3",
                 "react-dom": ">= 16.3"
+            }
+        },
+        "node_modules/react-virtuoso": {
+            "version": "4.18.10",
+            "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.10.tgz",
+            "integrity": "sha512-P6GIZ7kWAPOYB2H16yRQNgy+VF9pJOuTFw1EUc1EAtCj5WxVSAF1Sql3x3fbLwaLeBFsiPnu+3U9o6sIOyTdFw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16 || >=17 || >= 18 || >= 19",
+                "react-dom": ">=16 || >=17 || >= 18 || >=19"
             }
         },
         "node_modules/react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -100,6 +100,7 @@
         "react-markdown": "^10.1.0",
         "react-minimal-pie-chart": "^9.1.2",
         "react-resizable": "^3.1.3",
+        "react-virtuoso": "^4.18.10",
         "remark-gfm": "^4.0.1",
         "rrule": "^2.8.1",
         "sharp": "^0.34.5",

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
@@ -15,7 +15,8 @@ import {
     Typography,
 } from '@mui/material';
 import { useTranslations } from 'next-intl';
-import { ProgressHistoryItem, useProgressHistoryEditor } from '../trainingPlan/ProgressHistory';
+import { useProgressHistoryEditor } from '../trainingPlan/ProgressHistory';
+import { ProgressHistoryItem } from '../trainingPlan/ProgressHistoryItem';
 
 export function EditTimelinEntryDialog({
     entry,
@@ -51,8 +52,10 @@ export function EditTimelinEntryDialog({
         cohortTime,
         totalCount,
         totalTime,
-        getUpdateItem,
-        getDeleteItem,
+        updateItem,
+        updateDraftItem,
+        getDraftItem,
+        deleteItem,
         onSubmit,
     } = useProgressHistoryEditor({
         requirement,
@@ -140,10 +143,12 @@ export function EditTimelinEntryDialog({
                 <Box sx={{ mt: 1 }}>
                     <ProgressHistoryItem
                         requirement={requirement}
-                        item={items[index]}
+                        item={getDraftItem(index) ?? items[index]}
                         error={errors[index] || {}}
-                        updateItem={getUpdateItem(index)}
-                        deleteItem={getDeleteItem(index)}
+                        itemIndex={index}
+                        updateItem={updateItem}
+                        updateDraftItem={updateDraftItem}
+                        deleteItem={deleteItem}
                     />
                 </Box>
 

--- a/frontend/src/components/profile/trainingPlan/ProgressHistory.recompute.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistory.recompute.test.tsx
@@ -1,0 +1,485 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { TimelineEntry } from '@/database/timeline';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { DateTime } from 'luxon';
+import { NextIntlClientProvider } from 'next-intl';
+import { forwardRef, type ChangeEventHandler, type ReactNode } from 'react';
+import { VirtuosoMockContext } from 'react-virtuoso';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ProgressHistory from './ProgressHistory';
+import { ProgressHistoryList } from './ProgressHistoryList';
+import type { HistoryItem } from './progressHistoryEditor';
+
+const messages = {
+    profile: {
+        trainingPlan: {
+            common: {
+                cancel: 'Cancel',
+                save: 'Save',
+                taskDetails: 'Task Details',
+                updateProgress: 'Update Progress',
+                date: 'Date',
+                hours: 'Hours',
+                minutes: 'Minutes',
+                comments: 'Comments',
+                commentsPlaceholder: 'Optional comments',
+                fieldRequired: 'This field is required',
+                mustBeInteger: 'This field must be an integer',
+            },
+            progressHistory: {
+                addNew: 'Add New',
+                noHistory: 'No history yet. Use the + button above to log your first entry.',
+                newEntryLabel: 'New',
+                fillInDetails: 'Fill in the details below',
+                cohort: 'Cohort',
+                deleteEntry: 'Delete entry',
+                totalCount: 'Total {label} : {total}. Current Cohort: {cohortCount}',
+                totalTime:
+                    'Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m',
+                deleteAriaLabel: 'delete',
+            },
+        },
+    },
+};
+
+const mocks = vi.hoisted(() => ({
+    entries: [] as TimelineEntry[],
+    getTimelineUpdate: vi.fn(() => ({
+        progress: { requirementId: 'classical-games', minutesSpent: {}, counts: {}, updatedAt: '' },
+        updated: [],
+        deleted: [],
+        errors: {},
+    })),
+    onClose: vi.fn(),
+    onDeleteEntries: vi.fn(),
+    onEditEntries: vi.fn(),
+    textFieldLabels: [] as (string | undefined)[],
+}));
+
+vi.mock('@/auth/Auth', () => ({
+    useAuth: () => ({
+        user: {
+            username: 'test',
+            displayName: 'Test User',
+            dojoCohort: '1400-1500',
+            timeFormat: '24',
+        },
+    }),
+}));
+
+vi.mock('@/components/profile/activity/useTimeline', () => ({
+    useTimelineContext: () => ({
+        entries: mocks.entries,
+        request: { isLoading: () => false },
+        onEditEntries: mocks.onEditEntries,
+        onDeleteEntries: mocks.onDeleteEntries,
+    }),
+}));
+
+vi.mock('@mui/material', () => {
+    const domProps = (props: Record<string, unknown>) => {
+        const result: Record<string, unknown> = {};
+        for (const key of ['aria-label', 'data-testid', 'placeholder']) {
+            if (props[key] !== undefined) {
+                result[key] = props[key];
+            }
+        }
+        return result;
+    };
+
+    const Container = forwardRef<
+        HTMLDivElement,
+        {
+            children?: ReactNode;
+            [key: string]: unknown;
+        }
+    >(function Container({ children, ...props }, ref) {
+        return (
+            <div ref={ref} {...domProps(props)}>
+                {children as ReactNode}
+            </div>
+        );
+    });
+
+    const Button = ({
+        children,
+        disabled,
+        onClick,
+        ...props
+    }: {
+        children?: ReactNode;
+        disabled?: boolean;
+        onClick?: () => void;
+        [key: string]: unknown;
+    }) => (
+        <button type='button' disabled={disabled} onClick={onClick} {...domProps(props)}>
+            {children}
+        </button>
+    );
+
+    const TextField = ({
+        children,
+        label,
+        multiline,
+        onChange,
+        onBlur,
+        select,
+        value,
+        ...props
+    }: {
+        children?: ReactNode;
+        label?: string;
+        multiline?: boolean;
+        onChange?: ChangeEventHandler<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
+        onBlur?: ChangeEventHandler<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
+        select?: boolean;
+        value?: string;
+        [key: string]: unknown;
+    }) => {
+        mocks.textFieldLabels.push(label);
+
+        const inputProps = {
+            'aria-label': label,
+            value: value ?? '',
+            ...domProps(props),
+        };
+
+        if (select) {
+            return (
+                <select {...inputProps} onChange={onChange} onBlur={onBlur}>
+                    {children}
+                </select>
+            );
+        }
+
+        if (multiline) {
+            return <textarea {...inputProps} onChange={onChange} onBlur={onBlur} />;
+        }
+
+        return <input {...inputProps} onChange={onChange} onBlur={onBlur} />;
+    };
+
+    return {
+        Alert: Container,
+        Box: Container,
+        Button,
+        Chip: ({ label }: { label?: ReactNode }) => <span>{label}</span>,
+        DialogActions: Container,
+        DialogContent: Container,
+        DialogContentText: Container,
+        Divider: () => <hr />,
+        Grid: Container,
+        IconButton: ({
+            children,
+            onClick,
+            ...props
+        }: {
+            children?: ReactNode;
+            onClick?: () => void;
+            [key: string]: unknown;
+        }) => (
+            <button type='button' onClick={onClick} {...domProps(props)}>
+                {children}
+            </button>
+        ),
+        MenuItem: ({ children, value }: { children?: ReactNode; value?: string }) => (
+            <option value={value}>{children}</option>
+        ),
+        Snackbar: ({
+            children,
+            message,
+            open,
+            ...props
+        }: {
+            children?: ReactNode;
+            message?: ReactNode;
+            open?: boolean;
+            [key: string]: unknown;
+        }) => (open ? <div {...domProps(props)}>{children ?? message}</div> : null),
+        Stack: Container,
+        TextField,
+        Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+        Typography: Container,
+    };
+});
+
+vi.mock('@mui/x-date-pickers', () => ({
+    DateTimePicker: ({
+        label,
+        value,
+        onChange,
+    }: {
+        label: string;
+        value: { toISO: () => string } | null;
+        onChange: (value: null) => void;
+    }) => (
+        <input
+            aria-label={label}
+            value={value?.toISO() ?? ''}
+            onChange={() => onChange(null)}
+            readOnly
+        />
+    ),
+}));
+
+vi.mock('./TaskDialog', () => ({
+    TaskDialogView: {
+        Details: 'DETAILS',
+        Progress: 'PROGRESS',
+        History: 'HISTORY',
+    },
+}));
+
+vi.mock('./progressHistoryEditor', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./progressHistoryEditor')>();
+    return {
+        ...actual,
+        getTimelineUpdate: mocks.getTimelineUpdate,
+    };
+});
+
+const requirement: Requirement = {
+    id: 'classical-games',
+    status: RequirementStatus.Active,
+    category: RequirementCategory.Games,
+    name: 'Play Classical Games',
+    description: '',
+    freeDescription: '',
+    counts: { '1400-1500': 40 },
+    startCount: 0,
+    numberOfCohorts: 1,
+    unitScore: 1,
+    totalScore: 0,
+    scoreboardDisplay: ScoreboardDisplay.Yearly,
+    progressBarSuffix: 'games',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    sortPriority: 'games',
+    expirationDays: -1,
+    isFree: false,
+    atomic: false,
+    expectedMinutes: 0,
+};
+
+function makeEntry(index: number): TimelineEntry {
+    const date = new Date(Date.UTC(2026, 0, index + 1, 12)).toISOString();
+    return {
+        owner: 'test',
+        id: `entry-${index}`,
+        ownerDisplayName: 'Test User',
+        cohort: '1400-1500',
+        requirementId: requirement.id,
+        requirementName: requirement.name,
+        requirementCategory: RequirementCategory.Games,
+        scoreboardDisplay: ScoreboardDisplay.Yearly,
+        progressBarSuffix: 'games',
+        totalCount: 40,
+        previousCount: index,
+        newCount: index + 1,
+        dojoPoints: 1,
+        totalDojoPoints: index + 1,
+        minutesSpent: 30,
+        totalMinutesSpent: (index + 1) * 30,
+        date,
+        createdAt: date,
+        notes: `notes ${index}`,
+        comments: [],
+        reactions: {},
+    };
+}
+
+function makeHistoryItem(index: number): HistoryItem {
+    const entry = makeEntry(index);
+    return {
+        date: DateTime.fromISO(entry.date || entry.createdAt),
+        count: `${entry.newCount - (entry.previousCount ?? 0)}`,
+        hours: `${Math.floor(entry.minutesSpent / 60)}`,
+        minutes: `${entry.minutesSpent % 60}`,
+        notes: entry.notes,
+        cohort: entry.cohort,
+        entry,
+        index,
+        deleted: false,
+        isNew: false,
+    };
+}
+
+function renderDialog() {
+    return render(
+        <NextIntlClientProvider locale='en' messages={messages}>
+            <VirtuosoMockContext.Provider value={{ viewportHeight: 700, itemHeight: 300 }}>
+                <ProgressHistory requirement={requirement} onClose={mocks.onClose} />
+            </VirtuosoMockContext.Provider>
+        </NextIntlClientProvider>,
+    );
+}
+
+function renderListWithoutScrollParent() {
+    const items = Array.from({ length: 150 }, (_, index) => makeHistoryItem(index));
+    return render(
+        <NextIntlClientProvider locale='en' messages={messages}>
+            <VirtuosoMockContext.Provider value={{ viewportHeight: 700, itemHeight: 300 }}>
+                <ProgressHistoryList
+                    requirement={requirement}
+                    items={items}
+                    errors={{}}
+                    updateItem={vi.fn()}
+                    updateDraftItem={vi.fn()}
+                    getDraftItem={() => undefined}
+                    deleteItem={vi.fn()}
+                    scrollParent={null}
+                />
+            </VirtuosoMockContext.Provider>
+        </NextIntlClientProvider>,
+    );
+}
+
+describe('ProgressHistory recompute behavior', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    beforeEach(() => {
+        mocks.entries = Array.from({ length: 150 }, (_, index) => makeEntry(index));
+        mocks.getTimelineUpdate.mockClear();
+        mocks.onClose.mockClear();
+        mocks.onDeleteEntries.mockClear();
+        mocks.onEditEntries.mockClear();
+        mocks.textFieldLabels = [];
+    });
+
+    it('does not build the save payload on initial render or draft edits', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+        expect(mocks.getTimelineUpdate).not.toHaveBeenCalled();
+
+        fireEvent.change(screen.getAllByLabelText('Comments')[0], {
+            target: { value: 'changed notes' },
+        });
+
+        expect(mocks.getTimelineUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does not rerender unchanged comment fields on draft edits', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+        mocks.textFieldLabels = [];
+
+        fireEvent.change(screen.getAllByLabelText('Comments')[0], {
+            target: { value: 'changed notes' },
+        });
+
+        const commentRenderCount = mocks.textFieldLabels.filter(
+            (label) => label === 'Comments',
+        ).length;
+        expect(commentRenderCount).toBeLessThanOrEqual(2);
+    });
+
+    it('does not mount the full 150-row history on initial render', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+
+        const commentFields = screen.getAllByLabelText('Comments');
+        expect(commentFields.length).toBeGreaterThan(0);
+        expect(commentFields.length).toBeLessThan(mocks.entries.length);
+        expect(screen.queryByDisplayValue('notes 0')).not.toBeInTheDocument();
+    });
+
+    it('pre-renders several rows beyond the visible viewport for smoother scrolling', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+
+        expect(screen.getAllByLabelText('Comments').length).toBeGreaterThanOrEqual(8);
+    });
+
+    it('renders initial rows without depending on the dialog scroll parent', async () => {
+        renderListWithoutScrollParent();
+
+        await screen.findByDisplayValue('notes 149');
+
+        expect(screen.getAllByLabelText('Comments').length).toBeGreaterThan(0);
+    });
+
+    it('uses the dialog content as the only scroll surface', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+
+        expect(screen.getByTestId('task-history-virtual-list')).toBeInTheDocument();
+        expect(screen.queryByTestId('virtuoso-scroller')).not.toBeInTheDocument();
+    });
+
+    it('keeps text edits local until blur so typing does not recompute the summary per key', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+        const summary = screen.getByTestId('total-count-summary');
+        expect(summary).toHaveTextContent('Total Games : 150');
+
+        const firstCountField = screen.getAllByTestId('task-history-count')[0];
+        fireEvent.change(firstCountField, { target: { value: '10' } });
+
+        expect(summary).toHaveTextContent('Total Games : 150');
+
+        fireEvent.blur(firstCountField);
+
+        expect(summary).toHaveTextContent('Total Games : 159');
+    });
+
+    it('maps virtual row edits back to the newest original history item', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+        const firstCommentField = screen.getAllByLabelText('Comments')[0];
+        fireEvent.change(firstCommentField, {
+            target: { value: 'changed newest notes' },
+        });
+        fireEvent.blur(firstCommentField);
+        fireEvent.click(screen.getByTestId('task-updater-save-button'));
+
+        expect(mocks.getTimelineUpdate).toHaveBeenCalledTimes(1);
+        const [, submittedItems] = mocks.getTimelineUpdate.mock.calls[0] as unknown as [
+            unknown,
+            { notes: string }[],
+        ];
+        expect(submittedItems[149].notes).toBe('changed newest notes');
+        expect(submittedItems[0].notes).toBe('notes 0');
+    });
+
+    it('includes active text drafts when Save is clicked before blur', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+        const firstCommentField = screen.getAllByLabelText('Comments')[0];
+        fireEvent.change(firstCommentField, {
+            target: { value: 'changed draft before blur' },
+        });
+
+        fireEvent.click(screen.getByTestId('task-updater-save-button'));
+
+        expect(mocks.getTimelineUpdate).toHaveBeenCalledTimes(1);
+        const [, submittedItems] = mocks.getTimelineUpdate.mock.calls[0] as unknown as [
+            unknown,
+            { notes: string }[],
+        ];
+        expect(submittedItems[149].notes).toBe('changed draft before blur');
+    });
+
+    it('builds the save payload once when Save is clicked', async () => {
+        renderDialog();
+
+        await screen.findByDisplayValue('notes 149');
+        fireEvent.click(screen.getByTestId('task-updater-save-button'));
+
+        expect(mocks.getTimelineUpdate).toHaveBeenCalledTimes(1);
+        expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/ProgressHistory.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistory.tsx
@@ -3,421 +3,43 @@ import { useApi } from '@/api/Api';
 import { RequestSnackbar, useRequest } from '@/api/Request';
 import { useAuth } from '@/auth/Auth';
 import { useTimelineContext } from '@/components/profile/activity/useTimeline';
-import {
-    CustomTask,
-    getCurrentScore,
-    getTotalCount,
-    isRequirement,
-    Requirement,
-    RequirementProgress,
-    ScoreboardDisplay,
-} from '@/database/requirement';
-import { TimelineEntry } from '@/database/timeline';
-import { ALL_COHORTS, compareCohorts, dojoCohorts, TimeFormat, User } from '@/database/user';
+import { CustomTask, isRequirement, Requirement, ScoreboardDisplay } from '@/database/requirement';
+import { ALL_COHORTS, compareCohorts, dojoCohorts, User } from '@/database/user';
 import LoadingPage from '@/loading/LoadingPage';
 import { useTranslatedRequirement } from '@/translation/useTranslatedRequirement';
 import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
 import {
-    Box,
     Button,
-    Chip,
     DialogActions,
     DialogContent,
     DialogContentText,
-    Divider,
-    Grid,
-    IconButton,
-    MenuItem,
     Stack,
-    TextField,
-    Tooltip,
     Typography,
 } from '@mui/material';
-import { DateTimePicker } from '@mui/x-date-pickers';
 import { AxiosResponse } from 'axios';
-import deepEqual from 'deep-equal';
 import { DateTime } from 'luxon';
 import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    createNewEntry,
+    getProgressSummary,
+    getTimelineUpdate,
+    type HistoryItem,
+    type HistoryItemError,
+    summarizeProgress,
+} from './progressHistoryEditor';
+import { ProgressHistoryList } from './ProgressHistoryList';
 import { TaskDialogView } from './TaskDialog';
 
-const NUMBER_REGEX = /^[0-9]*$/;
-const NEGATIVE_NUMBER_REGEX = /^-?[0-9]*$/;
-
-interface HistoryItem {
-    date: DateTime | null;
-    count: string;
-    hours: string;
-    minutes: string;
-    notes: string;
-    entry: TimelineEntry;
-    index: number;
-    deleted: boolean;
-    cohort: string;
-    /** True if this entry was added in the current session and not yet saved */
-    isNew?: boolean;
-}
-
-interface ProgressHistoryItemProps {
-    requirement: Requirement | CustomTask;
-    item: HistoryItem;
-    error: HistoryItemError;
-    updateItem: (item: HistoryItem) => void;
-    deleteItem: () => void;
-}
-
-export const ProgressHistoryItem = ({
-    requirement,
-    item,
-    error,
-    updateItem,
-    deleteItem,
-}: ProgressHistoryItemProps) => {
-    const t = useTranslations('profile.trainingPlan.progressHistory');
-    const tCommon = useTranslations('profile.trainingPlan.common');
-    const { user } = useAuth();
-    if (item.deleted) {
-        return null;
-    }
-
-    const cohortOptions = requirement.counts[ALL_COHORTS]
-        ? dojoCohorts
-        : Object.keys(requirement.counts).sort(compareCohorts);
-
-    const isTimeOnly =
-        item.entry.scoreboardDisplay === ScoreboardDisplay.NonDojo ||
-        item.entry.scoreboardDisplay === ScoreboardDisplay.Minutes;
-    const useTwelveHourClock = user?.timeFormat !== TimeFormat.TwentyFourHour;
-
-    const onChange = (
-        key: 'date' | 'count' | 'hours' | 'minutes' | 'notes' | 'cohort',
-        value: string | DateTime | null,
-    ) => {
-        updateItem({ ...item, [key]: value });
-    };
-
-    const rawSuffix = requirement.progressBarSuffix?.trim();
-    const countLabel = rawSuffix ? rawSuffix.charAt(0).toUpperCase() + rawSuffix.slice(1) : 'Count';
-
-    return (
-        <Box>
-            <Stack
-                direction='row'
-                spacing={{ sm: 1 }}
-                width={1}
-                alignItems='center'
-                flexWrap={{ xs: 'wrap', sm: 'nowrap' }}
-                rowGap={2}
-            >
-                <Grid container columnGap={2} rowGap={3} alignItems='center'>
-                    {item.isNew && (
-                        <Grid size={12}>
-                            <Stack direction='row' alignItems='center' spacing={1}>
-                                <Chip
-                                    label={t('newEntryLabel')}
-                                    size='small'
-                                    color='primary'
-                                    variant='outlined'
-                                />
-                                <Typography variant='body2' color='text.secondary'>
-                                    {t('fillInDetails')}
-                                </Typography>
-                            </Stack>
-                        </Grid>
-                    )}
-
-                    <Grid size={{ xs: 12, sm: 'grow' }}>
-                        <TextField
-                            label={t('cohort')}
-                            select
-                            value={item.cohort}
-                            onChange={(e) => onChange('cohort', e.target.value)}
-                            fullWidth
-                        >
-                            {cohortOptions.map((opt) => (
-                                <MenuItem key={opt} value={opt}>
-                                    {opt}
-                                </MenuItem>
-                            ))}
-                        </TextField>
-                    </Grid>
-
-                    <Grid size={{ xs: 12, sm: 'grow' }} sx={{ minWidth: '145px' }}>
-                        <DateTimePicker
-                            label={tCommon('date')}
-                            value={item.date}
-                            onChange={(v) => onChange('date', v)}
-                            slotProps={{
-                                textField: {
-                                    error: !!error.date,
-                                    helperText: error.date,
-                                    fullWidth: true,
-                                },
-                            }}
-                            ampm={useTwelveHourClock}
-                        />
-                    </Grid>
-
-                    {!isTimeOnly && (
-                        <Grid size={{ xs: 12, sm: 'grow' }}>
-                            <TextField
-                                data-testid='task-history-count'
-                                label={countLabel}
-                                value={item.count}
-                                onChange={(event) => onChange('count', event.target.value)}
-                                fullWidth
-                                error={!!error.count}
-                                helperText={error.count}
-                            />
-                        </Grid>
-                    )}
-
-                    <Grid size={{ xs: 12, sm: 'grow' }}>
-                        <TextField
-                            label={tCommon('hours')}
-                            value={item.hours}
-                            slotProps={{
-                                htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
-                            }}
-                            onChange={(event) => onChange('hours', event.target.value)}
-                            fullWidth
-                            error={!!error.hours}
-                            helperText={error.hours}
-                        />
-                    </Grid>
-
-                    <Grid size={{ xs: 12, sm: 'grow' }}>
-                        <TextField
-                            label={tCommon('minutes')}
-                            value={item.minutes}
-                            slotProps={{
-                                htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
-                            }}
-                            onChange={(event) => onChange('minutes', event.target.value)}
-                            fullWidth
-                            error={!!error.minutes}
-                            helperText={error.minutes}
-                        />
-                    </Grid>
-
-                    <Grid size={12}>
-                        <TextField
-                            label={tCommon('comments')}
-                            placeholder={tCommon('commentsPlaceholder')}
-                            multiline={true}
-                            maxRows={3}
-                            value={item.notes}
-                            onChange={(e) => onChange('notes', e.target.value)}
-                            fullWidth
-                        />
-                    </Grid>
-                </Grid>
-
-                <Tooltip title={t('deleteEntry')}>
-                    <IconButton
-                        data-testid='task-history-delete-button'
-                        aria-label={t('deleteAriaLabel')}
-                        onClick={deleteItem}
-                    >
-                        <DeleteIcon />
-                    </IconButton>
-                </Tooltip>
-            </Stack>
-
-            <Divider sx={{ mt: 3, mb: 1 }} />
-        </Box>
-    );
-};
-
-interface HistoryItemError {
-    date?: string;
-    count?: string;
-    hours?: string;
-    minutes?: string;
-}
-
-function createNewEntry(
-    requirement: Requirement | CustomTask,
-    cohort: string,
-    index: number,
-    user: User,
-): HistoryItem {
-    const now = DateTime.now().toUTC();
-    const id = `${now.toISODate()}_${uuidv4()}`;
-
-    const cohortOptions = requirement.counts[ALL_COHORTS]
-        ? dojoCohorts
-        : Object.keys(requirement.counts).sort(compareCohorts);
-    if (!cohortOptions.includes(cohort)) {
-        cohort = cohortOptions[0];
-    }
-
-    const totalCount = getTotalCount(cohort, requirement);
-
-    return {
-        date: now,
-        count: '',
-        hours: '',
-        minutes: '',
-        notes: '',
-        cohort,
-        index,
-        deleted: false,
-        isNew: true,
-        entry: {
-            owner: user.username,
-            id,
-            ownerDisplayName: user.displayName,
-            requirementId: requirement.id,
-            requirementName: isRequirement(requirement)
-                ? requirement.shortName || requirement.name
-                : requirement.name,
-            requirementCategory: requirement.category,
-            isCustomRequirement: !isRequirement(requirement),
-            scoreboardDisplay: requirement.scoreboardDisplay,
-            progressBarSuffix: requirement.progressBarSuffix,
-            cohort,
-            totalCount,
-            previousCount: 0,
-            newCount: 0,
-            dojoPoints: 0,
-            totalDojoPoints: 0,
-            minutesSpent: 0,
-            totalMinutesSpent: 0,
-            date: now.toISO() ?? '',
-            createdAt: now.toISO() ?? '',
-            notes: '',
-            comments: [],
-            reactions: {},
-        },
-    };
-}
-
-type TranslateCommon = (key: 'fieldRequired' | 'mustBeInteger') => string;
-
-function validateItems(
+function mergeDraftItems(
     items: HistoryItem[],
-    tc: TranslateCommon,
-): Record<number, HistoryItemError> {
-    const errors: Record<number, HistoryItemError> = {};
-
-    for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        if (item.deleted) continue;
-
-        const itemErrors: HistoryItemError = {};
-
-        if (item.date === null) {
-            itemErrors.date = tc('fieldRequired');
-        }
-        if (
-            item.count !== '' &&
-            (!NEGATIVE_NUMBER_REGEX.test(item.count) || isNaN(parseInt(item.count)))
-        ) {
-            itemErrors.count = tc('mustBeInteger');
-        }
-        if (item.hours !== '' && (!NUMBER_REGEX.test(item.hours) || isNaN(parseInt(item.hours)))) {
-            itemErrors.hours = tc('mustBeInteger');
-        }
-        if (
-            item.minutes !== '' &&
-            (!NUMBER_REGEX.test(item.minutes) || isNaN(parseInt(item.minutes)))
-        ) {
-            itemErrors.minutes = tc('mustBeInteger');
-        }
-
-        if (Object.keys(itemErrors).length > 0) {
-            errors[i] = itemErrors;
-        }
+    drafts: Record<number, HistoryItem | undefined>,
+): HistoryItem[] {
+    if (Object.keys(drafts).length === 0) {
+        return items;
     }
 
-    return errors;
-}
-
-function getTimelineUpdate(
-    requirement: Requirement | CustomTask | undefined,
-    items: HistoryItem[],
-    tc: TranslateCommon,
-): {
-    progress: RequirementProgress;
-    updated: TimelineEntry[];
-    deleted: TimelineEntry[];
-    errors: Record<number, HistoryItemError>;
-} {
-    const errors = validateItems(items, tc);
-
-    if (!requirement || Object.keys(errors).length > 0) {
-        return {
-            progress: { requirementId: requirement?.id || '', minutesSpent: {}, updatedAt: '' },
-            updated: [],
-            deleted: [],
-            errors,
-        };
-    }
-
-    const updated: TimelineEntry[] = [];
-    const deleted: TimelineEntry[] = [];
-    const progress: RequirementProgress & { counts: Record<string, number> } = {
-        requirementId: requirement.id,
-        minutesSpent: {},
-        counts: {},
-        updatedAt: '',
-    };
-
-    for (const item of items) {
-        if (item.deleted) {
-            deleted.push(item.entry);
-            continue;
-        }
-
-        const cohort =
-            requirement.numberOfCohorts === 0 || requirement.numberOfCohorts === 1
-                ? ALL_COHORTS
-                : item.cohort;
-
-        const minutesSpent = 60 * parseInt(item.hours || '0') + parseInt(item.minutes || '0');
-        progress.minutesSpent[item.cohort] =
-            (progress.minutesSpent[item.cohort] ?? 0) + minutesSpent;
-
-        const previousCount = progress.counts[cohort] ?? (requirement.startCount || 0);
-        const newCount =
-            item.entry.scoreboardDisplay === ScoreboardDisplay.Minutes
-                ? previousCount + minutesSpent
-                : previousCount + parseInt(item.count || '0');
-        progress.counts[cohort] = newCount;
-
-        let previousScore = 0;
-        let newScore = 0;
-        if (isRequirement(requirement)) {
-            previousScore = getCurrentScore(item.cohort, requirement, {
-                counts: { [ALL_COHORTS]: previousCount, [item.cohort]: previousCount },
-            } as unknown as RequirementProgress);
-            newScore = getCurrentScore(item.cohort, requirement, {
-                counts: { [ALL_COHORTS]: newCount, [item.cohort]: newCount },
-            } as unknown as RequirementProgress);
-        }
-
-        const newEntry = {
-            ...item.entry,
-            cohort: item.cohort,
-            notes: item.notes,
-            date: item.date?.toUTC().toISO() || item.entry.createdAt,
-            previousCount,
-            newCount,
-            dojoPoints: newScore - previousScore,
-            totalDojoPoints: newScore,
-            minutesSpent,
-            totalMinutesSpent: progress.minutesSpent[item.cohort],
-        };
-
-        if (!deepEqual(item.entry, newEntry)) {
-            updated.push(newEntry);
-        }
-    }
-
-    return { progress, updated, deleted, errors };
+    return items.map((item, index) => drafts[index] ?? item);
 }
 
 export function useProgressHistoryEditor({
@@ -473,42 +95,41 @@ export function useProgressHistoryEditor({
     }, [requirement, entries]);
 
     const [items, setItems] = useState(initialItems);
+    const draftItemsRef = useRef<Record<number, HistoryItem | undefined>>({});
 
     useEffect(() => {
+        draftItemsRef.current = {};
         setItems(initialItems);
     }, [initialItems]);
 
-    const update = useMemo(
-        () => getTimelineUpdate(requirement, items, tCommon),
-        [requirement, items, tCommon],
+    const summary = useMemo(
+        () => getProgressSummary(requirement, items, cohort),
+        [requirement, items, cohort],
     );
 
-    const cohortCount =
-        update.progress.counts?.ALL_COHORTS ?? update.progress.counts?.[cohort] ?? 0;
-    const totalCount = Object.values(update.progress.counts ?? {}).reduce(
-        (sum, value) => sum + value,
-        0,
-    );
-
-    const cohortTime = update.progress.minutesSpent[cohort] ?? 0;
-    const totalTime = Object.values(update.progress.minutesSpent).reduce(
-        (sum, value) => sum + value,
-        0,
-    );
-
-    const getUpdateItem = useCallback(
-        (idx: number) => (item: HistoryItem) =>
-            setItems((items) => [...items.slice(0, idx), item, ...items.slice(idx + 1)]),
+    const updateItem = useCallback(
+        (idx: number, item: HistoryItem) => {
+            draftItemsRef.current[idx] = undefined;
+            setItems((items) => [...items.slice(0, idx), item, ...items.slice(idx + 1)]);
+        },
         [setItems],
     );
 
-    const getDeleteItem = useCallback(
-        (idx: number) => () =>
+    const updateDraftItem = useCallback((idx: number, item: HistoryItem) => {
+        draftItemsRef.current[idx] = item;
+    }, []);
+
+    const getDraftItem = useCallback((idx: number) => draftItemsRef.current[idx], []);
+
+    const deleteItem = useCallback(
+        (idx: number) => {
+            draftItemsRef.current[idx] = undefined;
             setItems((items) => [
                 ...items.slice(0, idx),
                 { ...items[idx], deleted: true },
                 ...items.slice(idx + 1),
-            ]),
+            ]);
+        },
         [setItems],
     );
 
@@ -518,6 +139,8 @@ export function useProgressHistoryEditor({
     }, [requirement, cohort, user]);
 
     const onSubmit = async () => {
+        const submittedItems = mergeDraftItems(items, draftItemsRef.current);
+        const update = getTimelineUpdate(requirement, submittedItems, tCommon);
         setErrors(update.errors);
         if (Object.keys(update.errors).length > 0) return;
 
@@ -526,6 +149,8 @@ export function useProgressHistoryEditor({
             onSuccess();
             return;
         }
+
+        const submittedSummary = summarizeProgress(update.progress, cohort);
 
         request.onStart();
         try {
@@ -542,9 +167,9 @@ export function useProgressHistoryEditor({
                 is_custom_requirement: !isRequirement(requirement),
                 total_count:
                     requirement?.scoreboardDisplay === ScoreboardDisplay.Minutes
-                        ? totalTime
-                        : totalCount,
-                total_minutes: totalTime,
+                        ? submittedSummary.totalTime
+                        : submittedSummary.totalCount,
+                total_minutes: submittedSummary.totalTime,
             });
 
             onEditEntries(update.updated);
@@ -562,12 +187,14 @@ export function useProgressHistoryEditor({
         timelineRequest,
         isTimeOnly,
         items,
-        cohortCount,
-        cohortTime,
-        totalCount,
-        totalTime,
-        getUpdateItem,
-        getDeleteItem,
+        cohortCount: summary.cohortCount,
+        cohortTime: summary.cohortTime,
+        totalCount: summary.totalCount,
+        totalTime: summary.totalTime,
+        updateItem,
+        updateDraftItem,
+        getDraftItem,
+        deleteItem,
         addItem,
         onSubmit,
     };
@@ -588,6 +215,7 @@ const ProgressHistory = ({
     const t = useTranslations('profile.trainingPlan.progressHistory');
     const tCommon = useTranslations('profile.trainingPlan.common');
     const { user } = useAuth();
+    const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null);
     const {
         errors,
         request,
@@ -598,8 +226,10 @@ const ProgressHistory = ({
         cohortTime,
         totalCount,
         totalTime,
-        getUpdateItem,
-        getDeleteItem,
+        updateItem,
+        updateDraftItem,
+        getDraftItem,
+        deleteItem,
         addItem,
         onSubmit,
     } = useProgressHistoryEditor({
@@ -623,7 +253,7 @@ const ProgressHistory = ({
 
     return (
         <>
-            <DialogContent sx={{ position: 'relative' }}>
+            <DialogContent ref={setScrollParent} sx={{ position: 'relative' }}>
                 <Stack direction='row' justifyContent='flex-start' mb={3}>
                     <Button
                         data-testid='task-history-add-new-button'
@@ -643,22 +273,16 @@ const ProgressHistory = ({
                             {t('noHistory')}
                         </DialogContentText>
                     ) : (
-                        <Stack spacing={3} mt={1} width={1}>
-                            {items.map((_, idx, array) => {
-                                const reversedIdx = array.length - 1 - idx;
-                                const item = array[reversedIdx];
-                                return (
-                                    <ProgressHistoryItem
-                                        key={item.entry.id}
-                                        requirement={requirement}
-                                        item={item}
-                                        error={errors[reversedIdx] || {}}
-                                        updateItem={getUpdateItem(reversedIdx)}
-                                        deleteItem={getDeleteItem(reversedIdx)}
-                                    />
-                                );
-                            })}
-                        </Stack>
+                        <ProgressHistoryList
+                            requirement={requirement}
+                            items={items}
+                            errors={errors}
+                            updateItem={updateItem}
+                            updateDraftItem={updateDraftItem}
+                            getDraftItem={getDraftItem}
+                            deleteItem={deleteItem}
+                            scrollParent={scrollParent}
+                        />
                     )}
                 </Stack>
             </DialogContent>

--- a/frontend/src/components/profile/trainingPlan/ProgressHistoryItem.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistoryItem.tsx
@@ -92,7 +92,7 @@ export const ProgressHistoryItem = memo(function ProgressHistoryItem({
     const countLabel = rawSuffix ? rawSuffix.charAt(0).toUpperCase() + rawSuffix.slice(1) : 'Count';
 
     return (
-        <Box>
+        <Box sx={{ pb: 3 }}>
             <Stack
                 direction='row'
                 spacing={{ sm: 1 }}
@@ -220,7 +220,7 @@ export const ProgressHistoryItem = memo(function ProgressHistoryItem({
                 </Tooltip>
             </Stack>
 
-            <Divider sx={{ mt: 3, mb: 1 }} />
+            <Divider sx={{ mt: 3 }} />
         </Box>
     );
 });

--- a/frontend/src/components/profile/trainingPlan/ProgressHistoryItem.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistoryItem.tsx
@@ -1,0 +1,226 @@
+import { useAuth } from '@/auth/Auth';
+import { CustomTask, Requirement, ScoreboardDisplay } from '@/database/requirement';
+import { ALL_COHORTS, compareCohorts, dojoCohorts, TimeFormat } from '@/database/user';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+    Box,
+    Chip,
+    Divider,
+    Grid,
+    IconButton,
+    MenuItem,
+    Stack,
+    TextField,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import { DateTimePicker } from '@mui/x-date-pickers';
+import { DateTime } from 'luxon';
+import { useTranslations } from 'next-intl';
+import { memo, useCallback, useEffect, useState } from 'react';
+import { type HistoryItem, type HistoryItemError } from './progressHistoryEditor';
+
+interface ProgressHistoryItemProps {
+    requirement: Requirement | CustomTask;
+    item: HistoryItem;
+    error: HistoryItemError;
+    itemIndex: number;
+    updateItem: (index: number, item: HistoryItem) => void;
+    updateDraftItem: (index: number, item: HistoryItem) => void;
+    deleteItem: (index: number) => void;
+}
+
+export const ProgressHistoryItem = memo(function ProgressHistoryItem({
+    requirement,
+    item,
+    error,
+    itemIndex,
+    updateItem,
+    updateDraftItem,
+    deleteItem,
+}: ProgressHistoryItemProps) {
+    const t = useTranslations('profile.trainingPlan.progressHistory');
+    const tCommon = useTranslations('profile.trainingPlan.common');
+    const { user } = useAuth();
+    const [draftItem, setDraftItem] = useState(item);
+
+    useEffect(() => {
+        setDraftItem(item);
+    }, [item]);
+
+    const updateDraft = useCallback(
+        (
+            key: 'date' | 'count' | 'hours' | 'minutes' | 'notes' | 'cohort',
+            value: string | DateTime | null,
+        ) => {
+            setDraftItem((item) => {
+                const updatedItem = { ...item, [key]: value };
+                updateDraftItem(itemIndex, updatedItem);
+                return updatedItem;
+            });
+        },
+        [itemIndex, updateDraftItem],
+    );
+
+    const updateAndCommit = (
+        key: 'date' | 'count' | 'hours' | 'minutes' | 'notes' | 'cohort',
+        value: string | DateTime | null,
+    ) => {
+        const updatedItem = { ...draftItem, [key]: value };
+        setDraftItem(updatedItem);
+        updateItem(itemIndex, updatedItem);
+    };
+
+    const commitDraft = () => {
+        updateItem(itemIndex, draftItem);
+    };
+
+    if (item.deleted) {
+        return null;
+    }
+
+    const cohortOptions = requirement.counts[ALL_COHORTS]
+        ? dojoCohorts
+        : Object.keys(requirement.counts).sort(compareCohorts);
+
+    const isTimeOnly =
+        draftItem.entry.scoreboardDisplay === ScoreboardDisplay.NonDojo ||
+        draftItem.entry.scoreboardDisplay === ScoreboardDisplay.Minutes;
+    const useTwelveHourClock = user?.timeFormat !== TimeFormat.TwentyFourHour;
+
+    const rawSuffix = requirement.progressBarSuffix?.trim();
+    const countLabel = rawSuffix ? rawSuffix.charAt(0).toUpperCase() + rawSuffix.slice(1) : 'Count';
+
+    return (
+        <Box>
+            <Stack
+                direction='row'
+                spacing={{ sm: 1 }}
+                width={1}
+                alignItems='center'
+                flexWrap={{ xs: 'wrap', sm: 'nowrap' }}
+                rowGap={2}
+            >
+                <Grid container columnGap={2} rowGap={3} alignItems='center'>
+                    {item.isNew && (
+                        <Grid size={12}>
+                            <Stack direction='row' alignItems='center' spacing={1}>
+                                <Chip
+                                    label={t('newEntryLabel')}
+                                    size='small'
+                                    color='primary'
+                                    variant='outlined'
+                                />
+                                <Typography variant='body2' color='text.secondary'>
+                                    {t('fillInDetails')}
+                                </Typography>
+                            </Stack>
+                        </Grid>
+                    )}
+
+                    <Grid size={{ xs: 12, sm: 'grow' }}>
+                        <TextField
+                            label={t('cohort')}
+                            select
+                            value={draftItem.cohort}
+                            onChange={(e) => updateAndCommit('cohort', e.target.value)}
+                            fullWidth
+                        >
+                            {cohortOptions.map((opt) => (
+                                <MenuItem key={opt} value={opt}>
+                                    {opt}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                    </Grid>
+
+                    <Grid size={{ xs: 12, sm: 'grow' }} sx={{ minWidth: '145px' }}>
+                        <DateTimePicker
+                            label={tCommon('date')}
+                            value={draftItem.date}
+                            onChange={(v) => updateAndCommit('date', v)}
+                            slotProps={{
+                                textField: {
+                                    error: !!error.date,
+                                    helperText: error.date,
+                                    fullWidth: true,
+                                },
+                            }}
+                            ampm={useTwelveHourClock}
+                        />
+                    </Grid>
+
+                    {!isTimeOnly && (
+                        <Grid size={{ xs: 12, sm: 'grow' }}>
+                            <TextField
+                                data-testid='task-history-count'
+                                label={countLabel}
+                                value={draftItem.count}
+                                onChange={(event) => updateDraft('count', event.target.value)}
+                                onBlur={commitDraft}
+                                fullWidth
+                                error={!!error.count}
+                                helperText={error.count}
+                            />
+                        </Grid>
+                    )}
+
+                    <Grid size={{ xs: 12, sm: 'grow' }}>
+                        <TextField
+                            label={tCommon('hours')}
+                            value={draftItem.hours}
+                            slotProps={{
+                                htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
+                            }}
+                            onChange={(event) => updateDraft('hours', event.target.value)}
+                            onBlur={commitDraft}
+                            fullWidth
+                            error={!!error.hours}
+                            helperText={error.hours}
+                        />
+                    </Grid>
+
+                    <Grid size={{ xs: 12, sm: 'grow' }}>
+                        <TextField
+                            label={tCommon('minutes')}
+                            value={draftItem.minutes}
+                            slotProps={{
+                                htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
+                            }}
+                            onChange={(event) => updateDraft('minutes', event.target.value)}
+                            onBlur={commitDraft}
+                            fullWidth
+                            error={!!error.minutes}
+                            helperText={error.minutes}
+                        />
+                    </Grid>
+
+                    <Grid size={12}>
+                        <TextField
+                            label={tCommon('comments')}
+                            placeholder={tCommon('commentsPlaceholder')}
+                            multiline={true}
+                            maxRows={3}
+                            value={draftItem.notes}
+                            onChange={(e) => updateDraft('notes', e.target.value)}
+                            onBlur={commitDraft}
+                            fullWidth
+                        />
+                    </Grid>
+                </Grid>
+
+                <Tooltip title={t('deleteEntry')}>
+                    <IconButton
+                        data-testid='task-history-delete-button'
+                        aria-label={t('deleteAriaLabel')}
+                        onClick={() => deleteItem(itemIndex)}
+                    >
+                        <DeleteIcon />
+                    </IconButton>
+                </Tooltip>
+            </Stack>
+
+            <Divider sx={{ mt: 3, mb: 1 }} />
+        </Box>
+    );
+});

--- a/frontend/src/components/profile/trainingPlan/ProgressHistoryList.config.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistoryList.config.test.tsx
@@ -1,0 +1,171 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { TimelineEntry } from '@/database/timeline';
+import { render, screen } from '@testing-library/react';
+import { DateTime } from 'luxon';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProgressHistoryList } from './ProgressHistoryList';
+import type { HistoryItem } from './progressHistoryEditor';
+
+const virtuosoMock = vi.hoisted(() => ({
+    latestProps: undefined as
+        | {
+              components?: Record<string, unknown>;
+              customScrollParent?: HTMLElement;
+              data: { item: HistoryItem; itemIndex: number }[];
+              initialItemCount?: number;
+              itemContent: (
+                  index: number,
+                  row: { item: HistoryItem; itemIndex: number },
+              ) => ReactNode;
+              scrollSeekConfiguration?: unknown;
+              style?: Record<string, string>;
+          }
+        | undefined,
+}));
+
+vi.mock('react-virtuoso', () => ({
+    Virtuoso: (props: typeof virtuosoMock.latestProps) => {
+        virtuosoMock.latestProps = props;
+        return (
+            <div data-testid='virtuoso-list'>
+                {props?.data.slice(0, 4).map((row, index) => (
+                    <div key={row.item.entry.id}>{props.itemContent(index, row)}</div>
+                ))}
+            </div>
+        );
+    },
+}));
+
+vi.mock('@mui/material', () => ({
+    Box: ({
+        children,
+        'data-testid': dataTestId,
+    }: {
+        children?: ReactNode;
+        'data-testid'?: string;
+    }) => <div data-testid={dataTestId}>{children}</div>,
+}));
+
+vi.mock('./ProgressHistoryItem', () => ({
+    ProgressHistoryItem: ({ item }: { item: HistoryItem }) => (
+        <div data-testid='progress-history-item'>{item.notes}</div>
+    ),
+}));
+
+const requirement: Requirement = {
+    id: 'classical-games',
+    status: RequirementStatus.Active,
+    category: RequirementCategory.Games,
+    name: 'Play Classical Games',
+    description: '',
+    freeDescription: '',
+    counts: { '1400-1500': 40 },
+    startCount: 0,
+    numberOfCohorts: 1,
+    unitScore: 1,
+    totalScore: 0,
+    scoreboardDisplay: ScoreboardDisplay.Yearly,
+    progressBarSuffix: 'games',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    sortPriority: 'games',
+    expirationDays: -1,
+    isFree: false,
+    atomic: false,
+    expectedMinutes: 0,
+};
+
+function makeItem(index: number): HistoryItem {
+    const date = new Date(Date.UTC(2026, 0, index + 1, 12)).toISOString();
+    const entry: TimelineEntry = {
+        owner: 'test',
+        id: `entry-${index}`,
+        ownerDisplayName: 'Test User',
+        cohort: '1400-1500',
+        requirementId: requirement.id,
+        requirementName: requirement.name,
+        requirementCategory: RequirementCategory.Games,
+        scoreboardDisplay: ScoreboardDisplay.Yearly,
+        progressBarSuffix: 'games',
+        totalCount: 40,
+        previousCount: index,
+        newCount: index + 1,
+        dojoPoints: 1,
+        totalDojoPoints: index + 1,
+        minutesSpent: 30,
+        totalMinutesSpent: (index + 1) * 30,
+        date,
+        createdAt: date,
+        notes: `notes ${index}`,
+        comments: [],
+        reactions: {},
+    };
+
+    return {
+        date: DateTime.fromISO(entry.date || entry.createdAt),
+        count: '1',
+        hours: '0',
+        minutes: '30',
+        notes: entry.notes,
+        entry,
+        index,
+        deleted: false,
+        cohort: '1400-1500',
+        isNew: false,
+    };
+}
+
+describe('ProgressHistoryList Virtuoso configuration', () => {
+    const items = Array.from({ length: 8 }, (_, index) => makeItem(index));
+
+    beforeEach(() => {
+        virtuosoMock.latestProps = undefined;
+    });
+
+    it('uses the provided scroll parent without scroll-seek placeholders', () => {
+        const scrollParent = document.createElement('div');
+
+        render(
+            <ProgressHistoryList
+                requirement={requirement}
+                items={items}
+                errors={{}}
+                updateItem={vi.fn()}
+                updateDraftItem={vi.fn()}
+                getDraftItem={() => undefined}
+                deleteItem={vi.fn()}
+                scrollParent={scrollParent}
+            />,
+        );
+
+        expect(virtuosoMock.latestProps?.customScrollParent).toBe(scrollParent);
+        expect(virtuosoMock.latestProps?.scrollSeekConfiguration).toBeUndefined();
+        expect(virtuosoMock.latestProps?.components?.ScrollSeekPlaceholder).toBeUndefined();
+        expect(virtuosoMock.latestProps?.style).toBeUndefined();
+        expect(virtuosoMock.latestProps?.initialItemCount).toBeGreaterThan(0);
+    });
+
+    it('renders pending draft items when virtual rows remount', () => {
+        const draftItem = { ...items[7], notes: 'pending draft from virtual row' };
+
+        render(
+            <ProgressHistoryList
+                requirement={requirement}
+                items={items}
+                errors={{}}
+                updateItem={vi.fn()}
+                updateDraftItem={vi.fn()}
+                getDraftItem={(index) => (index === 7 ? draftItem : undefined)}
+                deleteItem={vi.fn()}
+                scrollParent={document.createElement('div')}
+            />,
+        );
+
+        expect(screen.getByText('pending draft from virtual row')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/ProgressHistoryList.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistoryList.tsx
@@ -1,0 +1,84 @@
+import { CustomTask, Requirement } from '@/database/requirement';
+import { Box } from '@mui/material';
+import { useMemo } from 'react';
+import { Virtuoso } from 'react-virtuoso';
+import { ProgressHistoryItem } from './ProgressHistoryItem';
+import { type HistoryItem, type HistoryItemError } from './progressHistoryEditor';
+
+interface ProgressHistoryListProps {
+    requirement: Requirement | CustomTask;
+    items: HistoryItem[];
+    errors: Record<number, HistoryItemError>;
+    updateItem: (index: number, item: HistoryItem) => void;
+    updateDraftItem: (index: number, item: HistoryItem) => void;
+    getDraftItem: (index: number) => HistoryItem | undefined;
+    deleteItem: (index: number) => void;
+    scrollParent: HTMLElement | null;
+}
+
+interface ProgressHistoryListRow {
+    item: HistoryItem;
+    itemIndex: number;
+}
+
+const emptyHistoryItemError: HistoryItemError = {};
+const estimatedRowHeight = 300;
+const scrollBufferHeight = estimatedRowHeight * 3;
+const initialRenderRowCount = 4;
+
+export function ProgressHistoryList({
+    requirement,
+    items,
+    errors,
+    updateItem,
+    updateDraftItem,
+    getDraftItem,
+    deleteItem,
+    scrollParent,
+}: ProgressHistoryListProps) {
+    const rows = useMemo(
+        () =>
+            items
+                .map((item, itemIndex) => ({ item, itemIndex }))
+                .filter(({ item }) => !item.deleted)
+                .reverse(),
+        [items],
+    );
+
+    const renderRow = (row: ProgressHistoryListRow) => {
+        const item = getDraftItem(row.itemIndex) ?? row.item;
+
+        return (
+            <Box key={item.entry.id} data-testid='task-history-virtual-row'>
+                <ProgressHistoryItem
+                    requirement={requirement}
+                    item={item}
+                    error={errors[row.itemIndex] ?? emptyHistoryItemError}
+                    itemIndex={row.itemIndex}
+                    updateItem={updateItem}
+                    updateDraftItem={updateDraftItem}
+                    deleteItem={deleteItem}
+                />
+            </Box>
+        );
+    };
+
+    return (
+        <Box data-testid='task-history-virtual-list' sx={{ width: 1 }}>
+            {scrollParent ? (
+                <Virtuoso<ProgressHistoryListRow>
+                    customScrollParent={scrollParent}
+                    data={rows}
+                    computeItemKey={(_, row) => row.item.entry.id}
+                    defaultItemHeight={estimatedRowHeight}
+                    increaseViewportBy={{ top: scrollBufferHeight, bottom: scrollBufferHeight }}
+                    initialItemCount={Math.min(rows.length, initialRenderRowCount)}
+                    minOverscanItemCount={{ top: 3, bottom: 6 }}
+                    itemContent={(_, row) => renderRow(row)}
+                />
+            ) : (
+                rows.slice(0, initialRenderRowCount).map(renderRow)
+            )}
+        </Box>
+    );
+}

--- a/frontend/src/components/profile/trainingPlan/progressHistoryEditor.test.ts
+++ b/frontend/src/components/profile/trainingPlan/progressHistoryEditor.test.ts
@@ -1,0 +1,131 @@
+import {
+    Requirement,
+    RequirementCategory,
+    RequirementStatus,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { TimelineEntry } from '@/database/timeline';
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+import {
+    getProgressSummary,
+    getTimelineUpdate,
+    HistoryItem,
+    validateItems,
+} from './progressHistoryEditor';
+
+const requirement: Requirement = {
+    id: 'classical-games',
+    status: RequirementStatus.Active,
+    category: RequirementCategory.Games,
+    name: 'Play Classical Games',
+    description: '',
+    freeDescription: '',
+    counts: { '1400-1500': 40 },
+    startCount: 0,
+    numberOfCohorts: 1,
+    unitScore: 1,
+    totalScore: 0,
+    scoreboardDisplay: ScoreboardDisplay.Yearly,
+    progressBarSuffix: 'games',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    sortPriority: 'games',
+    expirationDays: -1,
+    isFree: false,
+    atomic: false,
+    expectedMinutes: 0,
+};
+
+const tc = (key: 'fieldRequired' | 'mustBeInteger') => key;
+
+function makeEntry(index: number): TimelineEntry {
+    const date = `2026-01-${`${(index % 28) + 1}`.padStart(2, '0')}T12:00:00.000Z`;
+    return {
+        owner: 'test',
+        id: `entry-${index}`,
+        ownerDisplayName: 'Test User',
+        cohort: '1400-1500',
+        requirementId: requirement.id,
+        requirementName: requirement.name,
+        requirementCategory: RequirementCategory.Games,
+        scoreboardDisplay: ScoreboardDisplay.Yearly,
+        progressBarSuffix: 'games',
+        totalCount: 40,
+        previousCount: index,
+        newCount: index + 1,
+        dojoPoints: 1,
+        totalDojoPoints: index + 1,
+        minutesSpent: 30,
+        totalMinutesSpent: (index + 1) * 30,
+        date,
+        createdAt: date,
+        notes: `notes ${index}`,
+        comments: [],
+        reactions: {},
+    };
+}
+
+function makeItem(index: number, deleted = false): HistoryItem {
+    const entry = makeEntry(index);
+    return {
+        date: DateTime.fromISO(entry.date || entry.createdAt),
+        count: '1',
+        hours: '0',
+        minutes: '30',
+        notes: entry.notes,
+        entry,
+        index,
+        deleted,
+        cohort: '1400-1500',
+        isNew: false,
+    };
+}
+
+describe('progressHistoryEditor', () => {
+    it('summarizes draft counts and time without building a save payload', () => {
+        const items = [makeItem(0), makeItem(1), makeItem(2)];
+
+        expect(getProgressSummary(requirement, items, '1400-1500')).toEqual({
+            cohortCount: 3,
+            totalCount: 3,
+            cohortTime: 90,
+            totalTime: 90,
+        });
+    });
+
+    it('ignores deleted rows in draft summaries and save payloads', () => {
+        const items = [makeItem(0), makeItem(1, true), makeItem(2)];
+
+        expect(getProgressSummary(requirement, items, '1400-1500')).toEqual({
+            cohortCount: 2,
+            totalCount: 2,
+            cohortTime: 60,
+            totalTime: 60,
+        });
+
+        const update = getTimelineUpdate(requirement, items, tc);
+        expect(update.deleted).toEqual([items[1].entry]);
+        expect(update.progress.counts?.ALL_COHORTS).toBe(2);
+        expect(update.progress.minutesSpent['1400-1500']).toBe(60);
+    });
+
+    it('validates invalid draft values only when validation is requested', () => {
+        const invalid = makeItem(0);
+        invalid.count = 'abc';
+        invalid.hours = '1.5';
+
+        expect(getProgressSummary(requirement, [invalid], '1400-1500')).toEqual({
+            cohortCount: 0,
+            totalCount: 0,
+            cohortTime: 30,
+            totalTime: 30,
+        });
+
+        expect(validateItems([invalid], tc)).toEqual({
+            0: {
+                count: 'mustBeInteger',
+                hours: 'mustBeInteger',
+            },
+        });
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/progressHistoryEditor.ts
+++ b/frontend/src/components/profile/trainingPlan/progressHistoryEditor.ts
@@ -1,0 +1,292 @@
+import {
+    CustomTask,
+    getCurrentScore,
+    getTotalCount,
+    isRequirement,
+    Requirement,
+    RequirementProgress,
+    ScoreboardDisplay,
+} from '@/database/requirement';
+import { TimelineEntry } from '@/database/timeline';
+import { ALL_COHORTS, compareCohorts, dojoCohorts, User } from '@/database/user';
+import deepEqual from 'deep-equal';
+import { DateTime } from 'luxon';
+import { v4 as uuidv4 } from 'uuid';
+
+const NUMBER_REGEX = /^[0-9]*$/;
+const NEGATIVE_NUMBER_REGEX = /^-?[0-9]*$/;
+
+export interface HistoryItem {
+    date: DateTime | null;
+    count: string;
+    hours: string;
+    minutes: string;
+    notes: string;
+    entry: TimelineEntry;
+    index: number;
+    deleted: boolean;
+    cohort: string;
+    /** True if this entry was added in the current session and not yet saved */
+    isNew?: boolean;
+}
+
+export interface HistoryItemError {
+    date?: string;
+    count?: string;
+    hours?: string;
+    minutes?: string;
+}
+
+export interface ProgressHistorySummary {
+    cohortCount: number;
+    cohortTime: number;
+    totalCount: number;
+    totalTime: number;
+}
+
+type TranslateCommon = (key: 'fieldRequired' | 'mustBeInteger') => string;
+
+export function createNewEntry(
+    requirement: Requirement | CustomTask,
+    cohort: string,
+    index: number,
+    user: User,
+): HistoryItem {
+    const now = DateTime.now().toUTC();
+    const id = `${now.toISODate()}_${uuidv4()}`;
+
+    const cohortOptions = requirement.counts[ALL_COHORTS]
+        ? dojoCohorts
+        : Object.keys(requirement.counts).sort(compareCohorts);
+    if (!cohortOptions.includes(cohort)) {
+        cohort = cohortOptions[0];
+    }
+
+    const totalCount = getTotalCount(cohort, requirement);
+
+    return {
+        date: now,
+        count: '',
+        hours: '',
+        minutes: '',
+        notes: '',
+        cohort,
+        index,
+        deleted: false,
+        isNew: true,
+        entry: {
+            owner: user.username,
+            id,
+            ownerDisplayName: user.displayName,
+            requirementId: requirement.id,
+            requirementName: isRequirement(requirement)
+                ? requirement.shortName || requirement.name
+                : requirement.name,
+            requirementCategory: requirement.category,
+            isCustomRequirement: !isRequirement(requirement),
+            scoreboardDisplay: requirement.scoreboardDisplay,
+            progressBarSuffix: requirement.progressBarSuffix,
+            cohort,
+            totalCount,
+            previousCount: 0,
+            newCount: 0,
+            dojoPoints: 0,
+            totalDojoPoints: 0,
+            minutesSpent: 0,
+            totalMinutesSpent: 0,
+            date: now.toISO() ?? '',
+            createdAt: now.toISO() ?? '',
+            notes: '',
+            comments: [],
+            reactions: {},
+        },
+    };
+}
+
+export function validateItems(
+    items: HistoryItem[],
+    tc: TranslateCommon,
+): Record<number, HistoryItemError> {
+    const errors: Record<number, HistoryItemError> = {};
+
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.deleted) continue;
+
+        const itemErrors: HistoryItemError = {};
+
+        if (item.date === null) {
+            itemErrors.date = tc('fieldRequired');
+        }
+        if (
+            item.count !== '' &&
+            (!NEGATIVE_NUMBER_REGEX.test(item.count) || isNaN(parseInt(item.count)))
+        ) {
+            itemErrors.count = tc('mustBeInteger');
+        }
+        if (item.hours !== '' && (!NUMBER_REGEX.test(item.hours) || isNaN(parseInt(item.hours)))) {
+            itemErrors.hours = tc('mustBeInteger');
+        }
+        if (
+            item.minutes !== '' &&
+            (!NUMBER_REGEX.test(item.minutes) || isNaN(parseInt(item.minutes)))
+        ) {
+            itemErrors.minutes = tc('mustBeInteger');
+        }
+
+        if (Object.keys(itemErrors).length > 0) {
+            errors[i] = itemErrors;
+        }
+    }
+
+    return errors;
+}
+
+function parseDraftInteger(value: string): number {
+    if (!/^-?[0-9]+$/.test(value)) {
+        return 0;
+    }
+    return parseInt(value, 10);
+}
+
+export function getDraftProgress(
+    requirement: Requirement | CustomTask | undefined,
+    items: HistoryItem[],
+): RequirementProgress & { counts: Record<string, number> } {
+    const progress: RequirementProgress & { counts: Record<string, number> } = {
+        requirementId: requirement?.id || '',
+        minutesSpent: {},
+        counts: {},
+        updatedAt: '',
+    };
+
+    if (!requirement) {
+        return progress;
+    }
+
+    for (const item of items) {
+        if (item.deleted) continue;
+
+        const cohort =
+            requirement.numberOfCohorts === 0 || requirement.numberOfCohorts === 1
+                ? ALL_COHORTS
+                : item.cohort;
+
+        const minutesSpent = 60 * parseDraftInteger(item.hours) + parseDraftInteger(item.minutes);
+        progress.minutesSpent[item.cohort] =
+            (progress.minutesSpent[item.cohort] ?? 0) + minutesSpent;
+
+        const previousCount = progress.counts[cohort] ?? (requirement.startCount || 0);
+        const newCount =
+            item.entry.scoreboardDisplay === ScoreboardDisplay.Minutes
+                ? previousCount + minutesSpent
+                : previousCount + parseDraftInteger(item.count);
+        progress.counts[cohort] = newCount;
+    }
+
+    return progress;
+}
+
+export function summarizeProgress(
+    progress: RequirementProgress,
+    cohort: string,
+): ProgressHistorySummary {
+    const cohortCount = progress.counts?.ALL_COHORTS ?? progress.counts?.[cohort] ?? 0;
+    const totalCount = Object.values(progress.counts ?? {}).reduce((sum, value) => sum + value, 0);
+    const cohortTime = progress.minutesSpent[cohort] ?? 0;
+    const totalTime = Object.values(progress.minutesSpent).reduce((sum, value) => sum + value, 0);
+
+    return { cohortCount, cohortTime, totalCount, totalTime };
+}
+
+export function getProgressSummary(
+    requirement: Requirement | CustomTask | undefined,
+    items: HistoryItem[],
+    cohort: string,
+): ProgressHistorySummary {
+    return summarizeProgress(getDraftProgress(requirement, items), cohort);
+}
+
+export function getTimelineUpdate(
+    requirement: Requirement | CustomTask | undefined,
+    items: HistoryItem[],
+    tc: TranslateCommon,
+): {
+    progress: RequirementProgress;
+    updated: TimelineEntry[];
+    deleted: TimelineEntry[];
+    errors: Record<number, HistoryItemError>;
+} {
+    const errors = validateItems(items, tc);
+
+    if (!requirement || Object.keys(errors).length > 0) {
+        return {
+            progress: { requirementId: requirement?.id || '', minutesSpent: {}, updatedAt: '' },
+            updated: [],
+            deleted: [],
+            errors,
+        };
+    }
+
+    const updated: TimelineEntry[] = [];
+    const deleted: TimelineEntry[] = [];
+    const progress: RequirementProgress & { counts: Record<string, number> } = {
+        requirementId: requirement.id,
+        minutesSpent: {},
+        counts: {},
+        updatedAt: '',
+    };
+
+    for (const item of items) {
+        if (item.deleted) {
+            deleted.push(item.entry);
+            continue;
+        }
+
+        const cohort =
+            requirement.numberOfCohorts === 0 || requirement.numberOfCohorts === 1
+                ? ALL_COHORTS
+                : item.cohort;
+
+        const minutesSpent = 60 * parseDraftInteger(item.hours) + parseDraftInteger(item.minutes);
+        progress.minutesSpent[item.cohort] =
+            (progress.minutesSpent[item.cohort] ?? 0) + minutesSpent;
+
+        const previousCount = progress.counts[cohort] ?? (requirement.startCount || 0);
+        const newCount =
+            item.entry.scoreboardDisplay === ScoreboardDisplay.Minutes
+                ? previousCount + minutesSpent
+                : previousCount + parseDraftInteger(item.count);
+        progress.counts[cohort] = newCount;
+
+        let previousScore = 0;
+        let newScore = 0;
+        if (isRequirement(requirement)) {
+            previousScore = getCurrentScore(item.cohort, requirement, {
+                counts: { [ALL_COHORTS]: previousCount, [item.cohort]: previousCount },
+            } as unknown as RequirementProgress);
+            newScore = getCurrentScore(item.cohort, requirement, {
+                counts: { [ALL_COHORTS]: newCount, [item.cohort]: newCount },
+            } as unknown as RequirementProgress);
+        }
+
+        const newEntry = {
+            ...item.entry,
+            cohort: item.cohort,
+            notes: item.notes,
+            date: item.date?.toUTC().toISO() || item.entry.createdAt,
+            previousCount,
+            newCount,
+            dojoPoints: newScore - previousScore,
+            totalDojoPoints: newScore,
+            minutesSpent,
+            totalMinutesSpent: progress.minutesSpent[item.cohort],
+        };
+
+        if (!deepEqual(item.entry, newEntry)) {
+            updated.push(newEntry);
+        }
+    }
+
+    return { progress, updated, deleted, errors };
+}


### PR DESCRIPTION
## Summary

This PR improves the progress history dialog responsiveness. Previously, typing into fields could feel delayed because the dialog recalculated too much progress-history state on each edit. For users with many logged entries, opening the dialog could also be slow because every history row was rendered at once.

The dialog now keeps field edits lightweight while the user is typing and calculates the full progress update when saving. It also only renders the visible history rows, which improves the experience for large histories while preserving the existing save behavior.

## Related Issues

Fixes #2442

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}
