### PR TITLE
feat(#2537): add monthly federation rating updates

### DIFF
--- a/backend/database/fideRatings.go
+++ b/backend/database/fideRatings.go
@@ -1,0 +1,59 @@
+package database
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
+)
+
+var fideRatingsTable = stage + "-fide-ratings"
+
+// FideRating is one row of the monthly FIDE rating list import.
+type FideRating struct {
+	// The player's FIDE ID.
+	Id string `dynamodbav:"id" json:"id"`
+
+	// The player's standard rating. 0 if the player has no standard rating.
+	Rating int `dynamodbav:"rating" json:"rating"`
+
+	// TTL attribute. DynamoDB deletes rows not refreshed by a later import.
+	ExpiresAt int64 `dynamodbav:"expiresAt" json:"expiresAt"`
+}
+
+// GetFideRating returns the rating for the given FIDE ID from the monthly
+// rating list import. IDs absent from the list return a 404 error.
+func (repo *dynamoRepository) GetFideRating(fideId string) (*Rating, error) {
+	input := &dynamodb.GetItemInput{
+		Key: map[string]*dynamodb.AttributeValue{
+			"id": {S: aws.String(fideId)},
+		},
+		TableName: aws.String(fideRatingsTable),
+	}
+	result, err := repo.svc.GetItem(input)
+	if err != nil {
+		return nil, errors.Wrap(500, "Temporary server error", "DynamoDB GetItem failure", err)
+	}
+	if result.Item == nil {
+		return nil, errors.New(404, "Invalid request: FIDE ID not found in rating list", fmt.Sprintf("FIDE ID %q not in table", fideId))
+	}
+
+	item := FideRating{}
+	if err := dynamodbattribute.UnmarshalMap(result.Item, &item); err != nil {
+		return nil, errors.Wrap(500, "Temporary server error", "Failed to unmarshal FideRating", err)
+	}
+	return fideRatingToRating(&item, time.Now())
+}
+
+// fideRatingToRating rejects expired rows: DynamoDB TTL deletion is
+// asynchronous, so expired items can still be returned by GetItem.
+func fideRatingToRating(item *FideRating, now time.Time) (*Rating, error) {
+	if item.ExpiresAt <= now.Unix() {
+		return nil, errors.New(404, "Invalid request: FIDE ID not found in rating list", fmt.Sprintf("FIDE ID %q expired at %d", item.Id, item.ExpiresAt))
+	}
+	return &Rating{CurrentRating: item.Rating}, nil
+}

--- a/backend/database/fideRatings_test.go
+++ b/backend/database/fideRatings_test.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFideRatingToRating_Valid(t *testing.T) {
+	now := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	item := &FideRating{Id: "1503014", Rating: 2839, ExpiresAt: now.Add(24 * time.Hour).Unix()}
+
+	rating, err := fideRatingToRating(item, now)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if rating.CurrentRating != 2839 {
+		t.Errorf("expected rating 2839, got %d", rating.CurrentRating)
+	}
+}
+
+func TestFideRatingToRating_UnratedIsZero(t *testing.T) {
+	now := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	item := &FideRating{Id: "123", Rating: 0, ExpiresAt: now.Add(24 * time.Hour).Unix()}
+
+	rating, err := fideRatingToRating(item, now)
+	if err != nil {
+		t.Fatalf("expected success for unrated player, got %v", err)
+	}
+	if rating.CurrentRating != 0 {
+		t.Errorf("expected rating 0, got %d", rating.CurrentRating)
+	}
+}
+
+func TestFideRatingToRating_ExpiredIsNotFound(t *testing.T) {
+	now := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+	for _, expiresAt := range []int64{now.Unix(), now.Add(-time.Hour).Unix()} {
+		item := &FideRating{Id: "123", Rating: 2000, ExpiresAt: expiresAt}
+		if _, err := fideRatingToRating(item, now); err == nil {
+			t.Errorf("expected error for expiresAt=%d <= now", expiresAt)
+		}
+	}
+}

--- a/backend/root/serverless.yml
+++ b/backend/root/serverless.yml
@@ -343,6 +343,22 @@ resources:
             Projection:
               ProjectionType: ALL
 
+    FideRatingsTable:
+      Type: AWS::DynamoDB::Table
+      DeletionPolicy: !If [IsNotSimple, 'Retain', 'Delete']
+      Properties:
+        TableName: ${sls:stage}-fide-ratings
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        TimeToLiveSpecification:
+          AttributeName: expiresAt
+          Enabled: true
+
     EventsTable:
       Type: AWS::DynamoDB::Table
       DeletionPolicy: !If [IsNotSimple, 'Retain', 'Delete']
@@ -762,6 +778,8 @@ resources:
       Value: !GetAtt CognitoUserPool.ProviderURL
     UsersTableArn:
       Value: !GetAtt UsersTable.Arn
+    FideRatingsTableArn:
+      Value: !GetAtt FideRatingsTable.Arn
     RequirementsTableArn:
       Value: !GetAtt RequirementsTable.Arn
     GraduationsTableArn:

--- a/backend/serverless-compose.yml
+++ b/backend/serverless-compose.yml
@@ -10,6 +10,7 @@ services:
       UserPoolArn: ${chess-dojo-scheduler.UserPoolArn}
       UserPoolId: ${chess-dojo-scheduler.UserPoolId}
       UsersTableArn: ${chess-dojo-scheduler.UsersTableArn}
+      FideRatingsTableArn: ${chess-dojo-scheduler.FideRatingsTableArn}
       RequirementsTableArn: ${chess-dojo-scheduler.RequirementsTableArn}
       TimelineTableArn: ${chess-dojo-scheduler.TimelineTableArn}
       GraduationsTableArn: ${chess-dojo-scheduler.GraduationsTableArn}

--- a/backend/user/ratings/fide/main.go
+++ b/backend/user/ratings/fide/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
@@ -49,14 +50,23 @@ var listUrl = "https://ratings.fide.com/download/players_list.zip"
 var downloadClient = &http.Client{Timeout: 5 * time.Minute}
 
 type dynamoClient interface {
-	BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error)
-	GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
-	PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error)
+	BatchWriteItemWithContext(ctx aws.Context, input *dynamodb.BatchWriteItemInput, opts ...request.Option) (*dynamodb.BatchWriteItemOutput, error)
+	GetItemWithContext(ctx aws.Context, input *dynamodb.GetItemInput, opts ...request.Option) (*dynamodb.GetItemOutput, error)
+	PutItemWithContext(ctx aws.Context, input *dynamodb.PutItemInput, opts ...request.Option) (*dynamodb.PutItemOutput, error)
 }
 
 var svc dynamoClient = dynamodb.New(session.Must(session.NewSession()))
 var fideRatingsTable = os.Getenv("stage") + "-fide-ratings"
