### PR TITLE
feat(2423) add comments to incorrect moves in solitaire mode

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1,4 +1,27 @@
 {
+    "_translationMeta": {
+        "_about": "Instructions for whoever produces a translated copy of this file. Paths listed under skipAutoTranslate should not be passed through an automated translator; manual human translation of those paths is welcome where appropriate. preserveStructure rules apply to every key during translation. This block is stripped at message-load time and never reaches the runtime UI.",
+        "skipAutoTranslate": {
+            "enums.ratingSystem": "Backend wire values plus brand-name display labels. Keep English so users can match the labels on the actual rating-system websites. Manual translation OK if the translator knows the local convention.",
+            "enums.requirementCategory": "Display labels for a backend category enum. Manual translation welcome.",
+            "enums.requirementCategoryShort": "Same as requirementCategory.",
+            "landing.senseis": "Trainer names are proper nouns; bios are credential prose with embedded titles and platform names. Manual translation only.",
+            "coach.stripe.connect": "References a payment processor brand. Manual translation if surrounding text needs it.",
+            "coach.stripe.dashboard": "Same.",
+            "profile.ratings.chesscomUsername": "Brand name in label.",
+            "profile.ratings.lichessUsername": "Brand name in label.",
+            "profile.ratings.fideId": "Acronym for an international chess federation.",
+            "profile.ratings.uscfId": "Acronym for a national chess federation.",
+            "profile.ratings.ecfRatingCode": "Acronym for a national chess federation.",
+            "profile.ratings.cfcId": "Acronym for a national chess federation.",
+            "profile.ratings.dwzId": "Acronym for a national rating system."
+        },
+        "preserveStructure": {
+            "icuPlurals": "Preserve {count, plural, =1 {...} other {...}} syntax verbatim. Translate only the text inside the inner braces.",
+            "tagPlaceholders": "Preserve <tagName>...</tagName> tags including the tag name itself. Translate only the text between tags.",
+            "variables": "Preserve {variableName} placeholders verbatim. Surrounding sentence may be restructured for word order, but placeholder spelling and case must not change."
+        }
+    },
     "common": {
         "timezone": "Zeitzone",
         "language": "Sprache",
@@ -2195,11 +2218,11 @@
                 "lichessJoin": "Tritt <link>ChessDoji's Team</link> auf Lichess bei.",
                 "chesscomJoin": "Tritt <link>ChessDojo's Team</link> auf Chess.com bei",
                 "discordJoin": "Tritt <link>ChessDojo's Discord</link> bei, um optional deine Lichess- und Chess.com-Konten zu verbinden!",
-                "leaderboardHeader": "Ranglisten Info",
                 "eventsHeader": "Wöchentliche Swiss-Events",
                 "mondayEvents": "Montag 14 Uhr ET — Blitz 3+2 (9 Runden)",
                 "wednesdayEvents": "Mittwoch 13 Uhr ET — Rapid 15+5 (5 Runden)",
                 "saturdayEvents": "Samstag 12 Uhr ET — Klassisch 30+5 (4 Runden)",
+                "leaderboardHeader": "Ranglisten Info",
                 "weeklyEvents": "Wöchentliche Swiss-Events:",
                 "weeklySwissPoints": {
                     "first": "1. Platz: 12 Punkte",
@@ -3710,6 +3733,7 @@
                 "replyPostButton": "Antworten",
                 "updatedAt": "Aktualisiert am {date} • {time}"
             },
+            "directories": {},
             "share": {
                 "addToFolder": "Zum Ordner hinzufügen",
                 "copyUrl": "URL kopieren",
@@ -3875,7 +3899,8 @@
                 "startFromCurrentMoveButton": "Vom aktuellen Zug starten",
                 "exitSolitaireModeButton": "Solitär-Modus beenden",
                 "cannotStartLastMoveError": "Kann nicht vom letzten Zug starten",
-                "cannotStartVariationError": "Kann nicht von einer Variante starten"
+                "cannotStartVariationError": "Kann nicht von einer Variante starten",
+                "incorrectMoveComment": "Falsche Eingabe im Solitärmodus"
             }
         }
     },
@@ -3969,6 +3994,7 @@
             "faqClassCalendar": "<faqLink>FAQ</faqLink> / <calendarLink>Kurs-Kalender</calendarLink>",
             "perClassSubtitle": "(~ {currency}{amount} / Klasse)"
         },
