### PR TITLE
fix: block auto-translate on training plan categories

### DIFF
--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanSection.tsx
@@ -87,6 +87,11 @@ export function FullTrainingPlanSection({
     const tCategory = useTranslations('enums.requirementCategory');
     const isFreeTier = useFreeTier();
     const [showCustomTaskEditor, setShowCustomTaskEditor] = useState(false);
+    const preventCategoryTranslation =
+        section.category === RequirementCategory.Opening ||
+        section.category === RequirementCategory.Middlegames ||
+        section.category === RequirementCategory.Endgame ||
+        section.category === RequirementCategory.Graduation;
 
     const hiddenTaskCount = useMemo(() => {
         if (!isFreeTier) {
@@ -126,9 +131,14 @@ export function FullTrainingPlanSection({
                                     verticalAlign: 'middle',
                                 }}
                             />
-                            {tCategory.has(section.category)
-                                ? tCategory(section.category)
-                                : section.category}
+                            <span
+                                translate={preventCategoryTranslation ? 'no' : undefined}
+                                className={preventCategoryTranslation ? 'notranslate' : undefined}
+                            >
+                                {tCategory.has(section.category)
+                                    ? tCategory(section.category)
+                                    : section.category}
+                            </span>
                         </Typography>
                     </Grid>
 


### PR DESCRIPTION
## Summary

chrome auto-translate can mistranslate training plan category names. added a conditional preventCategoryTranslation check that applies translate="no" and className="notranslate" only to Opening, Middlegames + Strategy, Endgame, and Graduation.
scoped strictly to the category headings in the full training  plan

## Related Issues

Closes #2544 
Related #2536 
