### PR TITLE
fix(#2537): serialize rating update invocations

### DIFF
--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -399,6 +399,7 @@ functions:
 
   updateRatings:
     handler: ratings/update/main.go
+    reservedConcurrency: 1
     events:
       - schedule:
           rate: cron(0 0 * * ? *)


### PR DESCRIPTION
## Summary

Limits the `updateRatings` Lambda to one concurrent invocation.

## Related Issues

Follow-up to #2537

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [ ] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [x] It was not necessary to add tests because this is a Serverless configuration-only change