+        "sellingPoint": {},
         "pricingPage": {
             "tabMonthly": "Monatlich",
             "tabYearly": "Jährlich",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3899,7 +3899,8 @@
                 "startFromCurrentMoveButton": "Start from Current Move",
                 "exitSolitaireModeButton": "Exit Solitaire Mode",
                 "cannotStartLastMoveError": "Cannot start from the last move",
-                "cannotStartVariationError": "Cannot start from a variation"
+                "cannotStartVariationError": "Cannot start from a variation",
+                "incorrectMoveComment": "Incorrect guess in solitaire mode"
             }
         }
     },

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -3899,7 +3899,8 @@
                 "startFromCurrentMoveButton": "Empezar desde la jugada actual",
                 "exitSolitaireModeButton": "Salir del modo solitario",
                 "cannotStartLastMoveError": "No se puede empezar desde la última jugada",
-                "cannotStartVariationError": "No se puede empezar desde una variante"
+                "cannotStartVariationError": "No se puede empezar desde una variante",
+                "incorrectMoveComment": "Suposición incorrecta en el modo solitario."
             }
         }
     },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1,4 +1,27 @@
 {
+    "_translationMeta": {
+        "_about": "Instructions for whoever produces a translated copy of this file. Paths listed under skipAutoTranslate should not be passed through an automated translator; manual human translation of those paths is welcome where appropriate. preserveStructure rules apply to every key during translation. This block is stripped at message-load time and never reaches the runtime UI.",
+        "skipAutoTranslate": {
+            "enums.ratingSystem": "Backend wire values plus brand-name display labels. Keep English so users can match the labels on the actual rating-system websites. Manual translation OK if the translator knows the local convention.",
+            "enums.requirementCategory": "Display labels for a backend category enum. Manual translation welcome.",
+            "enums.requirementCategoryShort": "Same as requirementCategory.",
+            "landing.senseis": "Trainer names are proper nouns; bios are credential prose with embedded titles and platform names. Manual translation only.",
+            "coach.stripe.connect": "References a payment processor brand. Manual translation if surrounding text needs it.",
+            "coach.stripe.dashboard": "Same.",
+            "profile.ratings.chesscomUsername": "Brand name in label.",
+            "profile.ratings.lichessUsername": "Brand name in label.",
+            "profile.ratings.fideId": "Acronym for an international chess federation.",
+            "profile.ratings.uscfId": "Acronym for a national chess federation.",
+            "profile.ratings.ecfRatingCode": "Acronym for a national chess federation.",
+            "profile.ratings.cfcId": "Acronym for a national chess federation.",
+            "profile.ratings.dwzId": "Acronym for a national rating system."
+        },
+        "preserveStructure": {
+            "icuPlurals": "Preserve {count, plural, =1 {...} other {...}} syntax verbatim. Translate only the text inside the inner braces.",
+            "tagPlaceholders": "Preserve <tagName>...</tagName> tags including the tag name itself. Translate only the text between tags.",
+            "variables": "Preserve {variableName} placeholders verbatim. Surrounding sentence may be restructured for word order, but placeholder spelling and case must not change."
+        }
+    },
     "common": {
         "timezone": "Fuseau horaire",
         "language": "Langue",
@@ -3876,7 +3899,8 @@
                 "startFromCurrentMoveButton": "Commencer depuis le coup actuel",
                 "exitSolitaireModeButton": "Quitter le mode Solitaire",
                 "cannotStartLastMoveError": "Impossible de commencer depuis le dernier coup",
-                "cannotStartVariationError": "Impossible de commencer depuis une variante"
+                "cannotStartVariationError": "Impossible de commencer depuis une variante",
+                "incorrectMoveComment": "Mauvaise réponse en mode solitaire"
             }
         }
     },

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -1,4 +1,27 @@
 {
+    "_translationMeta": {
+        "_about": "Instructions for whoever produces a translated copy of this file. Paths listed under skipAutoTranslate should not be passed through an automated translator; manual human translation of those paths is welcome where appropriate. preserveStructure rules apply to every key during translation. This block is stripped at message-load time and never reaches the runtime UI.",
+        "skipAutoTranslate": {
+            "enums.ratingSystem": "Backend wire values plus brand-name display labels. Keep English so users can match the labels on the actual rating-system websites. Manual translation OK if the translator knows the local convention.",
+            "enums.requirementCategory": "Display labels for a backend category enum. Manual translation welcome.",
+            "enums.requirementCategoryShort": "Same as requirementCategory.",
+            "landing.senseis": "Trainer names are proper nouns; bios are credential prose with embedded titles and platform names. Manual translation only.",
+            "coach.stripe.connect": "References a payment processor brand. Manual translation if surrounding text needs it.",
+            "coach.stripe.dashboard": "Same.",
+            "profile.ratings.chesscomUsername": "Brand name in label.",
+            "profile.ratings.lichessUsername": "Brand name in label.",
+            "profile.ratings.fideId": "Acronym for an international chess federation.",
+            "profile.ratings.uscfId": "Acronym for a national chess federation.",
+            "profile.ratings.ecfRatingCode": "Acronym for a national chess federation.",
+            "profile.ratings.cfcId": "Acronym for a national chess federation.",
+            "profile.ratings.dwzId": "Acronym for a national rating system."
+        },
+        "preserveStructure": {
+            "icuPlurals": "Preserve {count, plural, =1 {...} other {...}} syntax verbatim. Translate only the text inside the inner braces.",
+            "tagPlaceholders": "Preserve <tagName>...</tagName> tags including the tag name itself. Translate only the text between tags.",
+            "variables": "Preserve {variableName} placeholders verbatim. Surrounding sentence may be restructured for word order, but placeholder spelling and case must not change."
+        }
+    },
     "common": {
         "timezone": "Fuso orario",
         "language": "Lingua",
@@ -3876,7 +3899,8 @@
                 "startFromCurrentMoveButton": "Inizia dalla mossa attuale",
                 "exitSolitaireModeButton": "Esci dalla modalità solitario",
                 "cannotStartLastMoveError": "Impossibile iniziare dall'ultima mossa",
-                "cannotStartVariationError": "Impossibile iniziare da una variante"
+                "cannotStartVariationError": "Impossibile iniziare da una variante",
+                "incorrectMoveComment": "Indovinare in modo errato nella modalità solitario"
             }
         }
     },

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -2218,11 +2218,11 @@
                 "lichessJoin": "[T] Join <link>ChessDojo's Team</link> on Lichess.",
                 "chesscomJoin": "[T] Join <link>ChessDojo's Team</link> on Chess.com.",
                 "discordJoin": "[T] Join <link>ChessDojo's Discord</link> to optionally connect your Lichess and Chess.com accounts!",
