### PR TITLE
feat: add draw offer ui to edit PGN in analysis board

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -3519,6 +3519,7 @@
             "commentBefore": "Kommentar Davor",
             "commentAfter": "Kommentar danach",
             "viewMore": "Mehr anzeigen",
+            "offerDraw": "Remis anbieten",
             "nullMove": "Null",
             "makeMainLine": "Hauptlinie festlegen",
             "moveVariationUp": "Variation nach oben verschieben",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3519,6 +3519,7 @@
             "commentBefore": "Comment Before",
             "commentAfter": "Comment After",
             "viewMore": "View more",
+            "offerDraw": "Offer draw",
             "nullMove": "Null",
             "makeMainLine": "Make main line",
             "moveVariationUp": "Move variation up",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -3519,6 +3519,7 @@
             "commentBefore": "Comentario antes",
             "commentAfter": "Comentario después",
             "viewMore": "Ver más",
+            "offerDraw": "Ofrecer tablas",
             "nullMove": "Nula",
             "makeMainLine": "Convertir en línea principal",
             "moveVariationUp": "Subir variante",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -3519,6 +3519,7 @@
             "commentBefore": "Commentaire avant",
             "commentAfter": "Commentaire après",
             "viewMore": "Voir plus",
+            "offerDraw": "Proposer nulle",
             "nullMove": "Nul",
             "makeMainLine": "Définir comme variante principale",
             "moveVariationUp": "Déplacer la variante vers le haut",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -3519,6 +3519,7 @@
             "commentBefore": "Commento prima",
             "commentAfter": "Commento dopo",
             "viewMore": "Mostra altro",
+            "offerDraw": "Offri patta",
             "nullMove": "Nulla",
             "makeMainLine": "Imposta come variante principale",
             "moveVariationUp": "Sposta la variante in alto",

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -3519,6 +3519,7 @@
             "commentBefore": "[T] Comment Before",
             "commentAfter": "[T] Comment After",
             "viewMore": "[T] View more",
+            "offerDraw": "[T] Offer draw",
             "nullMove": "[T] Null",
             "makeMainLine": "[T] Make main line",
             "moveVariationUp": "[T] Move variation up",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -3519,6 +3519,7 @@
             "commentBefore": "Comentário antes",
             "commentAfter": "Comentário depois",
             "viewMore": "Ver mais",
+            "offerDraw": "Oferecer empate",
             "nullMove": "Nulo",
             "makeMainLine": "Tornar linha principal",
             "moveVariationUp": "Mover variante para cima",

--- a/frontend/src/board/pgn/boardTools/underboard/Editor.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/Editor.tsx
@@ -93,6 +93,8 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
     const [moreNagAnchorEl, setMoreNagAnchorEl] = useState<HTMLElement>();
 
     const t = useTranslations('analysisBoard.underboard');
+    const editorMoveNags = moveNags.filter((nag) => nag !== '$7');
+    const moreNags = ['$7', ...positionalNags];
 
     useEffect(() => {
         if (chess) {
@@ -167,7 +169,7 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
     };
 
     const onClickMenuNag = (nag: string) => {
-        const currentNags = getNagsInSet(positionalNags, move?.nags);
+        const currentNags = getNagsInSet(moreNags, move?.nags);
         const index = currentNags.indexOf(nag);
         if (index < 0) {
             currentNags.push(nag);
@@ -182,6 +184,16 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
         reconcile();
     };
 
+    const onToggleDrawOffer = () => {
+        if (!move) {
+            return;
+        }
+
+        move.drawOffer = !move.drawOffer;
+        chess.setNags([...(move.nags ?? [])], move);
+        reconcile();
+    };
+
     const onUpdateTimeControl = (value: string) => {
         chess.setHeader('TimeControl', value);
         setShowTimeControlEditor(false);
@@ -192,6 +204,7 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
         (Boolean(move) && config?.disableTakebacks?.[0] === move?.color);
 
     const nullMoveStatus = getNullMoveStatus(chess, t);
+    const currentMoveNag = getNagInSet(editorMoveNags, chess.currentMove()?.nags);
 
     return (
         <CardContent sx={{ height: { md: 1 } }}>
@@ -306,17 +319,18 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
                         ))}
                     </ToggleButtonGroup>
 
-                    <ToggleButtonGroup
-                        disabled={!move}
-                        exclusive
-                        value={getNagInSet(moveNags, chess.currentMove()?.nags)}
-                        onChange={handleExclusiveNag(moveNags)}
-                        size='small'
-                    >
-                        {moveNags.map((nag) => (
+                    <ToggleButtonGroup disabled={!move} size='small'>
+                        {editorMoveNags.map((nag) => (
                             <NagButton
                                 key={nag}
                                 value={nag}
+                                selected={currentMoveNag === nag}
+                                onClick={() =>
+                                    handleExclusiveNag(editorMoveNags)(
+                                        undefined,
+                                        currentMoveNag === nag ? null : nag,
+                                    )
+                                }
                                 text={nags[nag].label}
                                 description={nags[nag].description}
                                 sx={{
@@ -325,6 +339,31 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
                                 }}
                             />
                         ))}
+
+                        <Tooltip title={t('offerDraw')} disableInteractive>
+                            <span style={{ width: `${100 / 8}%` }}>
+                                <ToggleButton
+                                    value='draw'
+                                    selected={Boolean(move?.drawOffer)}
+                                    onChange={onToggleDrawOffer}
+                                    sx={{
+                                        width: 1,
+                                        borderTopLeftRadius: 0,
+                                        borderTopRightRadius: 0,
+                                    }}
+                                >
+                                    <Typography
+                                        sx={{
+                                            whiteSpace: 'nowrap',
+                                            fontSize: '1.3rem',
+                                            fontWeight: '600',
+                                        }}
+                                    >
+                                        (=)
+                                    </Typography>
+                                </ToggleButton>
+                            </span>
+                        </Tooltip>
 
                         <Tooltip title={t('viewMore')} disableInteractive>
                             <span style={{ width: `${100 / 8}%` }}>
@@ -344,7 +383,7 @@ const Editor: React.FC<EditorProps> = ({ focusEditor, setFocusEditor }) => {
                         open={!!moreNagAnchorEl}
                         onClose={() => setMoreNagAnchorEl(undefined)}
                     >
-                        {positionalNags.map((nag) => (
+                        {moreNags.map((nag) => (
                             <MenuItem
                                 key={nag}
                                 onClick={() => onClickMenuNag(nag)}

--- a/frontend/src/board/pgn/pgnText/MoveButton.tsx
+++ b/frontend/src/board/pgn/pgnText/MoveButton.tsx
@@ -458,7 +458,7 @@ const MoveButton: React.FC<MoveButtonProps> = ({
         setMenuAnchorEl(undefined);
     };
 
-    const moveText = move.san;
+    const moveText = move.drawOffer ? `${move.san} (=)` : move.san;
 
     if (inline) {
         let text = '';


### PR DESCRIPTION
## Summary

added ui for marking a move as an offered draw in the pgn editor. the pgn text now displays `(=)` inline when `move.drawOffer` is set.

note: `@jackstenglein/chess`'s `renderPgn()` does not currently serialize `move.drawOffer` back into the pgn string. since save, export, and pdf download all rely on `renderPgn()`, the `(=)` annotation will display correctly in the ui but will not persist across saves or appear in exported files. flagged this for a follow-up pr or a fix in the core package. this pr only adds the frontend UI.

## Related Issues

Fixes #2495 

## Demo

<img width="607" height="797" alt="image" src="https://github.com/user-attachments/assets/36a7a0fe-f5db-4e47-851b-c04adcec1c26" />
