### PR TITLE
fix: accept multiple correct answers in blindfold mates

### DIFF
--- a/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
+++ b/frontend/src/components/puzzles/mateInOne/MateInOneDrillPage.tsx
@@ -342,8 +342,11 @@ function MateInOneDrill() {
         if (!currentPuzzle || feedback !== null || userInput.trim() === '') return;
 
         const responseTimeMs = performance.now() - questionStartRef.current;
-        const correct = isCorrectAnswer(userInput, currentPuzzle.correctSan);
-
+        const correct = isCorrectAnswer(
+            currentPuzzle.fenAfterSetup,
+            userInput,
+            currentPuzzle.correctSan,
+        );
         const attempt: MateInOneAttempt = {
             puzzleId: currentPuzzle.puzzle.id,
             fen: currentPuzzle.fenAfterSetup,

--- a/frontend/src/components/puzzles/mateInOne/mateInOneDrillUtils.ts
+++ b/frontend/src/components/puzzles/mateInOne/mateInOneDrillUtils.ts
@@ -1,3 +1,4 @@
+import { Chess } from '@jackstenglein/chess';
 import { MateInOneAttempt } from '@jackstenglein/chess-dojo-common/src/mateInOne/api';
 import {
     PUZZLES_PER_BLOCK,
@@ -27,8 +28,23 @@ export function normalizeSan(san: string): string {
  * @param correctSan - The puzzle's correct mating move in SAN.
  * @returns Whether the user's input matches the correct move.
  */
-export function isCorrectAnswer(userInput: string, correctSan: string): boolean {
-    return normalizeSan(userInput) === normalizeSan(correctSan);
+export function isCorrectAnswer(fen: string, userInput: string, correctSan: string): boolean {
+    if (normalizeSan(userInput) === normalizeSan(correctSan)) {
+        return true;
+    }
+
+    try {
+        const chess = new Chess({ fen });
+        const moveResult = chess.move(userInput);
+
+        if (moveResult && chess.isCheckmate()) {
+            return true;
+        }
+    } catch (_e) {
+        return false;
+    }
+
+    return false;
 }
 
 /** Aggregate stats for a list of mate-in-one attempts. */

--- a/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
@@ -38,42 +38,42 @@ describe('normalizeSan', () => {
 
 describe('isCorrectAnswer', () => {
     it('accepts exact match', () => {
-        expect(isCorrectAnswer('Qh7', 'Qh7')).toBe(true);
+        expect(isCorrectAnswer('', 'Qh7', 'Qh7')).toBe(true);
     });
 
     it('accepts answer without checkmate annotation', () => {
-        expect(isCorrectAnswer('Qh7', 'Qh7#')).toBe(true);
+        expect(isCorrectAnswer('', 'Qh7', 'Qh7#')).toBe(true);
     });
 
     it('accepts answer without check annotation', () => {
-        expect(isCorrectAnswer('Nf3', 'Nf3+')).toBe(true);
+        expect(isCorrectAnswer('', 'Nf3', 'Nf3+')).toBe(true);
     });
 
     it('accepts promotion without equals sign', () => {
-        expect(isCorrectAnswer('a8Q', 'a8=Q')).toBe(true);
+        expect(isCorrectAnswer('', 'a8Q', 'a8=Q')).toBe(true);
     });
 
     it('rejects wrong move', () => {
-        expect(isCorrectAnswer('Qh6', 'Qh7#')).toBe(false);
+        expect(isCorrectAnswer('', 'Qh6', 'Qh7#')).toBe(false);
     });
 
     it('is case-insensitive', () => {
-        expect(isCorrectAnswer('qh7', 'Qh7#')).toBe(true);
+        expect(isCorrectAnswer('', 'qh7', 'Qh7#')).toBe(true);
     });
 
     it('accepts answer without capture notation', () => {
-        expect(isCorrectAnswer('Qh7', 'Qxh7')).toBe(true);
+        expect(isCorrectAnswer('', 'Qh7', 'Qxh7')).toBe(true);
     });
 
     it('accepts castling using zeroes', () => {
-        expect(isCorrectAnswer('0-0', 'O-O')).toBe(true);
+        expect(isCorrectAnswer('', '0-0', 'O-O')).toBe(true);
     });
 
     it('accepts castling without dashes', () => {
-        expect(isCorrectAnswer('OO', 'O-O')).toBe(true);
+        expect(isCorrectAnswer('', 'OO', 'O-O')).toBe(true);
     });
 
     it('rejects castling wrong way', () => {
-        expect(isCorrectAnswer('O-O-O', 'O-O')).toBe(false);
+        expect(isCorrectAnswer('', 'O-O-O', 'O-O')).toBe(false);
     });
 });

--- a/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
+++ b/frontend/src/components/puzzles/mateInOne/normalizeSan.test.ts
@@ -76,4 +76,8 @@ describe('isCorrectAnswer', () => {
     it('rejects castling wrong way', () => {
         expect(isCorrectAnswer('', 'O-O-O', 'O-O')).toBe(false);
     });
+
+    it('accepts another move that is checkmate', () => {
+        expect(isCorrectAnswer('8/8/pK6/8/k7/2Q5/1P6/3q4 w - - 0 1', 'Qa3', 'Qc4#')).toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary

updated isCorrectAnswer to pass the board FEN. it still checks the strict string match first as a fast-path optimization. If that fails, it loads the FEN into chess.js, attempts the users move, and returns true if chess.isCheckmate() is valid. also added a catch (_e) to safely handle illegal move exceptions from the chess engine

## Related Issues

Closes #2483 