-                "leaderboardHeader": "[T] Leaderboard Info",
                 "eventsHeader": "[T] Weekly Swiss Events",
                 "mondayEvents": "[T] Monday 2pm ET — Blitz 3+2 (9 rounds)",
                 "wednesdayEvents": "[T] Wednesday 1pm ET — Rapid 15+5 (5 rounds)",
                 "saturdayEvents": "[T] Saturday 12pm ET — Classical 30+5 (4 rounds)",
+                "leaderboardHeader": "[T] Leaderboard Info",
                 "weeklyEvents": "[T] Weekly Swiss Events:",
                 "weeklySwissPoints": {
                     "first": "[T] 1st: 12 points",
@@ -3733,6 +3733,7 @@
                 "replyPostButton": "[T] reply",
                 "updatedAt": "[T] Updated at {date} • {time}"
             },
+            "directories": {},
             "share": {
                 "addToFolder": "[T] Add to Folder",
                 "copyUrl": "[T] Copy URL",
@@ -3898,7 +3899,8 @@
                 "startFromCurrentMoveButton": "[T] Start from Current Move",
                 "exitSolitaireModeButton": "[T] Exit Solitaire Mode",
                 "cannotStartLastMoveError": "[T] Cannot start from the last move",
-                "cannotStartVariationError": "[T] Cannot start from a variation"
+                "cannotStartVariationError": "[T] Cannot start from a variation",
+                "incorrectMoveComment": "[T] Incorrect guess in solitaire mode"
             }
         }
     },
@@ -3992,6 +3994,7 @@
             "faqClassCalendar": "[T] <faqLink>FAQ</faqLink> / <calendarLink>Class Calendar</calendarLink>",
             "perClassSubtitle": "[T] (~ {currency}{amount} / class)"
         },
+        "sellingPoint": {},
         "pricingPage": {
             "tabMonthly": "[T] Monthly",
             "tabYearly": "[T] Yearly",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -3899,7 +3899,8 @@
                 "startFromCurrentMoveButton": "Começar do lance atual",
                 "exitSolitaireModeButton": "Sair do modo solitário",
                 "cannotStartLastMoveError": "Não é possível começar do último lance",
-                "cannotStartVariationError": "Não é possível começar de uma variante"
+                "cannotStartVariationError": "Não é possível começar de uma variante",
+                "incorrectMoveComment": "Palpite incorreto no modo solitário"
             }
         }
     },

--- a/frontend/src/board/pgn/solitaire/useSolitaireChess.ts
+++ b/frontend/src/board/pgn/solitaire/useSolitaireChess.ts
@@ -8,7 +8,8 @@ import {
     CORRECT_SOUND_KEY,
     INCORRECT_SOUND_KEY,
 } from '@/components/puzzles/settings/puzzleSettingsKeys';