-var sleepFunc = time.Sleep
+var sleepFunc = func(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
 // fideParser extracts FIDE ID and standard rating from fixed-width lines of
 // the combined players list. Column offsets are derived from the header line
@@ -67,10 +77,11 @@ type fideParser struct {
 }
 
 func newFideParser(header string) (*fideParser, error) {
+	idStart := strings.Index(header, "ID Number")
 	idEnd := strings.Index(header, "Name")
 	ratingStart := strings.Index(header, "SRtng")
-	if idEnd <= 0 || ratingStart <= 0 {
-		return nil, errors.New(500, "Temporary server error", "FIDE list header is missing Name or SRtng column; wrong file?")
+	if idStart != 0 || idEnd <= len("ID Number") || ratingStart <= idEnd {
+		return nil, errors.New(500, "Temporary server error", "FIDE list header is missing or misorders ID Number, Name, or SRtng columns; wrong file?")
 	}
 	return &fideParser{idEnd: idEnd, ratingStart: ratingStart}, nil
 }
@@ -100,9 +111,9 @@ func (p *fideParser) parse(line string) (string, int, bool) {
 // writeBatch sends one BatchWriteItem, retrying unprocessed items with
 // exponential backoff. The existing database.batchWrite is not used because
 // it errors out on UnprocessedItems, which are expected at ~76K batches.
-func writeBatch(reqs []*dynamodb.WriteRequest) error {
+func writeBatch(ctx context.Context, reqs []*dynamodb.WriteRequest) error {
 	for attempt := 1; ; attempt++ {
-		output, err := svc.BatchWriteItem(&dynamodb.BatchWriteItemInput{
+		output, err := svc.BatchWriteItemWithContext(ctx, &dynamodb.BatchWriteItemInput{
 			RequestItems: map[string][]*dynamodb.WriteRequest{fideRatingsTable: reqs},
 		})
 		if err != nil {
@@ -116,15 +127,21 @@ func writeBatch(reqs []*dynamodb.WriteRequest) error {
 			return errors.New(500, "Temporary server error", fmt.Sprintf("%d items still unprocessed after %d attempts", len(unprocessed), attempt))
 		}
 		reqs = unprocessed
-		sleepFunc(time.Duration(1<<attempt) * 100 * time.Millisecond)
+		if err := sleepFunc(ctx, time.Duration(1<<attempt)*100*time.Millisecond); err != nil {
+			return errors.Wrap(500, "Temporary server error", "DynamoDB BatchWriteItem retry canceled", err)
+		}
 	}
 }
 
 // download fetches the list zip to ephemeral storage and returns the local
 // path and the Last-Modified header. Downloading fully before parsing means
 // no DynamoDB writes can happen on a failed or truncated download.
-func download() (string, time.Time, error) {
-	resp, err := downloadClient.Get(listUrl)
+func download(ctx context.Context) (string, time.Time, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, listUrl, nil)
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(500, "Temporary server error", "Failed to create FIDE rating list request", err)
+	}
+	resp, err := downloadClient.Do(req)
 	if err != nil {
 		return "", time.Time{}, errors.Wrap(500, "Temporary server error", "Failed to download FIDE rating list", err)
 	}
@@ -155,10 +172,11 @@ func download() (string, time.Time, error) {
 
 // lastImportedModified returns the Last-Modified recorded by the previous
 // successful import, or ok=false if none exists.
-func lastImportedModified() (time.Time, bool, error) {
-	output, err := svc.GetItem(&dynamodb.GetItemInput{
-		Key:       map[string]*dynamodb.AttributeValue{"id": {S: aws.String(metadataId)}},
-		TableName: aws.String(fideRatingsTable),
+func lastImportedModified(ctx context.Context) (time.Time, bool, error) {
+	output, err := svc.GetItemWithContext(ctx, &dynamodb.GetItemInput{
+		Key:            map[string]*dynamodb.AttributeValue{"id": {S: aws.String(metadataId)}},
+		TableName:      aws.String(fideRatingsTable),
+		ConsistentRead: aws.Bool(true),
 	})
 	if err != nil {
 		return time.Time{}, false, errors.Wrap(500, "Temporary server error", "Failed to get FIDE import metadata", err)
@@ -173,14 +191,20 @@ func lastImportedModified() (time.Time, bool, error) {
 	return stored, true, nil
 }
 
-func recordImport(lastModified time.Time, written int) error {
-	_, err := svc.PutItem(&dynamodb.PutItemInput{
-		TableName: aws.String(fideRatingsTable),
+func recordImport(ctx context.Context, lastModified time.Time, written int) error {
+	lastModifiedUnix := strconv.FormatInt(lastModified.Unix(), 10)
+	_, err := svc.PutItemWithContext(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(fideRatingsTable),
+		ConditionExpression: aws.String("attribute_not_exists(lastModifiedUnix) OR lastModifiedUnix < :lastModifiedUnix"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":lastModifiedUnix": {N: aws.String(lastModifiedUnix)},
+		},
 		Item: map[string]*dynamodb.AttributeValue{
-			"id":           {S: aws.String(metadataId)},
-			"lastModified": {S: aws.String(lastModified.UTC().Format(http.TimeFormat))},
-			"importedAt":   {S: aws.String(time.Now().Format(time.RFC3339))},
-			"written":      {N: aws.String(strconv.Itoa(written))},
+			"id":               {S: aws.String(metadataId)},
+			"lastModified":     {S: aws.String(lastModified.UTC().Format(http.TimeFormat))},
+			"lastModifiedUnix": {N: aws.String(lastModifiedUnix)},
+			"importedAt":       {S: aws.String(time.Now().Format(time.RFC3339))},
+			"written":          {N: aws.String(strconv.Itoa(written))},
 		},
 	})
 	return errors.Wrap(500, "Temporary server error", "Failed to record FIDE import metadata", err)
@@ -190,12 +214,12 @@ func recordImport(lastModified time.Time, written int) error {
 // number of rows written and the number of malformed lines skipped.
 func writeRatings(ctx context.Context, scanner *bufio.Scanner, parser *fideParser) (int, int, error) {
 	expiresAt := time.Now().Add(ttlDuration).Unix()
-	group, ctx := errgroup.WithContext(ctx)
+	group, groupCtx := errgroup.WithContext(ctx)
 	batches := make(chan []*dynamodb.WriteRequest)
 	for range numWriters {
 		group.Go(func() error {
 			for reqs := range batches {
-				if err := writeBatch(reqs); err != nil {
+				if err := writeBatch(groupCtx, reqs); err != nil {
 					return err
 				}
 			}
@@ -207,7 +231,7 @@ func writeRatings(ctx context.Context, scanner *bufio.Scanner, parser *fideParse
 		select {
 		case batches <- reqs:
 			return true
-		case <-ctx.Done():
+		case <-groupCtx.Done():
 			return false
 		}
 	}
@@ -233,6 +257,7 @@ func writeRatings(ctx context.Context, scanner *bufio.Scanner, parser *fideParse
 		reqs = append(reqs, &dynamodb.WriteRequest{PutRequest: &dynamodb.PutRequest{Item: item}})
 		if len(reqs) == batchSize {
 			if !send(reqs) {
+				loopErr = errors.Wrap(500, "Temporary server error", "FIDE list import canceled", groupCtx.Err())
 				break
 			}
 			written += batchSize
@@ -244,12 +269,19 @@ func writeRatings(ctx context.Context, scanner *bufio.Scanner, parser *fideParse
 			loopErr = errors.Wrap(500, "Temporary server error", "Failed reading FIDE list", err)
 		}
 	}
-	if loopErr == nil && len(reqs) > 0 && send(reqs) {
-		written += len(reqs)
+	if loopErr == nil && len(reqs) > 0 {
+		if send(reqs) {
+			written += len(reqs)
+		} else {
+			loopErr = errors.Wrap(500, "Temporary server error", "FIDE list import canceled", groupCtx.Err())
+		}
 	}
 	close(batches)
 	if err := group.Wait(); err != nil {
 		return written, malformed, err
+	}
+	if loopErr == nil && ctx.Err() != nil {
+		loopErr = errors.Wrap(500, "Temporary server error", "FIDE list import canceled", ctx.Err())
 	}
 	return written, malformed, loopErr
 }
@@ -257,14 +289,14 @@ func writeRatings(ctx context.Context, scanner *bufio.Scanner, parser *fideParse
 func Handler(ctx context.Context, event events.CloudWatchEvent) error {
 	log.SetRequestId(event.ID)
 
-	path, lastModified, err := download()
+	path, lastModified, err := download(ctx)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 	defer os.Remove(path)
 
-	stored, ok, err := lastImportedModified()
+	stored, ok, err := lastImportedModified(ctx)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -325,7 +357,12 @@ func Handler(ctx context.Context, event events.CloudWatchEvent) error {
 		log.Error(err)
 		return err
 	}
-	if err := recordImport(lastModified, written); err != nil {
+	if err := ctx.Err(); err != nil {
+		err = errors.Wrap(500, "Temporary server error", "FIDE list import canceled before recording metadata", err)
+		log.Error(err)
+		return err
+	}
+	if err := recordImport(ctx, lastModified, written); err != nil {
 		log.Error(err)
 		return err
 	}

--- a/backend/user/ratings/fide/main.go
+++ b/backend/user/ratings/fide/main.go
@@ -1,0 +1,338 @@
+// Package main implements the downloadFideRatings lambda, which imports the
+// monthly FIDE rating list into the fide-ratings DynamoDB table.
+package main
+
+import (
+	"archive/zip"
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+)
+
+const (
+	srtngWidth        = len("SRtng")
+	batchSize         = 25
+	maxBatchAttempts  = 6
+	metadataId        = "METADATA"
+	numWriters        = 8
+	maxMalformedLines = 1000
+	ttlDuration       = 90 * 24 * time.Hour
+)
+
+// minImportRows guards against a truncated-but-parseable file: importing a
+// small subset and recording its Last-Modified would block a rerun with the
+// same file via the strictly-newer check. The combined list has ~1.9M rows.
+// var (not const) so handler tests can use tiny fixtures.
+var minImportRows = 1_000_000
+
+var listUrl = "https://ratings.fide.com/download/players_list.zip"
+
+// The shared ratings client has a 5s timeout; a ~44MB download needs its own.
+var downloadClient = &http.Client{Timeout: 5 * time.Minute}
+
+type dynamoClient interface {
+	BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error)
+	GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
+	PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error)
+}
+
+var svc dynamoClient = dynamodb.New(session.Must(session.NewSession()))
+var fideRatingsTable = os.Getenv("stage") + "-fide-ratings"
+var sleepFunc = time.Sleep
+
+// fideParser extracts FIDE ID and standard rating from fixed-width lines of
+// the combined players list. Column offsets are derived from the header line
+// so FIDE layout shifts fail loudly instead of silently misparsing.
+type fideParser struct {
+	idEnd       int
+	ratingStart int
+}
+
+func newFideParser(header string) (*fideParser, error) {
+	idEnd := strings.Index(header, "Name")
+	ratingStart := strings.Index(header, "SRtng")
+	if idEnd <= 0 || ratingStart <= 0 {
+		return nil, errors.New(500, "Temporary server error", "FIDE list header is missing Name or SRtng column; wrong file?")
+	}
+	return &fideParser{idEnd: idEnd, ratingStart: ratingStart}, nil
+}
+
+func (p *fideParser) parse(line string) (string, int, bool) {
+	if len(line) < p.ratingStart+srtngWidth {
+		return "", 0, false
+	}
+	id := strings.TrimSpace(line[:p.idEnd])
+	if id == "" || strings.IndexFunc(id, func(r rune) bool { return r < '0' || r > '9' }) >= 0 {
+		return "", 0, false
+	}
+	field := strings.TrimSpace(line[p.ratingStart : p.ratingStart+srtngWidth])
+	if field == "" {
+		return id, 0, true
+	}
+	rating := 0
+	for _, r := range field {
+		if r < '0' || r > '9' {
+			return "", 0, false
+		}
+		rating = rating*10 + int(r-'0')
+	}
+	return id, rating, true
+}
+
+// writeBatch sends one BatchWriteItem, retrying unprocessed items with
+// exponential backoff. The existing database.batchWrite is not used because
+// it errors out on UnprocessedItems, which are expected at ~76K batches.
+func writeBatch(reqs []*dynamodb.WriteRequest) error {
+	for attempt := 1; ; attempt++ {
+		output, err := svc.BatchWriteItem(&dynamodb.BatchWriteItemInput{
+			RequestItems: map[string][]*dynamodb.WriteRequest{fideRatingsTable: reqs},
+		})
+		if err != nil {
+			return errors.Wrap(500, "Temporary server error", "Failed DynamoDB BatchWriteItem", err)
+		}
+		unprocessed := output.UnprocessedItems[fideRatingsTable]
+		if len(unprocessed) == 0 {
+			return nil
+		}
+		if attempt >= maxBatchAttempts {
+			return errors.New(500, "Temporary server error", fmt.Sprintf("%d items still unprocessed after %d attempts", len(unprocessed), attempt))
+		}
+		reqs = unprocessed
+		sleepFunc(time.Duration(1<<attempt) * 100 * time.Millisecond)
+	}
+}
+
+// download fetches the list zip to ephemeral storage and returns the local
+// path and the Last-Modified header. Downloading fully before parsing means
+// no DynamoDB writes can happen on a failed or truncated download.
+func download() (string, time.Time, error) {
+	resp, err := downloadClient.Get(listUrl)
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(500, "Temporary server error", "Failed to download FIDE rating list", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, errors.New(500, "Temporary server error", fmt.Sprintf("FIDE list download returned status %d", resp.StatusCode))
+	}
+	lastModified, err := http.ParseTime(resp.Header.Get("Last-Modified"))
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(500, "Temporary server error", "FIDE list response has no valid Last-Modified header", err)
+	}
+
+	f, err := os.CreateTemp("", "players_list_*.zip")
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(500, "Temporary server error", "Failed to create temp file", err)
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", time.Time{}, errors.Wrap(500, "Temporary server error", "Failed to write FIDE list to disk", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", time.Time{}, errors.Wrap(500, "Temporary server error", "Failed to close temp file", err)
+	}
+	return f.Name(), lastModified, nil
+}
+
+// lastImportedModified returns the Last-Modified recorded by the previous
+// successful import, or ok=false if none exists.
+func lastImportedModified() (time.Time, bool, error) {
+	output, err := svc.GetItem(&dynamodb.GetItemInput{
+		Key:       map[string]*dynamodb.AttributeValue{"id": {S: aws.String(metadataId)}},
+		TableName: aws.String(fideRatingsTable),
+	})
+	if err != nil {
+		return time.Time{}, false, errors.Wrap(500, "Temporary server error", "Failed to get FIDE import metadata", err)
+	}
+	if output.Item == nil || output.Item["lastModified"] == nil || output.Item["lastModified"].S == nil {
+		return time.Time{}, false, nil
+	}
+	stored, err := http.ParseTime(*output.Item["lastModified"].S)
+	if err != nil {
+		return time.Time{}, false, errors.Wrap(500, "Temporary server error", "Stored FIDE import metadata is invalid", err)
+	}
+	return stored, true, nil
+}
+
+func recordImport(lastModified time.Time, written int) error {
+	_, err := svc.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(fideRatingsTable),
+		Item: map[string]*dynamodb.AttributeValue{
+			"id":           {S: aws.String(metadataId)},
+			"lastModified": {S: aws.String(lastModified.UTC().Format(http.TimeFormat))},
+			"importedAt":   {S: aws.String(time.Now().Format(time.RFC3339))},
+			"written":      {N: aws.String(strconv.Itoa(written))},
+		},
+	})
+	return errors.Wrap(500, "Temporary server error", "Failed to record FIDE import metadata", err)
+}
+
+// writeRatings streams parsed rows to a pool of batch writers. Returns the
+// number of rows written and the number of malformed lines skipped.
+func writeRatings(ctx context.Context, scanner *bufio.Scanner, parser *fideParser) (int, int, error) {
+	expiresAt := time.Now().Add(ttlDuration).Unix()
+	group, ctx := errgroup.WithContext(ctx)
+	batches := make(chan []*dynamodb.WriteRequest)
+	for range numWriters {
+		group.Go(func() error {
+			for reqs := range batches {
+				if err := writeBatch(reqs); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	send := func(reqs []*dynamodb.WriteRequest) bool {
+		select {
+		case batches <- reqs:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	written, malformed := 0, 0
+	var loopErr error
+	var reqs []*dynamodb.WriteRequest
+	for scanner.Scan() {
+		id, rating, ok := parser.parse(scanner.Text())
+		if !ok {
+			malformed++
+			if malformed > maxMalformedLines {
+				loopErr = errors.New(500, "Temporary server error", fmt.Sprintf("FIDE list import aborted: more than %d malformed lines", maxMalformedLines))
+				break
+			}
+			continue
+		}
+		item, err := dynamodbattribute.MarshalMap(database.FideRating{Id: id, Rating: rating, ExpiresAt: expiresAt})
+		if err != nil {
+			loopErr = errors.Wrap(500, "Temporary server error", "Failed to marshal FideRating", err)
+			break
+		}
+		reqs = append(reqs, &dynamodb.WriteRequest{PutRequest: &dynamodb.PutRequest{Item: item}})
+		if len(reqs) == batchSize {
+			if !send(reqs) {
+				break
+			}
+			written += batchSize
+			reqs = nil
+		}
+	}
+	if loopErr == nil {
+		if err := scanner.Err(); err != nil {
+			loopErr = errors.Wrap(500, "Temporary server error", "Failed reading FIDE list", err)
+		}
+	}
+	if loopErr == nil && len(reqs) > 0 && send(reqs) {
+		written += len(reqs)
+	}
+	close(batches)
+	if err := group.Wait(); err != nil {
+		return written, malformed, err
+	}
+	return written, malformed, loopErr
+}
+
+func Handler(ctx context.Context, event events.CloudWatchEvent) error {
+	log.SetRequestId(event.ID)
+
+	path, lastModified, err := download()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	defer os.Remove(path)
+
+	stored, ok, err := lastImportedModified()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if ok && !lastModified.After(stored) {
+		err := errors.New(500, "Temporary server error", fmt.Sprintf("FIDE list (Last-Modified %s) is not newer than last import (%s)", lastModified, stored))
+		log.Error(err)
+		return err
+	}
+
+	reader, err := zip.OpenReader(path)
+	if err != nil {
+		err = errors.Wrap(500, "Temporary server error", "Failed to open FIDE list zip", err)
+		log.Error(err)
+		return err
+	}
+	defer reader.Close()
+
+	var txt *zip.File
+	for _, f := range reader.File {
+		if strings.HasSuffix(f.Name, ".txt") {
+			txt = f
+			break
+		}
+	}
+	if txt == nil {
+		err := errors.New(500, "Temporary server error", "FIDE list zip contains no .txt file")
+		log.Error(err)
+		return err
+	}
+	contents, err := txt.Open()
+	if err != nil {
+		err = errors.Wrap(500, "Temporary server error", "Failed to open FIDE list txt", err)
+		log.Error(err)
+		return err
+	}
+	defer contents.Close()
+
+	scanner := bufio.NewScanner(contents)
+	if !scanner.Scan() {
+		err := errors.New(500, "Temporary server error", "FIDE list txt is empty")
+		log.Error(err)
+		return err
+	}
+	parser, err := newFideParser(scanner.Text())
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	written, malformed, err := writeRatings(ctx, scanner, parser)
+	if err != nil {
+		log.Errorf("FIDE import failed after %d writes (%d malformed): %v", written, malformed, err)
+		return err
+	}
+	if written < minImportRows {
+		err := errors.New(500, "Temporary server error", fmt.Sprintf("FIDE import wrote only %d rows (minimum %d); refusing to record metadata for a truncated list", written, minImportRows))
+		log.Error(err)
+		return err
+	}
+	if err := recordImport(lastModified, written); err != nil {
+		log.Error(err)
+		return err
+	}
+	log.Infof("FIDE import complete: written=%d malformed=%d lastModified=%s", written, malformed, lastModified)
+	return nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/backend/user/ratings/fide/main.go
+++ b/backend/user/ratings/fide/main.go
@@ -98,12 +98,9 @@ func (p *fideParser) parse(line string) (string, int, bool) {
 	if field == "" {
 		return id, 0, true
 	}
-	rating := 0
-	for _, r := range field {
-		if r < '0' || r > '9' {
-			return "", 0, false
-		}
-		rating = rating*10 + int(r-'0')
+	rating, err := strconv.Atoi(field)
+	if err != nil {
+		return "", 0, false
 	}
 	return id, rating, true
 }

--- a/backend/user/ratings/fide/main_test.go
+++ b/backend/user/ratings/fide/main_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
@@ -37,6 +38,12 @@ func TestNewFideParser_RejectsWrongHeader(t *testing.T) {
 	}
 	if _, err := newFideParser(""); err == nil {
 		t.Error("expected error for empty header")
+	}
+	if _, err := newFideParser("prefix Name SRtng"); err == nil {
+		t.Error("expected error for header without ID Number column")
+	}
+	if _, err := newFideParser("ID Number SRtng Name"); err == nil {
+		t.Error("expected error when SRtng appears before Name")
 	}
 }
 
@@ -89,16 +96,21 @@ type fakeDynamo struct {
 	// return none.
 	unprocessed [][]*dynamodb.WriteRequest
 	batchErr    error
+	batchHook   func()
 
+	getInputs []*dynamodb.GetItemInput
 	getOutput *dynamodb.GetItemOutput
 	getErr    error
 	putInputs []*dynamodb.PutItemInput
 	putErr    error
 }
 
-func (f *fakeDynamo) BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+func (f *fakeDynamo) BatchWriteItemWithContext(ctx aws.Context, input *dynamodb.BatchWriteItemInput, opts ...request.Option) (*dynamodb.BatchWriteItemOutput, error) {
 	call := len(f.batchInputs)
 	f.batchInputs = append(f.batchInputs, input)
+	if f.batchHook != nil {
+		f.batchHook()
+	}
 	if f.batchErr != nil {
 		return nil, f.batchErr
 	}
@@ -109,7 +121,8 @@ func (f *fakeDynamo) BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dynam
 	return out, nil
 }
 
-func (f *fakeDynamo) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+func (f *fakeDynamo) GetItemWithContext(ctx aws.Context, input *dynamodb.GetItemInput, opts ...request.Option) (*dynamodb.GetItemOutput, error) {
+	f.getInputs = append(f.getInputs, input)
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
@@ -119,7 +132,7 @@ func (f *fakeDynamo) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOut
 	return &dynamodb.GetItemOutput{}, nil
 }
 
-func (f *fakeDynamo) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+func (f *fakeDynamo) PutItemWithContext(ctx aws.Context, input *dynamodb.PutItemInput, opts ...request.Option) (*dynamodb.PutItemOutput, error) {
 	f.putInputs = append(f.putInputs, input)
 	return &dynamodb.PutItemOutput{}, f.putErr
 }
@@ -129,7 +142,7 @@ func setupDynamo(t *testing.T, fake *fakeDynamo) {
 	origSvc, origSleep := svc, sleepFunc
 	t.Cleanup(func() { svc, sleepFunc = origSvc, origSleep })
 	svc = fake
-	sleepFunc = func(time.Duration) {}
+	sleepFunc = func(context.Context, time.Duration) error { return nil }
 }
 
 func putReq(id string) *dynamodb.WriteRequest {
@@ -142,7 +155,7 @@ func TestWriteBatch_SucceedsFirstTry(t *testing.T) {
 	fake := &fakeDynamo{}
 	setupDynamo(t, fake)
 
-	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1")}); err != nil {
+	if err := writeBatch(context.Background(), []*dynamodb.WriteRequest{putReq("1")}); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if len(fake.batchInputs) != 1 {
@@ -154,7 +167,7 @@ func TestWriteBatch_RetriesOnlyUnprocessedItems(t *testing.T) {
 	fake := &fakeDynamo{unprocessed: [][]*dynamodb.WriteRequest{{putReq("2")}}}
 	setupDynamo(t, fake)
 
-	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1"), putReq("2")}); err != nil {
+	if err := writeBatch(context.Background(), []*dynamodb.WriteRequest{putReq("1"), putReq("2")}); err != nil {
 		t.Fatalf("expected success after retry, got %v", err)
 	}
 	if len(fake.batchInputs) != 2 {
@@ -174,7 +187,7 @@ func TestWriteBatch_GivesUpAfterMaxAttempts(t *testing.T) {
 	fake := &fakeDynamo{unprocessed: stuck}
 	setupDynamo(t, fake)
 
-	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1")}); err == nil {
+	if err := writeBatch(context.Background(), []*dynamodb.WriteRequest{putReq("1")}); err == nil {
 		t.Fatal("expected error when items never process")
 	}
 	if len(fake.batchInputs) != maxBatchAttempts {
@@ -186,7 +199,7 @@ func TestWriteBatch_RequestErrorFails(t *testing.T) {
 	fake := &fakeDynamo{batchErr: fmt.Errorf("network down")}
 	setupDynamo(t, fake)
 
-	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1")}); err == nil {
+	if err := writeBatch(context.Background(), []*dynamodb.WriteRequest{putReq("1")}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -236,12 +249,13 @@ func handlerEvent() events.CloudWatchEvent {
 }
 
 func TestHandler_ImportsListAndRecordsMetadata(t *testing.T) {
+	published := time.Date(2026, 7, 20, 21, 3, 32, 0, time.UTC)
 	lines := []string{
 		testHeader,
 		testLine("1503014", "Carlsen, Magnus", "2839"),
 		testLine("537001345", "A Arbhin Vanniarajan", "0"),
 	}
-	serveZip(t, buildZip(t, lines), time.Date(2026, 7, 20, 21, 3, 32, 0, time.UTC))
+	serveZip(t, buildZip(t, lines), published)
 	fake := &fakeDynamo{}
 	setupDynamo(t, fake)
 
@@ -268,6 +282,15 @@ func TestHandler_ImportsListAndRecordsMetadata(t *testing.T) {
 	meta := fake.putInputs[0].Item
 	if *meta["id"].S != metadataId || *meta["lastModified"].S != "Mon, 20 Jul 2026 21:03:32 GMT" {
 		t.Errorf("unexpected metadata item: %+v", meta)
+	}
+	if meta["lastModifiedUnix"] == nil || *meta["lastModifiedUnix"].N != fmt.Sprintf("%d", published.Unix()) {
+		t.Errorf("metadata must include numeric Last-Modified for ordering: %+v", meta)
+	}
+	if fake.putInputs[0].ConditionExpression == nil {
+		t.Error("metadata write must be conditional so Last-Modified cannot move backward")
+	}
+	if len(fake.getInputs) != 1 || !aws.BoolValue(fake.getInputs[0].ConsistentRead) {
+		t.Error("freshness metadata must use a strongly consistent read")
 	}
 }
 
@@ -368,5 +391,27 @@ func TestHandler_SkipsMalformedLinesButCountsThem(t *testing.T) {
 	items := fake.batchInputs[0].RequestItems[fideRatingsTable]
 	if len(items) != 2 {
 		t.Errorf("expected 2 items (malformed skipped), got %d", len(items))
+	}
+}
+
+func TestHandler_CancellationAfterWritesSkipsMetadata(t *testing.T) {
+	lines := []string{testHeader}
+	for i := 0; i < batchSize; i++ {
+		lines = append(lines, testLine(fmt.Sprintf("%d", i+1), "A", "1000"))
+	}
+	serveZip(t, buildZip(t, lines), time.Now())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeDynamo{batchHook: cancel}
+	setupDynamo(t, fake)
+
+	if err := Handler(ctx, handlerEvent()); err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if len(fake.batchInputs) != 1 {
+		t.Fatalf("expected first batch to be submitted before cancellation, got %d", len(fake.batchInputs))
+	}
+	if len(fake.putInputs) != 0 {
+		t.Error("metadata must not be recorded after cancellation")
 	}
 }

--- a/backend/user/ratings/fide/main_test.go
+++ b/backend/user/ratings/fide/main_test.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+// Layout copied from the real July 2026 file: Name at 15, SRtng at 113.
+const testHeader = "ID Number      Name                                                         Fed Sex Tit  WTit OTit           FOA SRtng SGm SK RRtng RGm Rk BRtng BGm BK B-day Flag"
+
+func testLine(id, name, rating string) string {
+	line := []byte(testHeader)
+	for i := range line {
+		line[i] = ' '
+	}
+	copy(line[0:], id)
+	copy(line[15:], name)
+	// Right-align within the 5-char SRtng column like the real file.
+	copy(line[113+5-len(rating):], rating)
+	return string(line)
+}
+
+func TestNewFideParser_RejectsWrongHeader(t *testing.T) {
+	if _, err := newFideParser("ID Number      Name   Fed"); err == nil {
+		t.Error("expected error for header without SRtng column")
+	}
+	if _, err := newFideParser(""); err == nil {
+		t.Error("expected error for empty header")
+	}
+}
+
+func TestFideParser_ParsesRatedPlayer(t *testing.T) {
+	p, err := newFideParser(testHeader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, rating, ok := p.parse(testLine("1503014", "Carlsen, Magnus", "2839"))
+	if !ok || id != "1503014" || rating != 2839 {
+		t.Errorf("got id=%q rating=%d ok=%v", id, rating, ok)
+	}
+}
+
+func TestFideParser_ParsesUnratedPlayer(t *testing.T) {
+	p, _ := newFideParser(testHeader)
+	id, rating, ok := p.parse(testLine("537001345", "A Arbhin Vanniarajan", "0"))
+	if !ok || id != "537001345" || rating != 0 {
+		t.Errorf("got id=%q rating=%d ok=%v", id, rating, ok)
+	}
+}
+
+func TestFideParser_EmptyRatingFieldIsZero(t *testing.T) {
+	p, _ := newFideParser(testHeader)
+	id, rating, ok := p.parse(testLine("123", "Blank, Rating", ""))
+	if !ok || id != "123" || rating != 0 {
+		t.Errorf("got id=%q rating=%d ok=%v", id, rating, ok)
+	}
+}
+
+func TestFideParser_RejectsMalformedLines(t *testing.T) {
+	p, _ := newFideParser(testHeader)
+	cases := []string{
+		"",                                     // empty
+		"short line",                           // shorter than rating column
+		testLine("12ab34", "Bad, Id", "2000"),  // non-numeric id
+		testLine("", "No, Id", "2000"),         // blank id
+		testLine("123", "Bad, Rating", "2x00"), // non-numeric rating
+	}
+	for _, line := range cases {
+		if _, _, ok := p.parse(line); ok {
+			t.Errorf("expected parse failure for %q", line)
+		}
+	}
+}
+
+type fakeDynamo struct {
+	batchInputs []*dynamodb.BatchWriteItemInput
+	// unprocessed[i] is returned as UnprocessedItems for call i; extra calls
+	// return none.
+	unprocessed [][]*dynamodb.WriteRequest
+	batchErr    error
+
+	getOutput *dynamodb.GetItemOutput
+	getErr    error
+	putInputs []*dynamodb.PutItemInput
+	putErr    error
+}
+
+func (f *fakeDynamo) BatchWriteItem(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+	call := len(f.batchInputs)
+	f.batchInputs = append(f.batchInputs, input)
+	if f.batchErr != nil {
+		return nil, f.batchErr
+	}
+	out := &dynamodb.BatchWriteItemOutput{UnprocessedItems: map[string][]*dynamodb.WriteRequest{}}
+	if call < len(f.unprocessed) && len(f.unprocessed[call]) > 0 {
+		out.UnprocessedItems[fideRatingsTable] = f.unprocessed[call]
+	}
+	return out, nil
+}
+
+func (f *fakeDynamo) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.getOutput != nil {
+		return f.getOutput, nil
+	}
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (f *fakeDynamo) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	f.putInputs = append(f.putInputs, input)
+	return &dynamodb.PutItemOutput{}, f.putErr
+}
+
+func setupDynamo(t *testing.T, fake *fakeDynamo) {
+	t.Helper()
+	origSvc, origSleep := svc, sleepFunc
+	t.Cleanup(func() { svc, sleepFunc = origSvc, origSleep })
+	svc = fake
+	sleepFunc = func(time.Duration) {}
+}
+
+func putReq(id string) *dynamodb.WriteRequest {
+	return &dynamodb.WriteRequest{PutRequest: &dynamodb.PutRequest{
+		Item: map[string]*dynamodb.AttributeValue{"id": {S: aws.String(id)}},
+	}}
+}
+
+func TestWriteBatch_SucceedsFirstTry(t *testing.T) {
+	fake := &fakeDynamo{}
+	setupDynamo(t, fake)
+
+	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1")}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(fake.batchInputs) != 1 {
+		t.Errorf("expected 1 call, got %d", len(fake.batchInputs))
+	}
+}
+
+func TestWriteBatch_RetriesOnlyUnprocessedItems(t *testing.T) {
+	fake := &fakeDynamo{unprocessed: [][]*dynamodb.WriteRequest{{putReq("2")}}}
+	setupDynamo(t, fake)
+
+	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1"), putReq("2")}); err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if len(fake.batchInputs) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(fake.batchInputs))
+	}
+	retried := fake.batchInputs[1].RequestItems[fideRatingsTable]
+	if len(retried) != 1 || *retried[0].PutRequest.Item["id"].S != "2" {
+		t.Errorf("second call must contain only the unprocessed item, got %+v", retried)
+	}
+}
+
+func TestWriteBatch_GivesUpAfterMaxAttempts(t *testing.T) {
+	stuck := make([][]*dynamodb.WriteRequest, maxBatchAttempts)
+	for i := range stuck {
+		stuck[i] = []*dynamodb.WriteRequest{putReq("1")}
+	}
+	fake := &fakeDynamo{unprocessed: stuck}
+	setupDynamo(t, fake)
+
+	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1")}); err == nil {
+		t.Fatal("expected error when items never process")
+	}
+	if len(fake.batchInputs) != maxBatchAttempts {
+		t.Errorf("expected %d attempts, got %d", maxBatchAttempts, len(fake.batchInputs))
+	}
+}
+
+func TestWriteBatch_RequestErrorFails(t *testing.T) {
+	fake := &fakeDynamo{batchErr: fmt.Errorf("network down")}
+	setupDynamo(t, fake)
+
+	if err := writeBatch([]*dynamodb.WriteRequest{putReq("1")}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// buildZip returns an in-memory players_list.zip containing the given lines.
+func buildZip(t *testing.T, lines []string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.Create("players_list_foa.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte(strings.Join(lines, "\n"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func serveZip(t *testing.T, body []byte, lastModified time.Time) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", lastModified.UTC().Format(http.TimeFormat))
+		w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	origUrl, origFloor := listUrl, minImportRows
+	t.Cleanup(func() { listUrl, minImportRows = origUrl, origFloor })
+	listUrl = server.URL
+	// Handler tests use tiny fixtures; the production floor is exercised by
+	// its dedicated test.
+	minImportRows = 1
+}
+
+func metadataOutput(lastModified time.Time) *dynamodb.GetItemOutput {
+	return &dynamodb.GetItemOutput{Item: map[string]*dynamodb.AttributeValue{
+		"id":           {S: aws.String(metadataId)},
+		"lastModified": {S: aws.String(lastModified.UTC().Format(http.TimeFormat))},
+	}}
+}
+
+func handlerEvent() events.CloudWatchEvent {
+	return events.CloudWatchEvent{ID: "DownloadFideRatings"}
+}
+
+func TestHandler_ImportsListAndRecordsMetadata(t *testing.T) {
+	lines := []string{
+		testHeader,
+		testLine("1503014", "Carlsen, Magnus", "2839"),
+		testLine("537001345", "A Arbhin Vanniarajan", "0"),
+	}
+	serveZip(t, buildZip(t, lines), time.Date(2026, 7, 20, 21, 3, 32, 0, time.UTC))
+	fake := &fakeDynamo{}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(fake.batchInputs) != 1 {
+		t.Fatalf("expected 1 batch write, got %d", len(fake.batchInputs))
+	}
+	items := fake.batchInputs[0].RequestItems[fideRatingsTable]
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	first := items[0].PutRequest.Item
+	if *first["id"].S != "1503014" || *first["rating"].N != "2839" {
+		t.Errorf("unexpected first item: %+v", first)
+	}
+	if first["expiresAt"] == nil {
+		t.Error("expected expiresAt TTL attribute")
+	}
+	if len(fake.putInputs) != 1 {
+		t.Fatalf("expected metadata PutItem, got %d", len(fake.putInputs))
+	}
+	meta := fake.putInputs[0].Item
+	if *meta["id"].S != metadataId || *meta["lastModified"].S != "Mon, 20 Jul 2026 21:03:32 GMT" {
+		t.Errorf("unexpected metadata item: %+v", meta)
+	}
+}
+
+func TestHandler_AbortsWhenListNotNewerThanLastImport(t *testing.T) {
+	published := time.Date(2026, 7, 20, 21, 3, 32, 0, time.UTC)
+	serveZip(t, buildZip(t, []string{testHeader, testLine("1", "A", "1000")}), published)
+	fake := &fakeDynamo{getOutput: metadataOutput(published)}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err == nil {
+		t.Fatal("expected error for not-newer list")
+	}
+	if len(fake.batchInputs) != 0 || len(fake.putInputs) != 0 {
+		t.Error("must not write anything when the list is not newer")
+	}
+}
+
+func TestHandler_ImportsWhenListIsNewer(t *testing.T) {
+	serveZip(t, buildZip(t, []string{testHeader, testLine("1", "A", "1000")}), time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC))
+	fake := &fakeDynamo{getOutput: metadataOutput(time.Date(2026, 7, 20, 21, 3, 32, 0, time.UTC))}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if len(fake.batchInputs) != 1 {
+		t.Errorf("expected 1 batch write, got %d", len(fake.batchInputs))
+	}
+}
+
+func TestHandler_AbortsOnWrongHeaderWithoutWrites(t *testing.T) {
+	serveZip(t, buildZip(t, []string{"WRONG HEADER", testLine("1", "A", "1000")}), time.Now())
+	fake := &fakeDynamo{}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err == nil {
+		t.Fatal("expected error for wrong header")
+	}
+	if len(fake.batchInputs) != 0 || len(fake.putInputs) != 0 {
+		t.Error("must not write anything on header mismatch")
+	}
+}
+
+func TestHandler_AbortsOnBadZipWithoutWrites(t *testing.T) {
+	serveZip(t, []byte("this is not a zip"), time.Now())
+	fake := &fakeDynamo{}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err == nil {
+		t.Fatal("expected error for corrupt zip")
+	}
+	if len(fake.batchInputs) != 0 || len(fake.putInputs) != 0 {
+		t.Error("must not write anything on corrupt zip")
+	}
+}
+
+func TestHandler_WriteFailureSkipsMetadata(t *testing.T) {
+	serveZip(t, buildZip(t, []string{testHeader, testLine("1", "A", "1000")}), time.Now())
+	fake := &fakeDynamo{batchErr: fmt.Errorf("throttled forever")}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err == nil {
+		t.Fatal("expected error when writes fail")
+	}
+	if len(fake.putInputs) != 0 {
+		t.Error("metadata must not be recorded after failed writes")
+	}
+}
+
+func TestHandler_AbortsBelowRowFloorWithoutMetadata(t *testing.T) {
+	serveZip(t, buildZip(t, []string{testHeader, testLine("1", "A", "1000")}), time.Now())
+	minImportRows = 5 // one row is below the floor
+	fake := &fakeDynamo{}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err == nil {
+		t.Fatal("expected error when fewer rows than the floor were written")
+	}
+	if len(fake.putInputs) != 0 {
+		t.Error("metadata must not be recorded for an incomplete import")
+	}
+}
+
+func TestHandler_SkipsMalformedLinesButCountsThem(t *testing.T) {
+	lines := []string{
+		testHeader,
+		testLine("1", "A", "1000"),
+		"garbage line",
+		testLine("2", "B", "1200"),
+	}
+	serveZip(t, buildZip(t, lines), time.Now())
+	fake := &fakeDynamo{}
+	setupDynamo(t, fake)
+
+	if err := Handler(context.Background(), handlerEvent()); err != nil {
+		t.Fatalf("expected success with skipped line, got %v", err)
+	}
+	items := fake.batchInputs[0].RequestItems[fideRatingsTable]
+	if len(items) != 2 {
+		t.Errorf("expected 2 items (malformed skipped), got %d", len(items))
+	}
+}

--- a/backend/user/ratings/ratings.go
+++ b/backend/user/ratings/ratings.go
@@ -32,7 +32,6 @@ const chesscomUserAgent = "ChessDojo rating updater (https://www.chessdojo.club)
 const maxChesscomAttempts = 3
 const maxRetryAfter = 10 * time.Second
 
-var fideRegexp, _ = regexp.Compile(`<p>(\d+)</p>\s*<p.*>STANDARD`)
 var acfRegexp, _ = regexp.Compile(`Current Rating:\s*</div>\s*<div id="stats-box-data-col">\s*[-\d]*\s*</div>\s*<div id="stats-box-data-col">\s*(\d+)`)
 
 type ChesscomResponse struct {
@@ -291,30 +290,7 @@ func findRating(body []byte, regex *regexp.Regexp) (int, error) {
 }
 
 func FetchFideRating(fideId string) (*database.Rating, error) {
-	resp, err := client.Get(fmt.Sprintf("https://ratings.fide.com/profile/%s", fideId))
-	if err != nil {
-		err = errors.Wrap(500, "Temporary server error", "Failed to get Fide page", err)
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		err = errors.New(400, fmt.Sprintf("Invalid request: FIDE returned status `%d` for given ID", resp.StatusCode), "")
-		return nil, err
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		err = errors.Wrap(500, "Temporary server error", "Failed to read FIDE response", err)
-		return nil, err
-	}
-
-	rating, err := findRating(b, fideRegexp)
-	if err != nil {
-		log.Warnf("FIDE id %q: no rating found on website", fideId)
-		rating = 0
-	}
-	return &database.Rating{CurrentRating: rating}, nil
+	return database.DynamoDB.GetFideRating(strings.TrimSpace(fideId))
 }
 
 func FetchUscfRating(uscfId string) (*database.Rating, error) {

--- a/backend/user/ratings/ratings.go
+++ b/backend/user/ratings/ratings.go
@@ -28,6 +28,13 @@ var chesscomHost = "https://api.chess.com"
 var lichessHost = "https://lichess.org"
 var sleepFunc = time.Sleep
 
+func ratingResponseErrorCode(status int) int {
+	if status == http.StatusNotFound {
+		return http.StatusNotFound
+	}
+	return http.StatusBadRequest
+}
+
 const chesscomUserAgent = "ChessDojo rating updater (https://www.chessdojo.club)"
 const maxChesscomAttempts = 3
 const maxRetryAfter = 10 * time.Second
@@ -301,7 +308,7 @@ func FetchUscfRating(uscfId string) (*database.Rating, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		err = errors.New(400, fmt.Sprintf("Invalid request: USCF returned status `%d` for given ID", resp.StatusCode), "")
+		err = errors.New(ratingResponseErrorCode(resp.StatusCode), fmt.Sprintf("Invalid request: USCF returned status `%d` for given ID", resp.StatusCode), "")
 		return nil, err
 	}
 
@@ -339,7 +346,7 @@ func FetchEcfRating(ecfId string) (*database.Rating, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		err = errors.New(400, fmt.Sprintf("Invalid request: ECF API returned status `%d`", resp.StatusCode), "")
+		err = errors.New(ratingResponseErrorCode(resp.StatusCode), fmt.Sprintf("Invalid request: ECF API returned status `%d`", resp.StatusCode), "")
 		return nil, err
 	}
 
@@ -412,7 +419,7 @@ func FetchAcfRating(acfId string) (*database.Rating, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		err = errors.New(400, fmt.Sprintf("Invalid request: ACF site returned status `%d`", resp.StatusCode), "")
+		err = errors.New(ratingResponseErrorCode(resp.StatusCode), fmt.Sprintf("Invalid request: ACF site returned status `%d`", resp.StatusCode), "")
 		return nil, err
 	}
 
@@ -461,7 +468,7 @@ func fetchKnsbListRating(knsbId string, listId int) (*database.Rating, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, errors.New(400, fmt.Sprintf("Invalid request: KNSB API returned status `%d`", resp.StatusCode), "")
+		return nil, errors.New(ratingResponseErrorCode(resp.StatusCode), fmt.Sprintf("Invalid request: KNSB API returned status `%d`", resp.StatusCode), "")
 	}
 
 	var r KnsbResponse

--- a/backend/user/ratings/ratings_test.go
+++ b/backend/user/ratings/ratings_test.go
@@ -1,13 +1,21 @@
 package ratings
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 const chesscomStatsBody = `{"chess_rapid": {"last": {"rating": 1500, "rd": 50}, "record": {"win": 10, "loss": 5, "draw": 2}}}`
 
@@ -235,5 +243,37 @@ func TestFetchBulkLichessRatings_Success(t *testing.T) {
 	}
 	if r, ok := result["user1"]; !ok || r.Performances.Classical.Rating != 1800 {
 		t.Errorf("expected user1 with rating 1800, got %+v", result)
+	}
+}
+
+func TestMonthlyFetchers_PreservePlayerNotFoundStatus(t *testing.T) {
+	originalClient := client
+	t.Cleanup(func() { client = originalClient })
+	client = http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	tests := []struct {
+		name  string
+		fetch func() error
+	}{
+		{"USCF", func() error { _, err := FetchUscfRating("123"); return err }},
+		{"ECF", func() error { _, err := FetchEcfRating("123"); return err }},
+		{"ACF", func() error { _, err := FetchAcfRating("123"); return err }},
+		{"KNSB player", func() error { _, err := fetchKnsbListRating("123", 1); return err }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fetch()
+			var apiErr *errors.Error
+			if !errors.As(err, &apiErr) || apiErr.Code != http.StatusNotFound {
+				t.Fatalf("expected API 404, got %v", err)
+			}
+		})
 	}
 }

--- a/backend/user/ratings/update/main.go
+++ b/backend/user/ratings/update/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,10 +25,14 @@ import (
 type Event events.CloudWatchEvent
 
 const (
-	chunkSize        = 50
-	flushSize        = 25
-	maxContinuations = 10
-	maxNotFoundCount = 3
+	chunkSize              = 50
+	flushSize              = 25
+	maxContinuations       = 10
+	maxNotFoundCount       = 3
+	monthlyFailureMinUsers = 10
+	// monthlyUpdateDay is the day of month on which monthly rating systems are
+	// fetched: the day after downloadFideRatings refreshes the FIDE table.
+	monthlyUpdateDay = 2
 	// checkpointBuffer is the remaining-time threshold below which the
 	// handler stops and re-invokes itself. Chosen together with the 700s
 	// UpdateRatingsTimeoutAlarm: normal runs end around 600s elapsed plus
@@ -48,6 +53,18 @@ var repository ratingsRepository = database.DynamoDB
 var invoker lambdaInvoker = lambdasvc.New(session.Must(session.NewSession()))
 var fetchBulkLichess = ratings.FetchBulkLichessRatings
 var fetchChesscom ratings.RatingFetchFunc = ratings.FetchChesscomRatingWithRetry
+var timeNow = time.Now
+var baseFetchFuncs = ratings.RatingFetchFuncs
+
+// monthlySystems only publish new ratings monthly (or slower) and are
+// fetched on monthlyUpdateDay instead of daily.
+var monthlySystems = map[database.RatingSystem]bool{
+	database.Fide: true,
+	database.Uscf: true,
+	database.Ecf:  true,
+	database.Knsb: true,
+	database.Acf:  true,
+}
 
 var remainingTime = func(ctx context.Context) time.Duration {
 	deadline, ok := ctx.Deadline()
@@ -64,9 +81,68 @@ var now = time.Now()
 type isBannedFunc func(username string) bool
 
 type RatingUpdateRequest struct {
-	Cohorts           []database.DojoCohort `json:"cohorts"`
-	StartKey          string                `json:"startKey,omitempty"`
-	ContinuationCount int                   `json:"continuationCount,omitempty"`
+	Cohorts           []database.DojoCohort         `json:"cohorts"`
+	StartKey          string                        `json:"startKey,omitempty"`
+	ContinuationCount int                           `json:"continuationCount,omitempty"`
+	ForceMonthly      bool                          `json:"forceMonthly,omitempty"`
+	MonthlyAttempts   map[database.RatingSystem]int `json:"monthlyAttempts,omitempty"`
+	MonthlyFailures   map[database.RatingSystem]int `json:"monthlyFailures,omitempty"`
+}
+
+// monthlyStats accumulates fetch attempts/failures per monthly system so the
+// handler can alarm on systemic outages that are otherwise only logged.
+type monthlyStats struct {
+	Attempts map[database.RatingSystem]int
+	Failures map[database.RatingSystem]int
+}
+
+func newMonthlyStats(attempts, failures map[database.RatingSystem]int) *monthlyStats {
+	s := &monthlyStats{
+		Attempts: map[database.RatingSystem]int{},
+		Failures: map[database.RatingSystem]int{},
+	}
+	for system, n := range attempts {
+		s.Attempts[system] = n
+	}
+	for system, n := range failures {
+		s.Failures[system] = n
+	}
+	return s
+}
+
+// record counts one fetch attempt. 404s do not count as failures: they
+// indicate a stale or invalid ID for one user (e.g. an expired USCF
+// membership), not a federation outage, and would otherwise accumulate as
+// permanent baseline noise toward the alarm threshold.
+func (s *monthlyStats) record(system database.RatingSystem, fetchErr error) {
+	s.Attempts[system]++
+	if fetchErr == nil {
+		return
+	}
+	var apiErr *errors.Error
+	if errors.As(fetchErr, &apiErr) && apiErr.Code == 404 {
+		return
+	}
+	s.Failures[system]++
+}
+
+// thresholdError reports systemic monthly-system outages. It must only be
+// called by the invocation that completes the request: returning an error
+// after scheduling a continuation would make the async retry spawn a
+// duplicate continuation chain.
+func (s *monthlyStats) thresholdError() error {
+	var failed []string
+	for system, failures := range s.Failures {
+		attempts := s.Attempts[system]
+		if failures >= monthlyFailureMinUsers && failures*4 > attempts {
+			failed = append(failed, fmt.Sprintf("%s (%d/%d failed)", system, failures, attempts))
+		}
+	}
+	if len(failed) == 0 {
+		return nil
+	}
+	sort.Strings(failed)
+	return errors.New(500, "Temporary server error", fmt.Sprintf("Monthly rating systems exceeded the failure threshold: %s", strings.Join(failed, ", ")))
 }
 
 // tracksNotFound reports whether not-found suppression applies to the system.
@@ -76,14 +152,14 @@ func tracksNotFound(system database.RatingSystem) bool {
 	return system == database.Chesscom || system == database.Lichess
 }
 
-func updateRating(rating *database.Rating, system database.RatingSystem, fetcher ratings.RatingFetchFunc) bool {
+func updateRating(rating *database.Rating, system database.RatingSystem, fetcher ratings.RatingFetchFunc) (bool, error) {
 	rating.Username = strings.TrimSpace(rating.Username)
 	if rating.Username == "" {
-		return false
+		return false, nil
 	}
 
 	if tracksNotFound(system) && rating.NotFoundCount >= maxNotFoundCount {
-		return false
+		return false, nil
 	}
 
 	data, err := fetcher(rating.Username)
@@ -91,10 +167,10 @@ func updateRating(rating *database.Rating, system database.RatingSystem, fetcher
 		if tracksNotFound(system) && errors.Is(err, ratings.ErrNotFound) {
 			rating.NotFoundCount++
 			log.Infof("%s username %q not found (count %d)", system, rating.Username, rating.NotFoundCount)
-			return true
+			return true, nil
 		}
 		log.Errorf("Failed to get %s rating for %q: %v", system, rating.Username, err)
-		return false
+		return false, err
 	}
 
 	shouldUpdate := rating.NotFoundCount != 0
@@ -113,15 +189,21 @@ func updateRating(rating *database.Rating, system database.RatingSystem, fetcher
 		shouldUpdate = true
 	}
 
-	return shouldUpdate
+	return shouldUpdate, nil
 }
 
-func updateUser(user *database.User, fetchFuncs map[database.RatingSystem]ratings.RatingFetchFunc, isBannedLichess isBannedFunc) bool {
+func updateUser(user *database.User, fetchFuncs map[database.RatingSystem]ratings.RatingFetchFunc, isBannedLichess isBannedFunc, includeMonthly bool, stats *monthlyStats) bool {
 	shouldUpdate := false
 
 	for system, rating := range user.Ratings {
 		if system != database.Custom && system != database.Custom2 && system != database.Custom3 {
-			shouldUpdate = updateRating(rating, system, fetchFuncs[system]) || shouldUpdate
+			if !monthlySystems[system] || includeMonthly {
+				changed, fetchErr := updateRating(rating, system, fetchFuncs[system])
+				shouldUpdate = changed || shouldUpdate
+				if monthlySystems[system] && rating.Username != "" {
+					stats.record(system, fetchErr)
+				}
+			}
 		}
 
 		if system == database.Lichess && isBannedLichess(rating.Username) {
@@ -187,8 +269,8 @@ func ratingFetchFuncs(lichessRatings map[string]ratings.LichessResponse, lichess
 		}, nil
 	}
 
-	funcs := make(map[database.RatingSystem]ratings.RatingFetchFunc, len(ratings.RatingFetchFuncs))
-	for system, fetch := range ratings.RatingFetchFuncs {
+	funcs := make(map[database.RatingSystem]ratings.RatingFetchFunc, len(baseFetchFuncs))
+	for system, fetch := range baseFetchFuncs {
 		funcs[system] = fetch
 	}
 	funcs[database.Chesscom] = fetchChesscom
@@ -227,7 +309,7 @@ func cursorForUser(cohort database.DojoCohort, user *database.User) string {
 // updateUsers processes users in order. It returns the cursor of the last
 // persisted user ("" if none), whether all users were processed, and any
 // write error. On a write error the checkpoint must not advance.
-func updateUsers(cohort database.DojoCohort, users []*database.User, outOfTime func() bool) (string, bool, error) {
+func updateUsers(cohort database.DojoCohort, users []*database.User, outOfTime func() bool, includeMonthly bool, stats *monthlyStats) (string, bool, error) {
 	if len(users) == 0 {
 		return "", true, nil
 	}
@@ -251,7 +333,7 @@ func updateUsers(cohort database.DojoCohort, users []*database.User, outOfTime f
 			return cursorForUser(cohort, users[i-1]), false, nil
 		}
 
-		if updateUser(user, fetchFuncs, isBannedLichess) {
+		if updateUser(user, fetchFuncs, isBannedLichess, includeMonthly, stats) {
 			queued = append(queued, user)
 			if len(queued) == flushSize {
 				if err := flush(queued); err != nil {
@@ -268,20 +350,15 @@ func updateUsers(cohort database.DojoCohort, users []*database.User, outOfTime f
 	return "", true, nil
 }
 
-// checkpoint asynchronously re-invokes this function to continue processing
-// from startKey. It fails loudly at the continuation cap.
-func checkpoint(event Event, cohorts []database.DojoCohort, startKey string, continuationCount int) error {
-	if continuationCount+1 > maxContinuations {
-		err := errors.New(500, "Temporary server error", fmt.Sprintf("updateRatings hit the continuation cap (%d) for cohorts %v without completing", maxContinuations, cohorts))
+// checkpoint asynchronously re-invokes this function with the given
+// continuation request. It fails loudly at the continuation cap.
+func checkpoint(event Event, req RatingUpdateRequest) error {
+	if req.ContinuationCount > maxContinuations {
+		err := errors.New(500, "Temporary server error", fmt.Sprintf("updateRatings hit the continuation cap (%d) for cohorts %v without completing", maxContinuations, req.Cohorts))
 		log.Error(err)
 		return err
 	}
 
-	req := RatingUpdateRequest{
-		Cohorts:           cohorts,
-		StartKey:          startKey,
-		ContinuationCount: continuationCount + 1,
-	}
 	detail, err := json.Marshal(req)
 	if err != nil {
 		return errors.Wrap(500, "Temporary server error", "Failed to marshal continuation request", err)
@@ -289,7 +366,7 @@ func checkpoint(event Event, cohorts []database.DojoCohort, startKey string, con
 
 	baseID := strings.Split(event.ID, "-cont")[0]
 	continuation := Event{
-		ID:         fmt.Sprintf("%s-cont%d", baseID, continuationCount+1),
+		ID:         fmt.Sprintf("%s-cont%d", baseID, req.ContinuationCount),
 		DetailType: event.DetailType,
 		Source:     event.Source,
 		Region:     event.Region,
@@ -312,14 +389,14 @@ func checkpoint(event Event, cohorts []database.DojoCohort, startKey string, con
 		return errors.New(500, "Temporary server error", fmt.Sprintf("Continuation invoke returned status %d", aws.Int64Value(output.StatusCode)))
 	}
 
-	log.Infof("Checkpointed: cohorts=%v startKey=%s continuation=%d", cohorts, startKey, continuationCount+1)
+	log.Infof("Checkpointed: cohorts=%v startKey=%s continuation=%d", req.Cohorts, req.StartKey, req.ContinuationCount)
 	return nil
 }
 
 func Handler(ctx context.Context, event Event) (Event, error) {
 	log.Infof("Event: %#v", event)
 	log.SetRequestId(event.ID)
-	now = time.Now()
+	now = timeNow()
 
 	var req RatingUpdateRequest
 	if err := json.Unmarshal(event.Detail, &req); err != nil {
@@ -329,6 +406,22 @@ func Handler(ctx context.Context, event Event) (Event, error) {
 	log.Infof("Request: %+v", req)
 
 	outOfTime := func() bool { return remainingTime(ctx) < checkpointBuffer }
+	includeMonthly := now.Day() == monthlyUpdateDay || req.ForceMonthly
+	stats := newMonthlyStats(req.MonthlyAttempts, req.MonthlyFailures)
+
+	// continuation builds the checkpoint request, propagating the monthly
+	// state. ForceMonthly carries includeMonthly so a day-2 run that crosses
+	// midnight keeps fetching monthly systems in its continuations.
+	continuation := func(cohorts []database.DojoCohort, startKey string) RatingUpdateRequest {
+		return RatingUpdateRequest{
+			Cohorts:           cohorts,
+			StartKey:          startKey,
+			ContinuationCount: req.ContinuationCount + 1,
+			ForceMonthly:      includeMonthly,
+			MonthlyAttempts:   stats.Attempts,
+			MonthlyFailures:   stats.Failures,
+		}
+	}
 
 	for i, cohort := range req.Cohorts {
 		startKey := ""
@@ -343,7 +436,7 @@ func Handler(ctx context.Context, event Event) (Event, error) {
 				return event, err
 			}
 
-			cursor, completed, err := updateUsers(cohort, users, outOfTime)
+			cursor, completed, err := updateUsers(cohort, users, outOfTime, includeMonthly, stats)
 			if err != nil {
 				return event, err
 			}
@@ -351,7 +444,7 @@ func Handler(ctx context.Context, event Event) (Event, error) {
 				if cursor == "" {
 					cursor = startKey
 				}
-				return event, checkpoint(event, req.Cohorts[i:], cursor, req.ContinuationCount)
+				return event, checkpoint(event, continuation(req.Cohorts[i:], cursor))
 			}
 
 			log.Infof("Processed chunk: cohort=%s users=%d continuation=%d", cohort, len(users), req.ContinuationCount)
@@ -362,13 +455,13 @@ func Handler(ctx context.Context, event Event) (Event, error) {
 			startKey = nextKey
 
 			if outOfTime() {
-				return event, checkpoint(event, req.Cohorts[i:], nextKey, req.ContinuationCount)
+				return event, checkpoint(event, continuation(req.Cohorts[i:], nextKey))
 			}
 		}
 		log.Infof("Cohort complete: cohort=%s continuation=%d", cohort, req.ContinuationCount)
 	}
 
-	return event, nil
+	return event, stats.thresholdError()
 }
 
 func main() {

--- a/backend/user/ratings/update/main_test.go
+++ b/backend/user/ratings/update/main_test.go
@@ -36,7 +36,8 @@ func TestUpdateRating_SkipsAtNotFoundThreshold(t *testing.T) {
 	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1200}}
 	rating := &database.Rating{Username: "gone", NotFoundCount: 3}
 
-	if updateRating(rating, database.Chesscom, fetcher.fetch) {
+	changed, _ := updateRating(rating, database.Chesscom, fetcher.fetch)
+	if changed {
 		t.Error("expected no update for suppressed rating")
 	}
 	if fetcher.calls != 0 {
@@ -48,7 +49,8 @@ func TestUpdateRating_IncrementsOnNotFound(t *testing.T) {
 	fetcher := &fakeFetcher{err: notFoundErr()}
 	rating := &database.Rating{Username: "gone", NotFoundCount: 1, CurrentRating: 900}
 
-	if !updateRating(rating, database.Chesscom, fetcher.fetch) {
+	changed, _ := updateRating(rating, database.Chesscom, fetcher.fetch)
+	if !changed {
 		t.Error("expected update=true so the increment persists")
 	}
 	if rating.NotFoundCount != 2 {
@@ -63,7 +65,8 @@ func TestUpdateRating_ResetsCounterOnSuccess(t *testing.T) {
 	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 900}}
 	rating := &database.Rating{Username: "back", NotFoundCount: 2, CurrentRating: 900, StartRating: 800}
 
-	if !updateRating(rating, database.Chesscom, fetcher.fetch) {
+	changed, _ := updateRating(rating, database.Chesscom, fetcher.fetch)
+	if !changed {
 		t.Error("expected update=true so the reset persists even with unchanged rating")
 	}
 	if rating.NotFoundCount != 0 {
@@ -75,7 +78,8 @@ func TestUpdateRating_OtherErrorLeavesCounter(t *testing.T) {
 	fetcher := &fakeFetcher{err: errors.New(500, "Temporary server error", "")}
 	rating := &database.Rating{Username: "flaky", NotFoundCount: 1}
 
-	if updateRating(rating, database.Chesscom, fetcher.fetch) {
+	changed, _ := updateRating(rating, database.Chesscom, fetcher.fetch)
+	if changed {
 		t.Error("expected no update on transient error")
 	}
 	if rating.NotFoundCount != 1 {
@@ -87,7 +91,8 @@ func TestUpdateRating_UntrackedSystemIgnoresNotFound(t *testing.T) {
 	fetcher := &fakeFetcher{err: notFoundErr()}
 	rating := &database.Rating{Username: "12345", NotFoundCount: 0}
 
-	if updateRating(rating, database.Uscf, fetcher.fetch) {
+	changed, _ := updateRating(rating, database.Uscf, fetcher.fetch)
+	if changed {
 		t.Error("expected no update for untracked system")
 	}
 	if rating.NotFoundCount != 0 {
@@ -99,7 +104,7 @@ func TestUpdateRating_UntrackedSystemNeverSkips(t *testing.T) {
 	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 2000}}
 	rating := &database.Rating{Username: "12345", NotFoundCount: 5}
 
-	updateRating(rating, database.Fide, fetcher.fetch)
+	_, _ = updateRating(rating, database.Fide, fetcher.fetch)
 	if fetcher.calls != 1 {
 		t.Errorf("expected FIDE fetch despite NotFoundCount, got %d calls", fetcher.calls)
 	}
@@ -109,7 +114,8 @@ func TestUpdateRating_ChangeDetectionStillWorks(t *testing.T) {
 	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1100, NumGames: 20}}
 	rating := &database.Rating{Username: "player", CurrentRating: 1000, StartRating: 950, NumGames: 15}
 
-	if !updateRating(rating, database.Chesscom, fetcher.fetch) {
+	changed, _ := updateRating(rating, database.Chesscom, fetcher.fetch)
+	if !changed {
 		t.Error("expected update for changed rating")
 	}
 	if rating.CurrentRating != 1100 || rating.NumGames != 20 {
@@ -137,12 +143,133 @@ func TestUpdateUser_EmptyHistorySliceDoesNotPanic(t *testing.T) {
 		},
 	}
 
-	if !updateUser(user, fetchFuncs, func(string) bool { return false }) {
+	if !updateUser(user, fetchFuncs, func(string) bool { return false }, true, newMonthlyStats(nil, nil)) {
 		t.Error("expected update from history append")
 	}
 	history := user.RatingHistories[database.Chesscom]
 	if len(history) != 1 || history[0].Rating != 1000 {
 		t.Errorf("expected one history entry with rating 1000, got %v", history)
+	}
+}
+
+func fideUser(name string) *database.User {
+	return &database.User{
+		Username: name,
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Fide: {Username: name, CurrentRating: 1500, StartRating: 1400},
+		},
+	}
+}
+
+func TestUpdateUser_SkipsMonthlySystemsWhenNotIncluded(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1600}}
+	user := fideUser("a")
+	fetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{database.Fide: fetcher.fetch}
+
+	if updateUser(user, fetchFuncs, func(string) bool { return false }, false, newMonthlyStats(nil, nil)) {
+		t.Error("expected no update when monthly systems are skipped")
+	}
+	if fetcher.calls != 0 {
+		t.Errorf("expected no FIDE fetch, got %d calls", fetcher.calls)
+	}
+	if user.Ratings[database.Fide].CurrentRating != 1500 {
+		t.Error("stored rating must be untouched")
+	}
+}
+
+func TestUpdateUser_FetchesMonthlySystemsWhenIncluded(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1600}}
+	user := fideUser("a")
+	fetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{database.Fide: fetcher.fetch}
+	stats := newMonthlyStats(nil, nil)
+
+	if !updateUser(user, fetchFuncs, func(string) bool { return false }, true, stats) {
+		t.Error("expected update from changed FIDE rating")
+	}
+	if fetcher.calls != 1 {
+		t.Errorf("expected 1 FIDE fetch, got %d", fetcher.calls)
+	}
+	if stats.Attempts[database.Fide] != 1 || stats.Failures[database.Fide] != 0 {
+		t.Errorf("expected attempts=1 failures=0, got %+v", stats)
+	}
+}
+
+func TestUpdateUser_DailySystemsUnaffectedByGate(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1600}}
+	user := chesscomUser("a", 0)
+	fetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{database.Chesscom: fetcher.fetch}
+
+	if !updateUser(user, fetchFuncs, func(string) bool { return false }, false, newMonthlyStats(nil, nil)) {
+		t.Error("expected chess.com update even when monthly systems are skipped")
+	}
+	if fetcher.calls != 1 {
+		t.Errorf("expected 1 chess.com fetch, got %d", fetcher.calls)
+	}
+}
+
+func TestUpdateUser_MonthlyFailureIsCounted(t *testing.T) {
+	fetcher := &fakeFetcher{err: errors.New(500, "Temporary server error", "USCF down")}
+	user := &database.User{
+		Username: "a",
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Uscf: {Username: "12345", CurrentRating: 1500},
+		},
+	}
+	fetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{database.Uscf: fetcher.fetch}
+	stats := newMonthlyStats(nil, nil)
+
+	updateUser(user, fetchFuncs, func(string) bool { return false }, true, stats)
+	if stats.Attempts[database.Uscf] != 1 || stats.Failures[database.Uscf] != 1 {
+		t.Errorf("expected attempts=1 failures=1, got %+v", stats)
+	}
+}
+
+func TestUpdateUser_MonthlyNotFoundNotCountedAsFailure(t *testing.T) {
+	fetcher := &fakeFetcher{err: errors.New(404, "Invalid request: USCF member does not have a regular rating", "")}
+	user := &database.User{
+		Username: "a",
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Uscf: {Username: "12345", CurrentRating: 1500},
+		},
+	}
+	fetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{database.Uscf: fetcher.fetch}
+	stats := newMonthlyStats(nil, nil)
+
+	updateUser(user, fetchFuncs, func(string) bool { return false }, true, stats)
+	if stats.Attempts[database.Uscf] != 1 || stats.Failures[database.Uscf] != 0 {
+		t.Errorf("404 must count as attempt but not failure, got %+v", stats)
+	}
+}
+
+func TestUpdateUser_EmptyUsernameNotCounted(t *testing.T) {
+	fetcher := &fakeFetcher{rating: &database.Rating{CurrentRating: 1600}}
+	user := &database.User{
+		Username: "a",
+		Ratings: map[database.RatingSystem]*database.Rating{
+			database.Fide: {Username: "   "},
+		},
+	}
+	fetchFuncs := map[database.RatingSystem]ratings.RatingFetchFunc{database.Fide: fetcher.fetch}
+	stats := newMonthlyStats(nil, nil)
+
+	updateUser(user, fetchFuncs, func(string) bool { return false }, true, stats)
+	if stats.Attempts[database.Fide] != 0 {
+		t.Errorf("empty username must not count as attempt, got %+v", stats)
+	}
+}
+
+func TestUpdateUser_MondayHistoryAppendsForSkippedMonthlySystem(t *testing.T) {
+	origNow := now
+	t.Cleanup(func() { now = origNow })
+	now = time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC) // a Monday
+
+	user := fideUser("a")
+	if !updateUser(user, map[database.RatingSystem]ratings.RatingFetchFunc{}, func(string) bool { return false }, false, newMonthlyStats(nil, nil)) {
+		t.Error("expected update from history append")
+	}
+	history := user.RatingHistories[database.Fide]
+	if len(history) != 1 || history[0].Rating != 1500 {
+		t.Errorf("expected history entry with stored rating 1500, got %v", history)
 	}
 }
 
@@ -193,8 +320,10 @@ func setupHandler(t *testing.T, repo *fakeRepo, inv *fakeInvoker, remaining ...t
 	t.Helper()
 
 	origRepo, origInvoker, origRemaining, origBulk, origChesscom := repository, invoker, remainingTime, fetchBulkLichess, fetchChesscom
+	origTimeNow, origBase := timeNow, baseFetchFuncs
 	t.Cleanup(func() {
 		repository, invoker, remainingTime, fetchBulkLichess, fetchChesscom = origRepo, origInvoker, origRemaining, origBulk, origChesscom
+		timeNow, baseFetchFuncs = origTimeNow, origBase
 	})
 
 	repository = repo
@@ -205,6 +334,8 @@ func setupHandler(t *testing.T, repo *fakeRepo, inv *fakeInvoker, remaining ...t
 	fetchChesscom = func(username string) (*database.Rating, error) {
 		return &database.Rating{CurrentRating: 1500, Deviation: 50, NumGames: 1}, nil
 	}
+	timeNow = func() time.Time { return time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC) } // Tuesday the 6th: not Monday, not day 2
+	baseFetchFuncs = map[database.RatingSystem]ratings.RatingFetchFunc{}
 	calls := 0
 	remainingTime = func(ctx context.Context) time.Duration {
 		i := calls
@@ -506,7 +637,7 @@ func TestUpdateUsers_LichessBulkFailureDoesNotIncrement(t *testing.T) {
 			database.Lichess: {Username: "a", NotFoundCount: 1},
 		},
 	}
-	_, completed, err := updateUsers("1000-1100", []*database.User{user}, func() bool { return false })
+	_, completed, err := updateUsers("1000-1100", []*database.User{user}, func() bool { return false }, false, newMonthlyStats(nil, nil))
 	if err != nil || !completed {
 		t.Fatalf("expected clean completion, got completed=%v err=%v", completed, err)
 	}
@@ -540,7 +671,7 @@ func TestUpdateUsers_LichessMissingFromSuccessfulBulkIncrements(t *testing.T) {
 			database.Lichess: {Username: "suppressed", NotFoundCount: 3},
 		},
 	}
-	_, completed, err := updateUsers("1000-1100", []*database.User{missing, suppressed}, func() bool { return false })
+	_, completed, err := updateUsers("1000-1100", []*database.User{missing, suppressed}, func() bool { return false }, false, newMonthlyStats(nil, nil))
 	if err != nil || !completed {
 		t.Fatalf("expected clean completion, got completed=%v err=%v", completed, err)
 	}
@@ -549,5 +680,168 @@ func TestUpdateUsers_LichessMissingFromSuccessfulBulkIncrements(t *testing.T) {
 	}
 	if len(requested) != 1 || requested[0] != "missing" {
 		t.Errorf("suppressed user must be excluded from bulk list, got %v", requested)
+	}
+}
+
+func TestMonthlyStats_ThresholdError(t *testing.T) {
+	cases := []struct {
+		name      string
+		attempts  int
+		failures  int
+		wantError bool
+	}{
+		{"no failures", 100, 0, false},
+		{"below min users", 20, 9, false},
+		{"min users but low rate", 100, 20, false},
+		{"exactly 25 percent is not over", 40, 10, false},
+		{"over threshold", 30, 10, true},
+		{"total outage", 12, 12, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stats := newMonthlyStats(
+				map[database.RatingSystem]int{database.Uscf: tc.attempts},
+				map[database.RatingSystem]int{database.Uscf: tc.failures},
+			)
+			err := stats.thresholdError()
+			if (err != nil) != tc.wantError {
+				t.Errorf("attempts=%d failures=%d: got err=%v, wantError=%v", tc.attempts, tc.failures, err, tc.wantError)
+			}
+		})
+	}
+}
+
+func failingFideFuncs() map[database.RatingSystem]ratings.RatingFetchFunc {
+	return map[database.RatingSystem]ratings.RatingFetchFunc{
+		database.Fide: func(username string) (*database.Rating, error) {
+			return nil, errors.New(500, "Temporary server error", "FIDE table empty")
+		},
+	}
+}
+
+func fideUsers(n int) []*database.User {
+	users := make([]*database.User, 0, n)
+	for i := 0; i < n; i++ {
+		users = append(users, fideUser(fmt.Sprintf("user%02d", i)))
+	}
+	return users
+}
+
+func TestHandler_ForceMonthlyFetchesAndReturnsThresholdError(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{"": {users: fideUsers(12)}}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+	baseFetchFuncs = failingFideFuncs()
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{
+		Cohorts:      []database.DojoCohort{"1000-1100"},
+		ForceMonthly: true,
+	}))
+	if err == nil {
+		t.Fatal("expected threshold error: 12/12 FIDE fetches failed")
+	}
+	if len(inv.inputs) != 0 {
+		t.Error("threshold error must not spawn a continuation")
+	}
+}
+
+func TestHandler_NoThresholdErrorWithoutMonthly(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{"": {users: fideUsers(12)}}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+	fideCalls := 0
+	baseFetchFuncs = map[database.RatingSystem]ratings.RatingFetchFunc{
+		database.Fide: func(username string) (*database.Rating, error) {
+			fideCalls++
+			return nil, errors.New(500, "Temporary server error", "should not be called")
+		},
+	}
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}}))
+	if err != nil {
+		t.Fatalf("expected success on a non-monthly day, got %v", err)
+	}
+	if fideCalls != 0 {
+		t.Errorf("expected no FIDE fetches on a non-monthly day, got %d", fideCalls)
+	}
+}
+
+func TestHandler_Day2EnablesMonthly(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{"": {users: fideUsers(1)}}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+	timeNow = func() time.Time { return time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC) } // Tuesday the 2nd
+	fideCalls := 0
+	baseFetchFuncs = map[database.RatingSystem]ratings.RatingFetchFunc{
+		database.Fide: func(username string) (*database.Rating, error) {
+			fideCalls++
+			return &database.Rating{CurrentRating: 1500}, nil
+		},
+	}
+
+	if _, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{Cohorts: []database.DojoCohort{"1000-1100"}})); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if fideCalls != 1 {
+		t.Errorf("expected 1 FIDE fetch on day 2, got %d", fideCalls)
+	}
+}
+
+func TestHandler_ContinuationCarriesMonthlyStateWithoutError(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{
+		"":     {users: fideUsers(12), nextKey: "key2"},
+		"key2": {users: []*database.User{fideUser("last")}},
+	}}
+	inv := &fakeInvoker{}
+	// Plenty of time for all 12 users of chunk 1, out of time between chunks.
+	remaining := make([]time.Duration, 0, 14)
+	for i := 0; i < 12; i++ {
+		remaining = append(remaining, time.Hour)
+	}
+	remaining = append(remaining, time.Minute)
+	setupHandler(t, repo, inv, remaining...)
+	baseFetchFuncs = failingFideFuncs()
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{
+		Cohorts:      []database.DojoCohort{"1000-1100"},
+		ForceMonthly: true,
+	}))
+	if err != nil {
+		t.Fatalf("continuation invocations must not return threshold errors, got %v", err)
+	}
+	if len(inv.inputs) != 1 {
+		t.Fatalf("expected one continuation, got %d", len(inv.inputs))
+	}
+	var cont events.CloudWatchEvent
+	if err := json.Unmarshal(inv.inputs[0].Payload, &cont); err != nil {
+		t.Fatal(err)
+	}
+	var req RatingUpdateRequest
+	if err := json.Unmarshal(cont.Detail, &req); err != nil {
+		t.Fatal(err)
+	}
+	if !req.ForceMonthly {
+		t.Error("continuation must carry ForceMonthly")
+	}
+	if req.MonthlyAttempts[database.Fide] != 12 || req.MonthlyFailures[database.Fide] != 12 {
+		t.Errorf("continuation must carry cumulative counts, got %+v", req)
+	}
+}
+
+func TestHandler_CumulativeCountsFromRequestFeedThreshold(t *testing.T) {
+	repo := &fakeRepo{pages: map[string]page{"": {users: []*database.User{fideUser("last")}}}}
+	inv := &fakeInvoker{}
+	setupHandler(t, repo, inv, time.Hour)
+	baseFetchFuncs = failingFideFuncs()
+
+	_, err := Handler(context.Background(), scheduledEvent(t, RatingUpdateRequest{
+		Cohorts:           []database.DojoCohort{"1000-1100"},
+		ForceMonthly:      true,
+		ContinuationCount: 1,
+		MonthlyAttempts:   map[database.RatingSystem]int{database.Fide: 11},
+		MonthlyFailures:   map[database.RatingSystem]int{database.Fide: 11},
+	}))
+	if err == nil {
+		t.Fatal("expected threshold error from cumulative 12/12 failures")
 	}
 }

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -110,6 +110,10 @@ functions:
         Resource: ${param:UsersTableArn}
       - Effect: Allow
         Action:
+          - dynamodb:GetItem
+        Resource: ${param:FideRatingsTableArn}
+      - Effect: Allow
+        Action:
           - dynamodb:Query
           - dynamodb:BatchWriteItem
         Resource: ${param:TimelineTableArn}
@@ -635,6 +639,24 @@ functions:
         Action:
           - lambda:InvokeFunction
         Resource: arn:aws:lambda:${aws:region}:${aws:accountId}:function:chess-dojo-users-${sls:stage}-updateRatings
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+        Resource: ${param:FideRatingsTableArn}
+
+  downloadFideRatings:
+    handler: ratings/fide/main.go
+    timeout: 900
+    events:
+      - schedule:
+          rate: cron(0 12 1 * ? *)
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:BatchWriteItem
+          - dynamodb:GetItem
+          - dynamodb:PutItem
+        Resource: ${param:FideRatingsTableArn}
 
   updateStatistics:
     handler: statistics/update/main.go
@@ -999,6 +1021,26 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: chess-dojo-users-${sls:stage}-updateRatings
+        Period: 86400
+        EvaluationPeriods: 1
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
+
+    DownloadFideRatingsErrorAlarm:
+      Condition: IsNotSimple
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: DownloadFideRatingsError-${sls:stage}
+        AlarmDescription: 'Notifications about Lambda errors for the downloadFideRatings function, including stale-list aborts and failed imports'
+        AlarmActions:
+          - ${param:AlertNotificationsTopic}
+        Namespace: AWS/Lambda
+        MetricName: Errors
+        Statistic: Sum
+        Dimensions:
+          - Name: FunctionName
+            Value: chess-dojo-users-${sls:stage}-downloadFideRatings
         Period: 86400
         EvaluationPeriods: 1
         Threshold: 0

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -647,6 +647,7 @@ functions:
   downloadFideRatings:
     handler: ratings/fide/main.go
     timeout: 900
+    reservedConcurrency: 1
     events:
       - schedule:
           rate: cron(0 12 1 * ? *)


### PR DESCRIPTION
## Summary

Replaces FIDE website scraping with a monthly rating-list import backed by DynamoDB. FIDE, USCF, ECF, KNSB, and ACF batch updates now run monthly because these federations publish ratings monthly or less frequently. Also adds failure monitoring and manual recovery support.

## Deployment Note

After deployment, manually invoke `downloadFideRatings` once to populate the new table. Until this initial import completes, FIDE lookups will return 404 responses.

## Related Issues

Fixes #2537 and #2501

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [x] New Go unit tests were added
* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}}
