### PR TITLE
feat(2423) add comments to incorrect moves in solitaire mode

### DIFF
--- a/frontend/src/board/pgn/solitaire/useSolitaireChess.ts
+++ b/frontend/src/board/pgn/solitaire/useSolitaireChess.ts
@@ -242,6 +242,11 @@ function handleCorrectMove({
     setResults: React.Dispatch<React.SetStateAction<SolitaireResults>>;
 }) {
     const nextMove = chess.move(move);
+
+    nextMove?.variations?.forEach((variation) => {
+        variation[0].commentMove = 'Incorrect guess in solitaire mode';
+    });
+
     const color = nextMove?.color === Color.white ? 'white' : 'black';
     setResults((results) => ({
         ...results,


### PR DESCRIPTION

## Summary

Adds comment for incorrect moves when going through game in solitaire mode. Comments added in useSolitaireChess hook

## Related Issues

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to: Found no relevant tests for solitaire mode (should add?)

## Demo

<img width="1244" height="722" alt="image" src="https://github.com/user-attachments/assets/764f29fd-866b-446d-a169-ab0ba496bad7" />