-import { Chess, Color, Move, Square } from '@jackstenglein/chess';
+import { Chess, Color, CommentType, Move, Square } from '@jackstenglein/chess';
+import { useTranslations } from 'next-intl';
 import { RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
 
@@ -92,6 +93,8 @@ export function useSolitaireChess(
     const allowDifferentMates = useRef(false);
     const [correctSound] = useLocalStorage(CORRECT_SOUND_KEY, true);
     const [incorrectSound] = useLocalStorage(INCORRECT_SOUND_KEY, true);
+    const t = useTranslations('analysisBoard.underboard.tools');
+    const incorrectMoveComment = t('incorrectMoveComment');
 
     const start = useCallback(
         (move: Move | null, opts?: SolitaireChessOptions) => {
@@ -148,6 +151,11 @@ export function useSolitaireChess(
             }
 
             const move = { from: primMove.orig, to: primMove.dest, promotion: primMove.promotion };
+            const existingMove = chess.move(move, {
+                previousMove: currentMove,
+                skipSeek: true,
+                existingOnly: true,
+            });
             const testMove = chess.move(move, { previousMove: currentMove, skipSeek: true });
             if (
                 chess.isMainline(move) ||
@@ -176,8 +184,15 @@ export function useSolitaireChess(
             }
 
             incorrectMoves.current.push(move);
-            if (!addWrongMoves) {
+            if (!addWrongMoves && existingMove === null) {
                 chess.delete(testMove);
+            } else if (
+                addWrongMoves &&
+                testMove &&
+                !testMove.commentAfter?.includes(incorrectMoveComment)
+            ) {
+                const newComment = (testMove.commentAfter ?? '') + '\n\n' + incorrectMoveComment;
+                chess.setComment(newComment.trim(), CommentType.After, testMove);
             }
             board.set({
                 movable: {},
@@ -194,7 +209,15 @@ export function useSolitaireChess(
             }, 500);
             onWrongMove.current?.();
         },
-        [showGlyphs, addWrongMoves, currentMove, playAs, incorrectSound, correctSound],
+        [
+            showGlyphs,
+            addWrongMoves,
+            currentMove,
+            playAs,
+            incorrectSound,
+            correctSound,
+            incorrectMoveComment,
+        ],
     );
 
     const complete = currentMove === lastMove.current || chess.isCheckmate(currentMove);
@@ -242,11 +265,6 @@ function handleCorrectMove({
     setResults: React.Dispatch<React.SetStateAction<SolitaireResults>>;
 }) {
     const nextMove = chess.move(move);
-
-    nextMove?.variations?.forEach((variation) => {
-        variation[0].commentMove = 'Incorrect guess in solitaire mode';
-    });
-
     const color = nextMove?.color === Color.white ? 'white' : 'black';
     setResults((results) => ({
         ...results,

--- a/frontend/src/board/pgn/solitaire/useSolitaireChess.ts
+++ b/frontend/src/board/pgn/solitaire/useSolitaireChess.ts
@@ -242,6 +242,11 @@ function handleCorrectMove({
     setResults: React.Dispatch<React.SetStateAction<SolitaireResults>>;
 }) {
     const nextMove = chess.move(move);
+
+    nextMove?.variations?.forEach((variation) => {
+        variation[0].commentMove = 'Incorrect guess in solitaire mode';
+    });
+
     const color = nextMove?.color === Color.white ? 'white' : 'black';
     setResults((results) => ({
         ...results,

--- a/scripts/i18n_auto_translate.py
+++ b/scripts/i18n_auto_translate.py
@@ -382,12 +382,12 @@ def collect_translation_units(en_node, existing_node, key_path, skip_paths, over
         if not isinstance(en_value, str):
             return
 
-        if should_skip_auto_translate(path, skip_paths):
-            units.append((path, en_value, existing_value, 'skip'))
-            return
-
         if not overwrite_existing and not is_empty_value(existing_value):
             units.append((path, en_value, existing_value, 'keep'))
+            return
+        
+        if should_skip_auto_translate(path, skip_paths):
+            units.append((path, en_value, existing_value, 'skip'))
             return
 
         units.append((path, en_value, existing_value, 'translate'))
@@ -472,10 +472,10 @@ def apply_plan_to_tree(en_tree: dict, existing_tree: dict, plan: LocalePlan, ski
     changes_by_key = {change.key: change.translated for change in plan.changes}
 
     def resolve(path, english, existing_value):
-        if should_skip_auto_translate(path, skip_paths):
-            return english
         if not overwrite_existing and not is_empty_value(existing_value):
             return existing_value
+        if should_skip_auto_translate(path, skip_paths):
+            return english
         return changes_by_key.get(path, english)
 
     def walk(en_value, existing_value, path):


### PR DESCRIPTION
## Summary

Adds comment for incorrect moves when going through game in solitaire mode. Comments added in useSolitaireChess hook

## Related Issues

## Type of change

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests due to: Found no relevant tests for solitaire mode (should add?)

## Demo

<img width="1244" height="722" alt="image" src="https://github.com/user-attachments/assets/10ccb41e-4fe1-461f-a9ed-f0647898b701" />
