### PR TITLE
fix: block chrome auto-translate on chess terms

### DIFF
--- a/frontend/src/board/pgn/explorer/Database.tsx
+++ b/frontend/src/board/pgn/explorer/Database.tsx
@@ -416,10 +416,11 @@ function Database({
                                 sx={{ width: 1 }}
                                 size='small'
                                 error={timeControls.length === 0}
+                                noTranslate
                             />
                             <Tooltip
                                 title={
-                                    <span>
+                                    <span translate='no' className='notranslate'>
                                         {t.rich('timeControlTooltip', {
                                             br: () => <br />,
                                         })}

--- a/frontend/src/board/pgn/pgnText/engine/EngineSection.tsx
+++ b/frontend/src/board/pgn/pgnText/engine/EngineSection.tsx
@@ -167,14 +167,20 @@ export default function EngineSection() {
                                         }}
                                     >
                                         <Tooltip
-                                            title={t('localDepthTooltip', {
-                                                depth: engineLines[0].depth,
-                                            })}
+                                            title={
+                                                <span translate='no' className='notranslate'>
+                                                    {t('localDepthTooltip', {
+                                                        depth: engineLines[0].depth,
+                                                    })}
+                                                </span>
+                                            }
                                         >
                                             <Typography variant='caption'>
-                                                {t('depthDisplay', {
-                                                    depth: engineLines[0].depth,
-                                                })}
+                                                <span translate='no' className='notranslate'>
+                                                    {t('depthDisplay', {
+                                                        depth: engineLines[0].depth,
+                                                    })}
+                                                </span>
                                             </Typography>
                                         </Tooltip>
                                         <Typography
@@ -191,7 +197,13 @@ export default function EngineSection() {
 
                                     {showCloudDepth && (
                                         <Tooltip
-                                            title={t('cloudDepthTooltip', { depth: chessDbDepth })}
+                                            title={
+                                                <span translate='no' className='notranslate'>
+                                                    {t('cloudDepthTooltip', {
+                                                        depth: chessDbDepth,
+                                                    })}
+                                                </span>
+                                            }
                                             disableInteractive
                                         >
                                             <Stack direction='row' alignItems='center' spacing={1}>
@@ -208,7 +220,9 @@ export default function EngineSection() {
                                                     variant='caption'
                                                     sx={{ color: 'text.secondary' }}
                                                 >
-                                                    {t('depthDisplay', { depth: chessDbDepth })}
+                                                    <span translate='no' className='notranslate'>
+                                                        {t('depthDisplay', { depth: chessDbDepth })}
+                                                    </span>
                                                 </Typography>
                                             </Stack>
                                         </Tooltip>

--- a/frontend/src/components/ui/MultipleSelectChip.tsx
+++ b/frontend/src/components/ui/MultipleSelectChip.tsx
@@ -47,6 +47,7 @@ export interface MultipleSelectChipProps {
     'data-testid'?: string;
     displayEmpty?: string;
     disabled?: boolean;
+    noTranslate?: boolean;
 }
 
 export default function MultipleSelectChip({
@@ -60,6 +61,7 @@ export default function MultipleSelectChip({
     helperText,
     displayEmpty,
     disabled,
+    noTranslate,
     ...others
 }: MultipleSelectChipProps) {
     const theme = useTheme();
@@ -75,7 +77,13 @@ export default function MultipleSelectChip({
     };
 
     return (
-        <FormControl {...others} sx={sx} error={error}>
+        <FormControl
+            {...others}
+            sx={sx}
+            error={error}
+            translate={noTranslate ? 'no' : undefined}
+            className={noTranslate ? 'notranslate' : undefined}
+        >
             {label && <InputLabel>{label}</InputLabel>}
             <Select
                 multiple
@@ -107,6 +115,8 @@ export default function MultipleSelectChip({
                         key={option.value}
                         value={option.value}
                         style={getStyles(option.value, selected, theme)}
+                        translate={noTranslate ? 'no' : undefined}
+                        className={noTranslate ? 'notranslate' : undefined}
                     >
                         {option.icon && <ListItemIcon>{option.icon}</ListItemIcon>}
                         <ListItemText>{option.label}</ListItemText>


### PR DESCRIPTION
## Summary

chrome auto-translate was mutating text nodes (turning "blitz" into "flash"). fixed by wrapping engine depth and time control labels with `translate="no"` and `className="notranslate"`.

handled mui portal edge cases by adding a `noTranslate` prop to `MultipleSelectChip`. this ensures both the base component and the portaled dropdown menu items inherit the translation blockers. applied strictly to the analysis board so we don't break unrelated selectors.

## Related Issues

Closes #2536 