### PR TITLE
fix: only guard analyses with more than five moves

### DIFF
--- a/frontend/playwright/tests/e2e/games/import/importStartingPosition.spec.ts
+++ b/frontend/playwright/tests/e2e/games/import/importStartingPosition.spec.ts
@@ -7,15 +7,31 @@ test.describe('Import Games Page - Position', () => {
 
     test('submits with default FEN', async ({ page }) => {
         await page.getByRole('button', { name: /Starting Position/ }).click();
+
         await expect(page).toHaveURL(/\/games\/analysis(?:\?|$)/);
     });
 
-    test('prevents navigating away from unsaved analysis', async ({ page }) => {
+    test('allows navigating away from analysis with five or fewer moves', async ({ page }) => {
         await page.getByRole('button', { name: /Starting Position/ }).click();
         await expect(page).toHaveURL(/\/games\/analysis(?:\?|$)/);
 
         await page.getByRole('link', { name: 'Training Plan' }).click();
 
+        await expect(page).not.toHaveURL(/\/games\/analysis(?:\?|$)/);
+    });
+
+    test('guards navigation when move six starts', async ({ page }) => {
+        await page.getByRole('button', { name: /^PGN/ }).click();
+        await page
+            .getByRole('textbox', { name: 'Paste PGN' })
+            .fill('1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1');
+        await page.getByRole('button', { name: 'Import' }).click();
+
+        await expect(page).toHaveURL(/\/games\/analysis(?:\?|$)/);
+
+        await page.getByRole('link', { name: 'Training Plan' }).click();
+
         await expect(page.getByTestId('unsaved-analysis-nav-guard')).toBeVisible();
+        await expect(page).toHaveURL(/\/games\/analysis(?:\?|$)/);
     });
 });

--- a/frontend/src/app/[locale]/(scoreboard)/games/analysis/AnalysisBoard.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/games/analysis/AnalysisBoard.tsx
@@ -56,9 +56,8 @@ export default function AnalysisBoard() {
     const { searchParams } = useNextSearchParams();
     const { user, status } = useAuth();
     const navGuard = useNavigationGuard({
-        enabled: ({ to }) => {
-            return !gameUrlRegex.test(to);
-        },
+        enabled: ({ to }) =>
+            !gameUrlRegex.test(to) && Math.ceil((latestChessRef.current?.plyCount() ?? 0) / 2) > 5,
     });
     const [chess, setChess] = useState<Chess>();
     const maiaGame = useMaiaGame();


### PR DESCRIPTION
## Summary

updated the analysis navigation guard so the save/delete interruption only appears when leaving an analysis with more than five full moves. uses the chess mainline ply count, treating `1. d4 d5` as one move.

also accounts for analyses initialized from black-to-move fens

## Related Issues

Closes #2490 
