### PR TITLE
feat(#2537): improve rating update reliability

### DIFF
--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -156,6 +156,12 @@ type Rating struct {
 
 	// Whether the user's rating is provisional
 	IsProvisional bool `dynamodbav:"isProvisional,omitempty" json:"isProvisional,omitempty"`
+
+	// The number of confirmed not-found responses for the username since the
+	// last successful fetch. Maintained by the ratings update pipeline for
+	// Chesscom and Lichess only; fetches are skipped once it reaches the
+	// threshold.
+	NotFoundCount int `dynamodbav:"notFoundCount,omitempty" json:"-"`
 }
 
 type RatingHistory struct {
@@ -1426,6 +1432,23 @@ const ratingsProjection = "username, dojoCohort, subscriptionStatus, paymentInfo
 // startkey is an optional parameter that can be used to perform pagination.
 // The list of users and the next start key are returned.
 func (repo *dynamoRepository) ListUserRatings(cohort DojoCohort, startKey string) ([]*User, string, error) {
+	return repo.ListUserRatingsPage(cohort, startKey, 0)
+}
+
+// ListUserRatingsPage returns up to limit Users matching the provided cohort.
+// A limit of 0 means no limit (up to 1MB of data). Only the fields necessary
+// for the rating/statistics update are returned. startKey is an optional
+// parameter that can be used to perform pagination.
+func (repo *dynamoRepository) ListUserRatingsPage(cohort DojoCohort, startKey string, limit int64) ([]*User, string, error) {
+	var users []*User
+	lastKey, err := repo.query(listUserRatingsInput(cohort, limit), startKey, &users)
+	if err != nil {
+		return nil, "", err
+	}
+	return users, lastKey, nil
+}
+
+func listUserRatingsInput(cohort DojoCohort, limit int64) *dynamodb.QueryInput {
 	input := &dynamodb.QueryInput{
 		KeyConditionExpression: aws.String("#cohort = :cohort"),
 		ExpressionAttributeNames: map[string]*string{
@@ -1438,13 +1461,10 @@ func (repo *dynamoRepository) ListUserRatings(cohort DojoCohort, startKey string
 		IndexName:            aws.String("CohortIdx"),
 		TableName:            aws.String(userTable),
 	}
-
-	var users []*User
-	lastKey, err := repo.query(input, startKey, &users)
-	if err != nil {
-		return nil, "", err
+	if limit > 0 {
+		input.SetLimit(limit)
 	}
-	return users, lastKey, nil
+	return input
 }
 
 func (repo *dynamoRepository) UpdateUserRatings(users []*User) error {
@@ -1475,7 +1495,25 @@ func (repo *dynamoRepository) UpdateUserRatings(users []*User) error {
 	output, err := repo.svc.BatchExecuteStatement(input)
 	log.Debugf("Batch execute statement output: %v", output)
 
-	return errors.Wrap(500, "Temporary server error", "Failed BatchExecuteStatement", err)
+	if err != nil {
+		return errors.Wrap(500, "Temporary server error", "Failed BatchExecuteStatement", err)
+	}
+	return batchStatementsError(output.Responses)
+}
+
+// batchStatementsError returns an error if any individual statement in a
+// BatchExecuteStatement response failed. DynamoDB can report overall success
+// while individual statements fail, so callers must inspect each response.
+func batchStatementsError(responses []*dynamodb.BatchStatementResponse) error {
+	for _, response := range responses {
+		if response.Error != nil {
+			return errors.New(500, "Temporary server error", fmt.Sprintf(
+				"PartiQL batch statement failed: %s: %s",
+				aws.StringValue(response.Error.Code), aws.StringValue(response.Error.Message),
+			))
+		}
+	}
+	return nil
 }
 
 const (

--- a/backend/database/user_test.go
+++ b/backend/database/user_test.go
@@ -2,6 +2,9 @@ package database
 
 import (
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 func TestIsValidCohort(t *testing.T) {
@@ -237,6 +240,56 @@ func TestGetRatings(t *testing.T) {
 				t.Errorf("GetRatings(%v) gotCurrent: %d; wantCurrent: %d", tc.user, gotCurrent, tc.wantCurrent)
 			}
 		})
+	}
+}
+
+func TestBatchStatementsError(t *testing.T) {
+	table := []struct {
+		name      string
+		responses []*dynamodb.BatchStatementResponse
+		wantErr   bool
+	}{
+		{name: "NilResponses", responses: nil, wantErr: false},
+		{
+			name:      "AllSuccessful",
+			responses: []*dynamodb.BatchStatementResponse{{}, {}},
+			wantErr:   false,
+		},
+		{
+			name: "OneFailed",
+			responses: []*dynamodb.BatchStatementResponse{
+				{},
+				{Error: &dynamodb.BatchStatementError{
+					Code:    aws.String("ValidationError"),
+					Message: aws.String("Item size exceeded"),
+				}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			err := batchStatementsError(tc.responses)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("batchStatementsError() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestListUserRatingsInput_Limit(t *testing.T) {
+	input := listUserRatingsInput("1000-1100", 50)
+	if input.Limit == nil || *input.Limit != 50 {
+		t.Errorf("expected Limit 50, got %v", input.Limit)
+	}
+
+	input = listUserRatingsInput("1000-1100", 0)
+	if input.Limit != nil {
+		t.Errorf("expected no Limit for 0, got %v", input.Limit)
+	}
+	if aws.StringValue(input.IndexName) != "CohortIdx" {
+		t.Errorf("expected CohortIdx index, got %v", input.IndexName)
 	}
 }
 

--- a/backend/user/ratings/ratings.go
+++ b/backend/user/ratings/ratings.go
@@ -2,8 +2,10 @@ package ratings
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -16,6 +18,19 @@ import (
 )
 
 var client = http.Client{Timeout: 5 * time.Second}
+
+// ErrNotFound indicates the rating system reports no account for the given
+// username/ID. Fetch errors wrap it so callers can distinguish a missing
+// account from a transient failure.
+var ErrNotFound = stderrors.New("username not found in rating system")
+
+var chesscomHost = "https://api.chess.com"
+var lichessHost = "https://lichess.org"
+var sleepFunc = time.Sleep
+
+const chesscomUserAgent = "ChessDojo rating updater (https://www.chessdojo.club)"
+const maxChesscomAttempts = 3
+const maxRetryAfter = 10 * time.Second
 
 var fideRegexp, _ = regexp.Compile(`<p>(\d+)</p>\s*<p.*>STANDARD`)
 var acfRegexp, _ = regexp.Compile(`Current Rating:\s*</div>\s*<div id="stats-box-data-col">\s*[-\d]*\s*</div>\s*<div id="stats-box-data-col">\s*(\d+)`)
@@ -100,17 +115,24 @@ var RatingFetchFuncs map[database.RatingSystem]RatingFetchFunc = map[database.Ra
 	database.Knsb:     FetchKnsbRating,
 }
 
+// FetchChesscomRating fetches with a single attempt. It is called
+// synchronously by the profile-update API, where retry sleeps would push
+// requests past the API Gateway timeout.
 func FetchChesscomRating(chesscomUsername string) (*database.Rating, error) {
-	resp, err := client.Get(fmt.Sprintf("https://api.chess.com/pub/player/%s/stats", chesscomUsername))
-	if err != nil {
-		err = errors.Wrap(500, "Temporary server error", "Failed to get chess.com stats", err)
-		return nil, err
-	}
+	return fetchChesscomRating(chesscomUsername, 1)
+}
 
-	if resp.StatusCode != 200 {
-		err = errors.New(400, fmt.Sprintf("Invalid request: chess.com returned status `%d` for given player", resp.StatusCode), "")
+// FetchChesscomRatingWithRetry retries 429 responses. Batch pipeline only.
+func FetchChesscomRatingWithRetry(chesscomUsername string) (*database.Rating, error) {
+	return fetchChesscomRating(chesscomUsername, maxChesscomAttempts)
+}
+
+func fetchChesscomRating(chesscomUsername string, maxAttempts int) (*database.Rating, error) {
+	resp, err := getChesscomStats(chesscomUsername, maxAttempts)
+	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var rating ChesscomResponse
 	err = json.NewDecoder(resp.Body).Decode(&rating)
@@ -128,12 +150,78 @@ func FetchChesscomRating(chesscomUsername string) (*database.Rating, error) {
 	return dojoRating, nil
 }
 
+// getChesscomStats requests the user's stats, retrying on 429 responses up to
+// maxAttempts total attempts. On success the caller owns the body.
+func getChesscomStats(chesscomUsername string, maxAttempts int) (*http.Response, error) {
+	url := fmt.Sprintf("%s/pub/player/%s/stats", chesscomHost, chesscomUsername)
+
+	for attempt := 1; ; attempt++ {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, errors.Wrap(500, "Temporary server error", "Failed to create chess.com request", err)
+		}
+		req.Header.Set("User-Agent", chesscomUserAgent)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, errors.Wrap(500, "Temporary server error", "Failed to get chess.com stats", err)
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusOK:
+			return resp, nil
+		case resp.StatusCode == http.StatusNotFound:
+			resp.Body.Close()
+			return nil, errors.Wrap(404, "Invalid request: chess.com returned status `404` for given player", "", ErrNotFound)
+		case resp.StatusCode == http.StatusTooManyRequests && attempt < maxAttempts:
+			resp.Body.Close()
+			wait, ok := chesscomRetryDelay(resp.Header.Get("Retry-After"), attempt)
+			if !ok {
+				return nil, errors.New(429, "Temporary server error: chess.com rate limit requested a wait longer than the cap", "")
+			}
+			sleepFunc(wait)
+		case resp.StatusCode == http.StatusTooManyRequests:
+			resp.Body.Close()
+			return nil, errors.New(429, "Temporary server error: chess.com rate limit exceeded", "")
+		default:
+			resp.Body.Close()
+			return nil, errors.New(400, fmt.Sprintf("Invalid request: chess.com returned status `%d` for given player", resp.StatusCode), "")
+		}
+	}
+}
+
+// chesscomRetryDelay returns how long to wait before the next attempt, or
+// ok=false if the server requested a wait longer than maxRetryAfter.
+func chesscomRetryDelay(retryAfter string, attempt int) (time.Duration, bool) {
+	if seconds, err := strconv.Atoi(retryAfter); err == nil {
+		wait := time.Duration(seconds) * time.Second
+		if wait > maxRetryAfter {
+			return 0, false
+		}
+		return wait, true
+	}
+	if date, err := http.ParseTime(retryAfter); err == nil {
+		wait := time.Until(date)
+		if wait > maxRetryAfter {
+			return 0, false
+		}
+		if wait < 0 {
+			wait = 0
+		}
+		return wait, true
+	}
+	backoff := time.Duration(attempt) * time.Second
+	jitter := time.Duration(rand.Int63n(int64(500 * time.Millisecond)))
+	return backoff + jitter, true
+}
+
 func FetchLichessRating(lichessUsername string) (*database.Rating, error) {
-	resp, err := client.Get(fmt.Sprintf("https://lichess.org/api/user/%s", lichessUsername))
+	resp, err := client.Get(fmt.Sprintf("%s/api/user/%s", lichessHost, lichessUsername))
 	if err != nil {
 		err = errors.Wrap(500, "Temporary server error", "Failed to get lichess stats", err)
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		err = errors.New(400, fmt.Sprintf("Invalid request: lichess returned status `%d` for given player", resp.StatusCode), "")
@@ -162,10 +250,15 @@ func FetchBulkLichessRatings(lichessUsernames []string) (map[string]LichessRespo
 		return make(map[string]LichessResponse, 0), nil
 	}
 
-	resp, err := client.Post("https://lichess.org/api/users", "text/plain", strings.NewReader(strings.Join(lichessUsernames, ",")))
+	resp, err := client.Post(lichessHost+"/api/users", "text/plain", strings.NewReader(strings.Join(lichessUsernames, ",")))
 	if err != nil {
 		err = errors.Wrap(500, "Temporary server error", "Failed to get lichess bulk stats", err)
 		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(500, "Temporary server error", fmt.Sprintf("Lichess bulk API returned status `%d`", resp.StatusCode))
 	}
 
 	var rs []*LichessResponse

--- a/backend/user/ratings/ratings_test.go
+++ b/backend/user/ratings/ratings_test.go
@@ -1,0 +1,239 @@
+package ratings
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
+)
+
+const chesscomStatsBody = `{"chess_rapid": {"last": {"rating": 1500, "rd": 50}, "record": {"win": 10, "loss": 5, "draw": 2}}}`
+
+// setupChesscom points the fetcher at a test server and captures sleeps.
+func setupChesscom(t *testing.T, handler http.HandlerFunc) *[]time.Duration {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	originalHost := chesscomHost
+	chesscomHost = server.URL
+	t.Cleanup(func() { chesscomHost = originalHost })
+
+	var slept []time.Duration
+	sleepFunc = func(d time.Duration) { slept = append(slept, d) }
+	t.Cleanup(func() { sleepFunc = time.Sleep })
+	return &slept
+}
+
+func TestFetchChesscomRating_Success(t *testing.T) {
+	var gotUserAgent string
+	setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
+		_, _ = w.Write([]byte(chesscomStatsBody))
+	})
+
+	rating, err := FetchChesscomRating("testuser")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if rating.CurrentRating != 1500 {
+		t.Errorf("expected rating 1500, got %d", rating.CurrentRating)
+	}
+	if rating.NumGames != 17 {
+		t.Errorf("expected 17 games, got %d", rating.NumGames)
+	}
+	if gotUserAgent != chesscomUserAgent {
+		t.Errorf("expected User-Agent %q, got %q", chesscomUserAgent, gotUserAgent)
+	}
+}
+
+func TestFetchChesscomRating_DoesNotRetry429(t *testing.T) {
+	calls := 0
+	slept := setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(429)
+	})
+
+	_, err := FetchChesscomRating("testuser")
+	if err == nil {
+		t.Fatal("expected error from single-attempt fetch")
+	}
+	if calls != 1 {
+		t.Errorf("interactive fetch must not retry, got %d calls", calls)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("interactive fetch must not sleep, got %v", *slept)
+	}
+	var apiErr *errors.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != 429 {
+		t.Errorf("expected api error with code 429, got %v", err)
+	}
+}
+
+func TestFetchChesscomRatingWithRetry_RetriesOn429ThenSucceeds(t *testing.T) {
+	calls := 0
+	slept := setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			w.WriteHeader(429)
+			return
+		}
+		_, _ = w.Write([]byte(chesscomStatsBody))
+	})
+
+	rating, err := FetchChesscomRatingWithRetry("testuser")
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if rating.CurrentRating != 1500 {
+		t.Errorf("expected rating 1500, got %d", rating.CurrentRating)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls)
+	}
+	if len(*slept) != 2 {
+		t.Fatalf("expected 2 sleeps, got %d", len(*slept))
+	}
+	// Backoff base is 1s then 2s, each plus up to 500ms jitter.
+	if (*slept)[0] < time.Second || (*slept)[0] > time.Second+500*time.Millisecond {
+		t.Errorf("first sleep out of range: %v", (*slept)[0])
+	}
+	if (*slept)[1] < 2*time.Second || (*slept)[1] > 2*time.Second+500*time.Millisecond {
+		t.Errorf("second sleep out of range: %v", (*slept)[1])
+	}
+}
+
+func TestFetchChesscomRatingWithRetry_GivesUpAfterThree429s(t *testing.T) {
+	calls := 0
+	setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(429)
+	})
+
+	_, err := FetchChesscomRatingWithRetry("testuser")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("429 give-up must not be ErrNotFound")
+	}
+	var apiErr *errors.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != 429 {
+		t.Errorf("expected api error with code 429 on give-up, got %v", err)
+	}
+}
+
+func TestFetchChesscomRatingWithRetry_HonorsRetryAfter(t *testing.T) {
+	calls := 0
+	slept := setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "3")
+			w.WriteHeader(429)
+			return
+		}
+		_, _ = w.Write([]byte(chesscomStatsBody))
+	})
+
+	if _, err := FetchChesscomRatingWithRetry("testuser"); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(*slept) != 1 || (*slept)[0] != 3*time.Second {
+		t.Errorf("expected exactly one 3s sleep, got %v", *slept)
+	}
+}
+
+func TestFetchChesscomRatingWithRetry_HonorsRetryAfterDate(t *testing.T) {
+	calls := 0
+	slept := setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", time.Now().Add(3*time.Second).UTC().Format(http.TimeFormat))
+			w.WriteHeader(429)
+			return
+		}
+		_, _ = w.Write([]byte(chesscomStatsBody))
+	})
+
+	if _, err := FetchChesscomRatingWithRetry("testuser"); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(*slept) != 1 || (*slept)[0] <= 0 || (*slept)[0] > 3*time.Second {
+		t.Errorf("expected one sleep of at most 3s from date header, got %v", *slept)
+	}
+}
+
+func TestFetchChesscomRatingWithRetry_GivesUpOnLongRetryAfter(t *testing.T) {
+	calls := 0
+	slept := setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(429)
+	})
+
+	_, err := FetchChesscomRatingWithRetry("testuser")
+	if err == nil {
+		t.Fatal("expected error for Retry-After above the cap")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt (no retry), got %d", calls)
+	}
+	if len(*slept) != 0 {
+		t.Errorf("expected no sleeps, got %v", *slept)
+	}
+}
+
+func TestFetchChesscomRating_404IsErrNotFound(t *testing.T) {
+	setupChesscom(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	})
+
+	_, err := FetchChesscomRating("missinguser")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	var apiErr *errors.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != 404 {
+		t.Errorf("expected api error with code 404, got %v", err)
+	}
+}
+
+func setupLichess(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	originalHost := lichessHost
+	lichessHost = server.URL
+	t.Cleanup(func() { lichessHost = originalHost })
+}
+
+func TestFetchBulkLichessRatings_ErrorOnNon200(t *testing.T) {
+	setupLichess(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+	})
+
+	_, err := FetchBulkLichessRatings([]string{"user1"})
+	if err == nil {
+		t.Fatal("expected error for non-200 bulk response")
+	}
+}
+
+func TestFetchBulkLichessRatings_Success(t *testing.T) {
+	setupLichess(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"id": "user1", "username": "User1", "perfs": {"classical": {"rating": 1800, "games": 100, "rd": 45, "prov": false}}}]`))
+	})
+
+	result, err := FetchBulkLichessRatings([]string{"User1"})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if r, ok := result["user1"]; !ok || r.Performances.Classical.Rating != 1800 {
+		t.Errorf("expected user1 with rating 1800, got %+v", result)
+	}
+}

--- a/backend/user/ratings/update/main.go
+++ b/backend/user/ratings/update/main.go
@@ -3,39 +3,102 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/user/ratings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	lambdasvc "github.com/aws/aws-sdk-go/service/lambda"
 )
 
 type Event events.CloudWatchEvent
 
-var repository = database.DynamoDB
+const (
+	chunkSize        = 50
+	flushSize        = 25
+	maxContinuations = 10
+	maxNotFoundCount = 3
+	// checkpointBuffer is the remaining-time threshold below which the
+	// handler stops and re-invokes itself. Chosen together with the 700s
+	// UpdateRatingsTimeoutAlarm: normal runs end around 600s elapsed plus
+	// one user's processing time, staying under the alarm.
+	checkpointBuffer = 300 * time.Second
+)
 
+type ratingsRepository interface {
+	ListUserRatingsPage(cohort database.DojoCohort, startKey string, limit int64) ([]*database.User, string, error)
+	UpdateUserRatings(users []*database.User) error
+}
+
+type lambdaInvoker interface {
+	Invoke(input *lambdasvc.InvokeInput) (*lambdasvc.InvokeOutput, error)
+}
+
+var repository ratingsRepository = database.DynamoDB
+var invoker lambdaInvoker = lambdasvc.New(session.Must(session.NewSession()))
+var fetchBulkLichess = ratings.FetchBulkLichessRatings
+var fetchChesscom ratings.RatingFetchFunc = ratings.FetchChesscomRatingWithRetry
+
+var remainingTime = func(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return time.Duration(1<<62 - 1)
+	}
+	return time.Until(deadline)
+}
+
+// now is refreshed at the start of each invocation: package init runs once per
+// container, and warm containers cross day boundaries.
 var now = time.Now()
 
 type isBannedFunc func(username string) bool
 
-func updateRating(rating *database.Rating, systemName string, fetcher ratings.RatingFetchFunc) bool {
+type RatingUpdateRequest struct {
+	Cohorts           []database.DojoCohort `json:"cohorts"`
+	StartKey          string                `json:"startKey,omitempty"`
+	ContinuationCount int                   `json:"continuationCount,omitempty"`
+}
+
+// tracksNotFound reports whether not-found suppression applies to the system.
+// Restricted to Chesscom and Lichess: other systems overload 404 with
+// different semantics (e.g. USCF returns 404 for "no regular rating").
+func tracksNotFound(system database.RatingSystem) bool {
+	return system == database.Chesscom || system == database.Lichess
+}
+
+func updateRating(rating *database.Rating, system database.RatingSystem, fetcher ratings.RatingFetchFunc) bool {
 	rating.Username = strings.TrimSpace(rating.Username)
 	if rating.Username == "" {
 		return false
 	}
 
-	data, err := fetcher(rating.Username)
-	if err != nil {
-		log.Errorf("Failed to get %s rating for %q: %v", systemName, rating.Username, err)
+	if tracksNotFound(system) && rating.NotFoundCount >= maxNotFoundCount {
 		return false
 	}
 
-	shouldUpdate := false
+	data, err := fetcher(rating.Username)
+	if err != nil {
+		if tracksNotFound(system) && errors.Is(err, ratings.ErrNotFound) {
+			rating.NotFoundCount++
+			log.Infof("%s username %q not found (count %d)", system, rating.Username, rating.NotFoundCount)
+			return true
+		}
+		log.Errorf("Failed to get %s rating for %q: %v", system, rating.Username, err)
+		return false
+	}
+
+	shouldUpdate := rating.NotFoundCount != 0
+	rating.NotFoundCount = 0
 
 	if data.CurrentRating != rating.CurrentRating || data.Deviation != rating.Deviation || data.NumGames != rating.NumGames || data.IsProvisional != rating.IsProvisional {
 		rating.CurrentRating = data.CurrentRating
@@ -53,12 +116,12 @@ func updateRating(rating *database.Rating, systemName string, fetcher ratings.Ra
 	return shouldUpdate
 }
 
-func updateIfNecessary(user *database.User, queuedUpdates []*database.User, ratingFetchFuncs map[database.RatingSystem]ratings.RatingFetchFunc, isBannedLichess isBannedFunc) (*database.User, []*database.User) {
+func updateUser(user *database.User, fetchFuncs map[database.RatingSystem]ratings.RatingFetchFunc, isBannedLichess isBannedFunc) bool {
 	shouldUpdate := false
 
 	for system, rating := range user.Ratings {
 		if system != database.Custom && system != database.Custom2 && system != database.Custom3 {
-			shouldUpdate = updateRating(rating, string(system), ratingFetchFuncs[system]) || shouldUpdate
+			shouldUpdate = updateRating(rating, system, fetchFuncs[system]) || shouldUpdate
 		}
 
 		if system == database.Lichess && isBannedLichess(rating.Username) {
@@ -70,7 +133,7 @@ func updateIfNecessary(user *database.User, queuedUpdates []*database.User, rati
 
 		if now.Weekday() == time.Monday {
 			history := user.RatingHistories[system]
-			if rating.CurrentRating > 0 && (history == nil || history[len(history)-1].Rating != rating.CurrentRating) {
+			if rating.CurrentRating > 0 && (len(history) == 0 || history[len(history)-1].Rating != rating.CurrentRating) {
 				if user.RatingHistories == nil {
 					user.RatingHistories = make(map[database.RatingSystem][]database.RatingHistory)
 				}
@@ -83,117 +146,226 @@ func updateIfNecessary(user *database.User, queuedUpdates []*database.User, rati
 		}
 	}
 
-	if shouldUpdate {
-		queuedUpdates = append(queuedUpdates, user)
-		if len(queuedUpdates) == 25 {
-			if err := repository.UpdateUserRatings(queuedUpdates); err != nil {
-				log.Error(err)
-			} else {
-				log.Infof("Updated %d users", len(queuedUpdates))
-			}
-			queuedUpdates = nil
-		}
-	}
-
-	return user, queuedUpdates
+	return shouldUpdate
 }
 
-func updateUsers(users []*database.User) {
-	if len(users) == 0 {
-		return
-	}
-
-	lichessUsernames := make([]string, 0, len(users))
+// fetchLichessRatings bulk-fetches lichess ratings for all users in the chunk,
+// excluding suppressed usernames. ok=false means the bulk call itself failed
+// and no user may be treated as missing.
+func fetchLichessRatings(users []*database.User) (map[string]ratings.LichessResponse, bool) {
+	var usernames []string
 	for _, user := range users {
-		if lichess := user.Ratings[database.Lichess]; lichess != nil {
-			if lichessUsername := strings.TrimSpace(lichess.Username); lichessUsername != "" {
-				lichessUsernames = append(lichessUsernames, lichessUsername)
+		if lichess := user.Ratings[database.Lichess]; lichess != nil && lichess.NotFoundCount < maxNotFoundCount {
+			if username := strings.TrimSpace(lichess.Username); username != "" {
+				usernames = append(usernames, username)
 			}
 		}
 	}
-	lichessRatings, err := ratings.FetchBulkLichessRatings(lichessUsernames)
+
+	result, err := fetchBulkLichess(usernames)
 	if err != nil {
 		log.Error(err)
+		return nil, false
 	}
-
-	fetchLichessRating := func(username string) (*database.Rating, error) {
-		if rating, ok := lichessRatings[strings.ToLower(username)]; !ok {
-			return nil, errors.New("no Lichess rating found in cache")
-		} else {
-			return &database.Rating{
-				CurrentRating: rating.Performances.Classical.Rating,
-				Deviation:     rating.Performances.Classical.Deviation,
-				NumGames:      rating.Performances.Classical.NumGames,
-				IsProvisional: rating.Performances.Classical.IsProvisional,
-			}, nil
-		}
-	}
-
-	isBannedLichess := func(username string) bool {
-		if result, ok := lichessRatings[strings.ToLower(username)]; !ok {
-			return false
-		} else {
-			return result.TosViolation
-		}
-	}
-
-	ratingFetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{
-		database.Chesscom: ratings.FetchChesscomRating,
-		database.Lichess:  fetchLichessRating,
-		database.Fide:     ratings.FetchFideRating,
-		database.Uscf:     ratings.FetchUscfRating,
-		database.Ecf:      ratings.FetchEcfRating,
-		database.Cfc:      ratings.FetchCfcRating,
-		database.Dwz:      ratings.FetchDwzRating,
-		database.Acf:      ratings.FetchAcfRating,
-		database.Knsb:     ratings.FetchKnsbRating,
-	}
-
-	var queuedUpdates []*database.User
-	for _, user := range users {
-		_, queuedUpdates = updateIfNecessary(user, queuedUpdates, ratingFetchFuncs, isBannedLichess)
-	}
-
-	if len(queuedUpdates) > 0 {
-		if err := repository.UpdateUserRatings(queuedUpdates); err != nil {
-			log.Error(err)
-		} else {
-			log.Infof("Updated %d users", len(queuedUpdates))
-		}
-	}
+	return result, true
 }
 
-type RatingUpdateRequest struct {
-	Cohorts []database.DojoCohort `json:"cohorts"`
+func ratingFetchFuncs(lichessRatings map[string]ratings.LichessResponse, lichessOK bool) map[database.RatingSystem]ratings.RatingFetchFunc {
+	fetchLichess := func(username string) (*database.Rating, error) {
+		if !lichessOK {
+			return nil, errors.New(500, "Temporary server error", "Lichess bulk fetch failed; skipping user")
+		}
+		rating, ok := lichessRatings[strings.ToLower(username)]
+		if !ok {
+			return nil, errors.Wrap(404, "Invalid request: lichess user not found in bulk response", "", ratings.ErrNotFound)
+		}
+		return &database.Rating{
+			CurrentRating: rating.Performances.Classical.Rating,
+			Deviation:     rating.Performances.Classical.Deviation,
+			NumGames:      rating.Performances.Classical.NumGames,
+			IsProvisional: rating.Performances.Classical.IsProvisional,
+		}, nil
+	}
+
+	funcs := make(map[database.RatingSystem]ratings.RatingFetchFunc, len(ratings.RatingFetchFuncs))
+	for system, fetch := range ratings.RatingFetchFuncs {
+		funcs[system] = fetch
+	}
+	funcs[database.Chesscom] = fetchChesscom
+	funcs[database.Lichess] = fetchLichess
+	return funcs
+}
+
+func flush(queued []*database.User) error {
+	if len(queued) == 0 {
+		return nil
+	}
+	if err := repository.UpdateUserRatings(queued); err != nil {
+		log.Errorf("Failed to update %d users: %v", len(queued), err)
+		return err
+	}
+	log.Infof("Updated %d users", len(queued))
+	return nil
+}
+
+// cursorForUser builds a startKey resuming the CohortIdx query after the given
+// user, byte-compatible with DynamoDB's LastEvaluatedKey encoding in
+// repository.query.
+func cursorForUser(cohort database.DojoCohort, user *database.User) string {
+	key := map[string]*dynamodb.AttributeValue{
+		"dojoCohort": {S: aws.String(string(cohort))},
+		"username":   {S: aws.String(user.Username)},
+	}
+	b, err := json.Marshal(key)
+	if err != nil {
+		log.Errorf("Failed to marshal cursor for user %q: %v", user.Username, err)
+		return ""
+	}
+	return string(b)
+}
+
+// updateUsers processes users in order. It returns the cursor of the last
+// persisted user ("" if none), whether all users were processed, and any
+// write error. On a write error the checkpoint must not advance.
+func updateUsers(cohort database.DojoCohort, users []*database.User, outOfTime func() bool) (string, bool, error) {
+	if len(users) == 0 {
+		return "", true, nil
+	}
+
+	lichessRatings, lichessOK := fetchLichessRatings(users)
+	fetchFuncs := ratingFetchFuncs(lichessRatings, lichessOK)
+	isBannedLichess := func(username string) bool {
+		result, ok := lichessRatings[strings.ToLower(username)]
+		return ok && result.TosViolation
+	}
+
+	var queued []*database.User
+	for i, user := range users {
+		if outOfTime() {
+			if err := flush(queued); err != nil {
+				return "", false, err
+			}
+			if i == 0 {
+				return "", false, nil
+			}
+			return cursorForUser(cohort, users[i-1]), false, nil
+		}
+
+		if updateUser(user, fetchFuncs, isBannedLichess) {
+			queued = append(queued, user)
+			if len(queued) == flushSize {
+				if err := flush(queued); err != nil {
+					return "", false, err
+				}
+				queued = nil
+			}
+		}
+	}
+
+	if err := flush(queued); err != nil {
+		return "", false, err
+	}
+	return "", true, nil
+}
+
+// checkpoint asynchronously re-invokes this function to continue processing
+// from startKey. It fails loudly at the continuation cap.
+func checkpoint(event Event, cohorts []database.DojoCohort, startKey string, continuationCount int) error {
+	if continuationCount+1 > maxContinuations {
+		err := errors.New(500, "Temporary server error", fmt.Sprintf("updateRatings hit the continuation cap (%d) for cohorts %v without completing", maxContinuations, cohorts))
+		log.Error(err)
+		return err
+	}
+
+	req := RatingUpdateRequest{
+		Cohorts:           cohorts,
+		StartKey:          startKey,
+		ContinuationCount: continuationCount + 1,
+	}
+	detail, err := json.Marshal(req)
+	if err != nil {
+		return errors.Wrap(500, "Temporary server error", "Failed to marshal continuation request", err)
+	}
+
+	baseID := strings.Split(event.ID, "-cont")[0]
+	continuation := Event{
+		ID:         fmt.Sprintf("%s-cont%d", baseID, continuationCount+1),
+		DetailType: event.DetailType,
+		Source:     event.Source,
+		Region:     event.Region,
+		Detail:     detail,
+	}
+	payload, err := json.Marshal(continuation)
+	if err != nil {
+		return errors.Wrap(500, "Temporary server error", "Failed to marshal continuation event", err)
+	}
+
+	output, err := invoker.Invoke(&lambdasvc.InvokeInput{
+		FunctionName:   aws.String(os.Getenv("AWS_LAMBDA_FUNCTION_NAME")),
+		InvocationType: aws.String(lambdasvc.InvocationTypeEvent),
+		Payload:        payload,
+	})
+	if err != nil {
+		return errors.Wrap(500, "Temporary server error", "Failed to invoke continuation", err)
+	}
+	if aws.Int64Value(output.StatusCode) != 202 {
+		return errors.New(500, "Temporary server error", fmt.Sprintf("Continuation invoke returned status %d", aws.Int64Value(output.StatusCode)))
+	}
+
+	log.Infof("Checkpointed: cohorts=%v startKey=%s continuation=%d", cohorts, startKey, continuationCount+1)
+	return nil
 }
 
 func Handler(ctx context.Context, event Event) (Event, error) {
 	log.Infof("Event: %#v", event)
 	log.SetRequestId(event.ID)
+	now = time.Now()
 
 	var req RatingUpdateRequest
-	err := json.Unmarshal(event.Detail, &req)
-	if err != nil {
-		log.Errorf("Failed to unmarshal request:%v ", err)
+	if err := json.Unmarshal(event.Detail, &req); err != nil {
+		log.Errorf("Failed to unmarshal request: %v", err)
 		return event, err
 	}
 	log.Infof("Request: %+v", req)
 
-	var startKey string
-	for _, cohort := range req.Cohorts {
-		log.Debugf("Processing cohort %s", cohort)
+	outOfTime := func() bool { return remainingTime(ctx) < checkpointBuffer }
 
-		var users []*database.User
-		startKey = ""
-		for ok := true; ok; ok = startKey != "" {
-			users, startKey, err = repository.ListUserRatings(cohort, startKey)
+	for i, cohort := range req.Cohorts {
+		startKey := ""
+		if i == 0 {
+			startKey = req.StartKey
+		}
+
+		for {
+			users, nextKey, err := repository.ListUserRatingsPage(cohort, startKey, chunkSize)
 			if err != nil {
-				log.Errorf("Failed to scan users: %v", err)
+				log.Errorf("Failed to query users: %v", err)
 				return event, err
 			}
-			log.Infof("Processing %d users", len(users))
-			updateUsers(users)
+
+			cursor, completed, err := updateUsers(cohort, users, outOfTime)
+			if err != nil {
+				return event, err
+			}
+			if !completed {
+				if cursor == "" {
+					cursor = startKey
+				}
+				return event, checkpoint(event, req.Cohorts[i:], cursor, req.ContinuationCount)
+			}
+
+			log.Infof("Processed chunk: cohort=%s users=%d continuation=%d", cohort, len(users), req.ContinuationCount)
+
+			if nextKey == "" {
+				break
+			}
+			startKey = nextKey
+
+			if outOfTime() {
+				return event, checkpoint(event, req.Cohorts[i:], nextKey, req.ContinuationCount)
+			}
 		}
+		log.Infof("Cohort complete: cohort=%s continuation=%d", cohort, req.ContinuationCount)
 	}
 
 	return event, nil

--- a/backend/user/ratings/update/main_test.go
+++ b/backend/user/ratings/update/main_test.go
@@ -1,0 +1,553 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	lambdasvc "github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/user/ratings"
+)
+
+// fakeFetcher records calls and returns a fixed result.
+type fakeFetcher struct {
+	calls  int
+	rating *database.Rating
+	err    error
+}
+
+func (f *fakeFetcher) fetch(username string) (*database.Rating, error) {
+	f.calls++
+	return f.rating, f.err
+}
+
+func notFoundErr() error {
+	return errors.Wrap(404, "Invalid request: not found", "", ratings.ErrNotFound)
+}
+
+func TestUpdateRating_SkipsAtNotFoundThreshold(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1200}}
+	rating := &database.Rating{Username: "gone", NotFoundCount: 3}
+
+	if updateRating(rating, database.Chesscom, fetcher.fetch) {
+		t.Error("expected no update for suppressed rating")
+	}
+	if fetcher.calls != 0 {
+		t.Errorf("expected fetcher not to be called, got %d calls", fetcher.calls)
+	}
+}
+
+func TestUpdateRating_IncrementsOnNotFound(t *testing.T) {
+	fetcher := &fakeFetcher{err: notFoundErr()}
+	rating := &database.Rating{Username: "gone", NotFoundCount: 1, CurrentRating: 900}
+
+	if !updateRating(rating, database.Chesscom, fetcher.fetch) {
+		t.Error("expected update=true so the increment persists")
+	}
+	if rating.NotFoundCount != 2 {
+		t.Errorf("expected NotFoundCount 2, got %d", rating.NotFoundCount)
+	}
+	if rating.CurrentRating != 900 {
+		t.Errorf("rating must not change on not-found, got %d", rating.CurrentRating)
+	}
+}
+
+func TestUpdateRating_ResetsCounterOnSuccess(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 900}}
+	rating := &database.Rating{Username: "back", NotFoundCount: 2, CurrentRating: 900, StartRating: 800}
+
+	if !updateRating(rating, database.Chesscom, fetcher.fetch) {
+		t.Error("expected update=true so the reset persists even with unchanged rating")
+	}
+	if rating.NotFoundCount != 0 {
+		t.Errorf("expected NotFoundCount reset to 0, got %d", rating.NotFoundCount)
+	}
+}
+
+func TestUpdateRating_OtherErrorLeavesCounter(t *testing.T) {
+	fetcher := &fakeFetcher{err: errors.New(500, "Temporary server error", "")}
+	rating := &database.Rating{Username: "flaky", NotFoundCount: 1}
+
+	if updateRating(rating, database.Chesscom, fetcher.fetch) {
+		t.Error("expected no update on transient error")
+	}
+	if rating.NotFoundCount != 1 {
+		t.Errorf("expected NotFoundCount unchanged at 1, got %d", rating.NotFoundCount)
+	}
+}
+
+func TestUpdateRating_UntrackedSystemIgnoresNotFound(t *testing.T) {
+	fetcher := &fakeFetcher{err: notFoundErr()}
+	rating := &database.Rating{Username: "12345", NotFoundCount: 0}
+
+	if updateRating(rating, database.Uscf, fetcher.fetch) {
+		t.Error("expected no update for untracked system")
+	}
+	if rating.NotFoundCount != 0 {
+		t.Errorf("expected NotFoundCount unchanged at 0 for USCF, got %d", rating.NotFoundCount)
+	}
+}
+
+func TestUpdateRating_UntrackedSystemNeverSkips(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 2000}}
+	rating := &database.Rating{Username: "12345", NotFoundCount: 5}
+
+	updateRating(rating, database.Fide, fetcher.fetch)
+	if fetcher.calls != 1 {
+		t.Errorf("expected FIDE fetch despite NotFoundCount, got %d calls", fetcher.calls)
+	}
+}
+
+func TestUpdateRating_ChangeDetectionStillWorks(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1100, NumGames: 20}}
+	rating := &database.Rating{Username: "player", CurrentRating: 1000, StartRating: 950, NumGames: 15}
+
+	if !updateRating(rating, database.Chesscom, fetcher.fetch) {
+		t.Error("expected update for changed rating")
+	}
+	if rating.CurrentRating != 1100 || rating.NumGames != 20 {
+		t.Errorf("expected rating fields updated, got %+v", rating)
+	}
+}
+
+func TestUpdateUser_EmptyHistorySliceDoesNotPanic(t *testing.T) {
+	origNow := now
+	t.Cleanup(func() { now = origNow })
+	now = time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC) // a Monday
+
+	user := &database.User{
+		Username: "a",
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Chesscom: {Username: "a", CurrentRating: 1000, StartRating: 900},
+		},
+		RatingHistories: map[database.RatingSystem][]database.RatingHistory{
+			database.Chesscom: {},
+		},
+	}
+	fetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{
+		database.Chesscom: func(username string) (*database.Rating, error) {
+			return &database.Rating{CurrentRating: 1000}, nil
+		},
+	}
+
+	if !updateUser(user, fetchFuncs, func(string) bool { return false }) {
+		t.Error("expected update from history append")
+	}
+	history := user.RatingHistories[database.Chesscom]
+	if len(history) != 1 || history[0].Rating != 1000 {
+		t.Errorf("expected one history entry with rating 1000, got %v", history)
+	}
+}
+
+type fakeRepo struct {
+	pages     map[string]page
+	limits    []int64
+	updates   [][]*database.User
+	updateErr error
+}
+
+type page struct {
+	users   []*database.User
+	nextKey string
+}
+
+func (f *fakeRepo) ListUserRatingsPage(cohort database.DojoCohort, startKey string, limit int64) ([]*database.User, string, error) {
+	f.limits = append(f.limits, limit)
+	p := f.pages[startKey]
+	return p.users, p.nextKey, nil
+}
+
+func (f *fakeRepo) UpdateUserRatings(users []*database.User) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	copied := make([]*database.User, len(users))
+	copy(copied, users)
+	f.updates = append(f.updates, copied)
+	return nil
+}
+
+type fakeInvoker struct {
+	inputs []*lambdasvc.InvokeInput
+	err    error
+}
+
+func (f *fakeInvoker) Invoke(input *lambdasvc.InvokeInput) (*lambdasvc.InvokeOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.inputs = append(f.inputs, input)
+	return &lambdasvc.InvokeOutput{StatusCode: aws.Int64(202)}, nil
+}
+
+// setupHandler installs fakes for every external dependency.
+// remaining is consumed one value per remainingTime call; the last value repeats.
+func setupHandler(t *testing.T, repo *fakeRepo, inv *fakeInvoker, remaining ...time.Duration) {
+	t.Helper()
+
+	origRepo, origInvoker, origRemaining, origBulk, origChesscom := repository, invoker, remainingTime, fetchBulkLichess, fetchChesscom
+	t.Cleanup(func() {
+		repository, invoker, remainingTime, fetchBulkLichess, fetchChesscom = origRepo, origInvoker, origRemaining, origBulk, origChesscom
+	})
+
+	repository = repo
+	invoker = inv
+	fetchBulkLichess = func(usernames []string) (map[string]ratings.LichessResponse, error) {
+		return map[string]ratings.LichessResponse{}, nil
+	}
+	fetchChesscom = func(username string) (*database.Rating, error) {
+		return &database.Rating{CurrentRating: 1500, Deviation: 50, NumGames: 1}, nil
+	}
+	calls := 0
+	remainingTime = func(ctx context.Context) time.Duration {
+		i := calls
+		if i >= len(remaining) {
+			i = len(remaining) - 1
+		}
+		calls++
+		return remaining[i]
+	}
+}
+
+func chesscomUser(name string, notFound int) *database.User {
+	return &database.User{
+		Username: name,
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Chesscom: {Username: name, NotFoundCount: notFound},
+		},
+	}
+}
+
+func scheduledEvent(t *testing.T, req RatingUpdateRequest) Event {
+	t.Helper()
+	detail, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Event{ID: "StatsUpdate1000-1100", DetailType: "Scheduled Event", Source: "Serverless", Detail: detail}
+}
+
+func TestHandler_CompletesSmallCohortWithoutContinuation(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"": {users: []*database.User{chesscomUser("a", 0), chesscomUser("b", 0)}},
+	}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(inv.inputs) != 0 {
+		t.Error("final chunk must not self-invoke")
+	}
+	if len(repo.limits) == 0 || repo.limits[0] != 50 {
+		t.Errorf("expected chunk limit 50, got %v", repo.limits)
+	}
+	if len(repo.updates) != 1 || len(repo.updates[0]) != 2 {
+		t.Fatalf("expected one flush of 2 users, got %v", repo.updates)
+	}
+}
+
+func TestHandler_ChainsPagesUntilDone(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"":     {users: []*database.User{chesscomUser("a", 0)}, nextKey: "key2"},
+		"key2": {users: []*database.User{chesscomUser("b", 0)}},
+	}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(repo.updates) != 2 {
+		t.Errorf("expected both pages processed, got %d flushes", len(repo.updates))
+	}
+	if len(inv.inputs) != 0 {
+		t.Error("expected no continuation")
+	}
+}
+
+func TestHandler_CheckpointsBetweenChunks(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"":     {users: []*database.User{chesscomUser("a", 0)}, nextKey: "key2"},
+		"key2": {users: []*database.User{chesscomUser("b", 0)}},
+	}}
+	inv := &fakeInvoker{}
+	// Plenty of time for user "a", then out of time at the between-chunk check.
+	setupHandler(t, repo, inv, time.Hour, time.Minute)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err != nil {
+		t.Fatalf("expected clean checkpoint, got %v", err)
+	}
+	if len(inv.inputs) != 1 {
+		t.Fatalf("expected one continuation invoke, got %d", len(inv.inputs))
+	}
+
+	var cont events.CloudWatchEvent
+	if err := json.Unmarshal(inv.inputs[0].Payload, &cont); err != nil {
+		t.Fatalf("continuation payload is not a CloudWatchEvent envelope: %v", err)
+	}
+	if cont.ID != "StatsUpdate1000-1100-cont1" {
+		t.Errorf("expected derived event ID, got %q", cont.ID)
+	}
+	var req RatingUpdateRequest
+	if err := json.Unmarshal(cont.Detail, &req); err != nil {
+		t.Fatalf("continuation Detail invalid: %v", err)
+	}
+	if req.StartKey != "key2" || req.ContinuationCount != 1 || len(req.Cohorts) != 1 {
+		t.Errorf("unexpected continuation request: %+v", req)
+	}
+	// Writes must be flushed before the continuation was sent.
+	if len(repo.updates) != 1 {
+		t.Errorf("expected flush before checkpoint, got %d flushes", len(repo.updates))
+	}
+}
+
+func TestHandler_MidChunkCursorResumesAfterLastPersistedUser(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"": {users: []*database.User{chesscomUser("a", 0), chesscomUser("b", 0), chesscomUser("c", 0)}},
+	}}
+	inv := &fakeInvoker{}
+	// Time ok for users a and b, out of time before user c.
+	setupHandler(t, repo, inv, time.Hour, time.Hour, time.Minute)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err != nil {
+		t.Fatalf("expected clean checkpoint, got %v", err)
+	}
+	if len(inv.inputs) != 1 {
+		t.Fatalf("expected one continuation, got %d", len(inv.inputs))
+	}
+
+	var cont events.CloudWatchEvent
+	_ = json.Unmarshal(inv.inputs[0].Payload, &cont)
+	var req RatingUpdateRequest
+	_ = json.Unmarshal(cont.Detail, &req)
+	if !strings.Contains(req.StartKey, `"b"`) {
+		t.Errorf("cursor must resume after user b (last persisted), got %q", req.StartKey)
+	}
+	if len(repo.updates) != 1 || len(repo.updates[0]) != 2 {
+		t.Fatalf("expected flush of exactly users a,b before checkpoint, got %v", repo.updates)
+	}
+}
+
+func TestHandler_StopBeforeFirstUserReusesChunkStartKey(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"": {users: []*database.User{chesscomUser("a", 0)}},
+	}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Minute)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err != nil {
+		t.Fatalf("expected clean checkpoint, got %v", err)
+	}
+	var cont events.CloudWatchEvent
+	_ = json.Unmarshal(inv.inputs[0].Payload, &cont)
+	var req RatingUpdateRequest
+	_ = json.Unmarshal(cont.Detail, &req)
+	if req.StartKey != "" {
+		t.Errorf("expected empty startKey (chunk start), got %q", req.StartKey)
+	}
+	if len(repo.updates) != 0 {
+		t.Error("no users processed, nothing should be flushed")
+	}
+}
+
+func TestHandler_FlushFailureFailsWithoutInvoking(t *testing.T) {
+	repo := &fakeRepo{
+		pages:     map[string]page{"": {users: []*database.User{chesscomUser("a", 0)}}},
+		updateErr: errors.New(500, "Temporary server error", "PartiQL statement failed"),
+	}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err == nil {
+		t.Fatal("expected error on write failure")
+	}
+	if len(inv.inputs) != 0 {
+		t.Error("must not self-invoke after failed writes")
+	}
+}
+
+func TestHandler_ContinuationCapFailsLoudly(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"": {users: []*database.User{chesscomUser("a", 0)}, nextKey: "key2"},
+	}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour, time.Minute)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{
+		Cohorts:           []database.DojoCohort{"1000-1100"},
+		ContinuationCount: 10,
+	}))
+	if err == nil {
+		t.Fatal("expected error at continuation cap")
+	}
+	if len(inv.inputs) != 0 {
+		t.Error("must not invoke past the cap")
+	}
+}
+
+func TestHandler_InvokeFailureReturnsError(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"": {users: []*database.User{chesscomUser("a", 0)}, nextKey: "key2"},
+	}}
+	inv := &fakeInvoker{err: fmt.Errorf("invoke failed")}
+	setupHandler(t, repo, inv, time.Hour, time.Minute)
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err == nil {
+		t.Fatal("expected error when self-invocation fails")
+	}
+}
+
+func TestHandler_DuplicateDeliveryIsIdempotent(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"": {users: []*database.User{chesscomUser("a", 0)}},
+	}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+
+	event := scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}})
+	if _, err := Handler(context.Background(), event); err != nil {
+		t.Fatalf("first delivery failed: %v", err)
+	}
+	// Reset the fake page state so the "retry" sees the same source data.
+	repo.pages[""] = page{users: []*database.User{chesscomUser("a", 0)}}
+	if _, err := Handler(context.Background(), event); err != nil {
+		t.Fatalf("duplicate delivery failed: %v", err)
+	}
+	if len(repo.updates) != 2 {
+		t.Fatalf("expected two flushes, got %d", len(repo.updates))
+	}
+	first, second := repo.updates[0][0].Ratings[database.Chesscom], repo.updates[1][0].Ratings[database.Chesscom]
+	if first.CurrentRating != second.CurrentRating || first.NotFoundCount != second.NotFoundCount {
+		t.Errorf("duplicate delivery must write identical state: %+v vs %+v", first, second)
+	}
+	if len(inv.inputs) != 0 {
+		t.Error("no continuation expected")
+	}
+}
+
+// TestHandler_ContinuationChainProcessesAllUsers drives the full checkpoint
+// loop: every payload the handler sends to the fake invoker is fed back into
+// the handler, simulating AWS delivering the continuation events, until the
+// cohort completes.
+func TestHandler_ContinuationChainProcessesAllUsers(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"":     {users: []*database.User{chesscomUser("a", 0)}, nextKey: "key2"},
+		"key2": {users: []*database.User{chesscomUser("b", 0)}, nextKey: "key3"},
+		"key3": {users: []*database.User{chesscomUser("c", 0)}},
+	}}
+	inv := &fakeInvoker{}
+	// Per invocation: one in-chunk check (plenty) and one between-chunk check
+	// (out of time), forcing a checkpoint after every chunk. The final
+	// invocation only makes the in-chunk check.
+	setupHandler(t, repo, inv, time.Hour, time.Minute, time.Hour, time.Minute, time.Hour)
+
+	event := scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}})
+	delivered := 0
+	for i := 0; i < maxContinuations+1; i++ {
+		if _, err := Handler(context.Background(), event); err != nil {
+			t.Fatalf("invocation %d failed: %v", i, err)
+		}
+		if len(inv.inputs) == delivered {
+			break
+		}
+		delivered = len(inv.inputs)
+		if err := json.Unmarshal(inv.inputs[delivered-1].Payload, &event); err != nil {
+			t.Fatalf("continuation payload does not round-trip through the handler event type: %v", err)
+		}
+	}
+
+	if delivered != 2 {
+		t.Fatalf("expected 2 continuations for 3 pages, got %d", delivered)
+	}
+	if event.ID != "StatsUpdate1000-1100-cont2" {
+		t.Errorf("expected final continuation ID cont2, got %q", event.ID)
+	}
+	var processed []string
+	for _, batch := range repo.updates {
+		for _, user := range batch {
+			processed = append(processed, user.Username)
+		}
+	}
+	if strings.Join(processed, ",") != "a,b,c" {
+		t.Errorf("expected users a,b,c processed exactly once in order, got %v", processed)
+	}
+}
+
+func TestUpdateUsers_LichessBulkFailureDoesNotIncrement(t *testing.T) {
+	origBulk := fetchBulkLichess
+	t.Cleanup(func() { fetchBulkLichess = origBulk })
+	fetchBulkLichess = func(usernames []string) (map[string]ratings.LichessResponse, error) {
+		return nil, errors.New(500, "Temporary server error", "bulk down")
+	}
+	origRepo := repository
+	t.Cleanup(func() { repository = origRepo })
+	repo := &fakeRepo{}
+	repository = repo
+
+	user := &database.User{
+		Username: "a",
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Lichess: {Username: "a", NotFoundCount: 1},
+		},
+	}
+	_, completed, err := updateUsers("1000-1100", []*database.User{user}, func() bool { return false })
+	if err != nil || !completed {
+		t.Fatalf("expected clean completion, got completed=%v err=%v", completed, err)
+	}
+	if user.Ratings[database.Lichess].NotFoundCount != 1 {
+		t.Errorf("bulk failure must not change NotFoundCount, got %d", user.Ratings[database.Lichess].NotFoundCount)
+	}
+}
+
+func TestUpdateUsers_LichessMissingFromSuccessfulBulkIncrements(t *testing.T) {
+	origBulk := fetchBulkLichess
+	t.Cleanup(func() { fetchBulkLichess = origBulk })
+	var requested []string
+	fetchBulkLichess = func(usernames []string) (map[string]ratings.LichessResponse, error) {
+		requested = usernames
+		return map[string]ratings.LichessResponse{}, nil
+	}
+	origRepo := repository
+	t.Cleanup(func() { repository = origRepo })
+	repo := &fakeRepo{}
+	repository = repo
+
+	missing := &database.User{
+		Username: "missing",
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Lichess: {Username: "missing", NotFoundCount: 0},
+		},
+	}
+	suppressed := &database.User{
+		Username: "suppressed",
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Lichess: {Username: "suppressed", NotFoundCount: 3},
+		},
+	}
+	_, completed, err := updateUsers("1000-1100", []*database.User{missing, suppressed}, func() bool { return false })
+	if err != nil || !completed {
+		t.Fatalf("expected clean completion, got completed=%v err=%v", completed, err)
+	}
+	if missing.Ratings[database.Lichess].NotFoundCount != 1 {
+		t.Errorf("expected increment to 1, got %d", missing.Ratings[database.Lichess].NotFoundCount)
+	}
+	if len(requested) != 1 || requested[0] != "missing" {
+		t.Errorf("suppressed user must be excluded from bulk list, got %v", requested)
+	}
+}

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -631,6 +631,10 @@ functions:
               - ''
               - - ${param:UsersTableArn}
                 - '/index/CohortIdx'
+      - Effect: Allow
+        Action:
+          - lambda:InvokeFunction
+        Resource: arn:aws:lambda:${aws:region}:${aws:accountId}:function:chess-dojo-users-${sls:stage}-updateRatings
 
   updateStatistics:
     handler: statistics/update/main.go
@@ -980,6 +984,26 @@ resources:
         Threshold: 700000
         ComparisonOperator: GreaterThanThreshold
         TreatMissingData: ignore
+
+    UpdateRatingsErrorAlarm:
+      Condition: IsNotSimple
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: UpdateRatingsError-${sls:stage}
+        AlarmDescription: 'Notifications about Lambda errors for the updateRatings function, including continuation-cap hits and failed writes'
+        AlarmActions:
+          - ${param:AlertNotificationsTopic}
+        Namespace: AWS/Lambda
+        MetricName: Errors
+        Statistic: Sum
+        Dimensions:
+          - Name: FunctionName
+            Value: chess-dojo-users-${sls:stage}-updateRatings
+        Period: 86400
+        EvaluationPeriods: 1
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
 
     UpdateStatisticsTimeoutAlarm:
       Condition: IsNotSimple


### PR DESCRIPTION
## Summary

Improves the rating update pipeline by adding checkpointed Lambda continuations, retrying Chess.com 429 responses, and suppressing repeated Chess.com/Lichess not-found lookups.

## Related Issues

Part 1 of #2537

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [x] New Go unit tests were added
* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests
